### PR TITLE
fix(p2p): Pull node IP address from ENR rather that defualt local host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,7 @@ dependencies = [
  "sha2",
  "snap",
  "ssz_types",
+ "thiserror 2.0.17",
  "tracing",
  "tree_hash",
  "tree_hash_derive",

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -33,6 +33,8 @@ ssz_types = "0.14.0"
 tree_hash = "0.12.0"
 tree_hash_derive = "0.12.0"
 
+thiserror.workspace = true
+
 sha2 = "0.10"
 
 prometheus.workspace = true

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -202,6 +202,14 @@ pub fn parse_enrs(enrs: Vec<String>) -> Vec<Bootnode> {
             .iter()
             .find(|(key, _)| key.as_ref() == b"secp256k1")
             .expect("node record missing public key");
+        
+        let (_, ip_bytes) = record
+            .pairs
+            .iter()
+            .find(|(key, _)| key.as_ref() == b"ip")
+            .expect("node record missing IP address");
+
+        let ip = IpAddr::decode(ip_bytes).unwrap();
 
         let public_key_bytes = H264::decode(public_key_rlp).unwrap();
         let public_key =
@@ -210,7 +218,7 @@ pub fn parse_enrs(enrs: Vec<String>) -> Vec<Bootnode> {
 
         let quic_port = u16::decode(quic_port_bytes.as_ref()).unwrap();
         bootnodes.push(Bootnode {
-            ip: "127.0.0.1".parse().unwrap(),
+            ip,
             quic_port,
             public_key: public_key.into(),
         });


### PR DESCRIPTION
This PR parses the node IP address from ENR, this is used to set up the node's bootnodes rather than the default 127.0.0.1. Implementation also supports IPv6 and IPv4