### PR TITLE
fix: change finalized state route to return SSZ instead of JSON

### DIFF
--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 ethlambda-metrics.workspace = true
 tracing.workspace = true
 ethlambda-storage.workspace = true
+ethlambda-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/net/rpc/src/metrics.rs
+++ b/crates/net/rpc/src/metrics.rs
@@ -10,10 +10,10 @@ pub fn start_prometheus_metrics_api() -> Router {
 
 pub(crate) async fn get_health() -> impl IntoResponse {
     let mut response = r#"{"status":"healthy","service":"lean-spec-api"}"#.into_response();
-    let content_type = HeaderValue::from_static("application/json; charset=utf-8");
-    response
-        .headers_mut()
-        .insert(header::CONTENT_TYPE, content_type);
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(crate::JSON_CONTENT_TYPE),
+    );
     response
 }
 


### PR DESCRIPTION
This PR changes the `/lean/v0/states/finalized` route to return SSZ instead of JSON. Also, changes the other JSON endpoints to return the correct content type header value: "application/json; charset=utf-8"