### PR TITLE
chore: bump leanSpec commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docker-build: ## 🐳 Build the Docker image
 		--build-arg GIT_BRANCH=$(GIT_BRANCH) \
 		-t ghcr.io/lambdaclass/ethlambda:local .
 
-LEAN_SPEC_COMMIT_HASH:=c187aab89e0ecc6ce9c1fd9304fd708312ea7106
+LEAN_SPEC_COMMIT_HASH:=4edcf7bc9271e6a70ded8aff17710d68beac4266
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch


### PR DESCRIPTION
This PR bumps leanSpec to devnet-2's 4edcf7bc9271e6a70ded8aff17710d68beac4266 commit