### PR TITLE
feat: store block signatures and respond to BlocksByRoot requests

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -366,8 +366,8 @@ pub fn on_block(
         store.update_checkpoints(ForkCheckpoints::new(store.head(), justified, finalized));
     }
 
-    // Store block and state
-    store.insert_block(block_root, block.clone());
+    // Store signed block and state
+    store.insert_signed_block(block_root, &signed_block);
     store.insert_state(block_root, post_state);
 
     // Process block body attestations and their signatures

--- a/crates/common/types/src/block.rs
+++ b/crates/common/types/src/block.rs
@@ -129,6 +129,40 @@ pub struct BlockWithAttestation {
     pub proposer_attestation: Attestation,
 }
 
+/// Stored block signatures and proposer attestation.
+///
+/// This type stores the data needed to reconstruct a `SignedBlockWithAttestation`
+/// when combined with a `Block` from the blocks table.
+#[derive(Clone, Encode, Decode)]
+pub struct BlockSignaturesWithAttestation {
+    /// The proposer's attestation for this block.
+    pub proposer_attestation: Attestation,
+
+    /// The aggregated signatures for the block.
+    pub signatures: BlockSignatures,
+}
+
+impl BlockSignaturesWithAttestation {
+    /// Create from a SignedBlockWithAttestation.
+    pub fn from_signed_block(signed_block: &SignedBlockWithAttestation) -> Self {
+        Self {
+            proposer_attestation: signed_block.message.proposer_attestation.clone(),
+            signatures: signed_block.signature.clone(),
+        }
+    }
+
+    /// Reconstruct a SignedBlockWithAttestation given the block.
+    pub fn to_signed_block(&self, block: Block) -> SignedBlockWithAttestation {
+        SignedBlockWithAttestation {
+            message: BlockWithAttestation {
+                block,
+                proposer_attestation: self.proposer_attestation.clone(),
+            },
+            signature: self.signatures.clone(),
+        }
+    }
+}
+
 /// The header of a block, containing metadata.
 ///
 /// Block headers summarize blocks without storing full content. The header

--- a/crates/storage/src/api/tables.rs
+++ b/crates/storage/src/api/tables.rs
@@ -3,6 +3,8 @@
 pub enum Table {
     /// Block storage: H256 -> Block
     Blocks,
+    /// Block signatures storage: H256 -> BlockSignaturesWithAttestation
+    BlockSignatures,
     /// State storage: H256 -> State
     States,
     /// Known attestations: u64 -> AttestationData
@@ -18,8 +20,9 @@ pub enum Table {
 }
 
 /// All table variants.
-pub const ALL_TABLES: [Table; 7] = [
+pub const ALL_TABLES: [Table; 8] = [
     Table::Blocks,
+    Table::BlockSignatures,
     Table::States,
     Table::LatestKnownAttestations,
     Table::LatestNewAttestations,

--- a/crates/storage/src/backend/rocksdb.rs
+++ b/crates/storage/src/backend/rocksdb.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 fn cf_name(table: Table) -> &'static str {
     match table {
         Table::Blocks => "blocks",
+        Table::BlockSignatures => "block_signatures",
         Table::States => "states",
         Table::LatestKnownAttestations => "latest_known_attestations",
         Table::LatestNewAttestations => "latest_new_attestations",


### PR DESCRIPTION
Add BlockSignatures table to store proposer attestation and signatures separately from blocks, allowing reconstruction of SignedBlockWithAttestation for P2P responses.

Changes:
- Add BlockSignaturesWithAttestation type with from_signed_block/to_signed_block
- Add BlockSignatures table to storage
- Add insert_signed_block and get_signed_block methods to Store
- Implement handle_blocks_by_root_request to serve signed blocks to peers
