### PR TITLE
fix: parse bootnode IP addresses

### DIFF
--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -475,9 +475,9 @@ pub fn parse_enrs(enrs: Vec<String>) -> Vec<Bootnode> {
                 let octets: [u8; 16] = bytes.as_ref().try_into().expect("invalid IPv6 address");
                 IpAddr::from(Ipv6Addr::from(octets))
             });
-        let ip = ipv4
-            .or(ipv6)
-            .expect("node record missing IP address");
+
+        // Prefer IPv4 if both are present
+        let ip = ipv4.or(ipv6).expect("node record missing IP address");
 
         bootnodes.push(Bootnode {
             ip,


### PR DESCRIPTION
We had a hardcoded value of 127.0.0.1 for bootnode IPs. This worked for local devnets but not for remote deployments.

This PR adds parsing from the ENRs to populate this value, including both "ip" (IPv4) and "ip6" (IPv6) fields, but using the IPv4 address only if both are specified.