### PR TITLE
ci: generate test fixtures from pinned leanSpec commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
         working-directory: leanSpec
         run: uv run fill --fork=Devnet --scheme prod -o fixtures -n 2
 
+      # Ensure make sees fixtures as up-to-date (its timestamp must be
+      # newer than leanSpec/, which intermediate steps may have modified).
+      - name: Mark fixtures as up-to-date
+        run: touch leanSpec/fixtures
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
Closes #115

## Summary

- Instead of downloading the latest `fixtures-prod-scheme` artifact from leanSpec's CI (which could drift from our pinned version), we now checkout leanSpec at the exact `LEAN_SPEC_COMMIT_HASH` from the Makefile and generate fixtures in CI.
- The commit hash is extracted from the Makefile at runtime, keeping a single source of truth.
- Two-layer caching strategy:
  - **Fixture cache** (keyed on commit hash): skips all Python/uv steps when the pinned version hasn't changed.
  - **Production keys cache** (keyed on key URL hash): avoids re-downloading keys when only the leanSpec commit changes.

This is similar to how leanSpec builds the fixtures in their CI: https://github.com/leanEthereum/leanSpec/blob/2997030704db02d15ea4318bd05682586c887c0a/.github/workflows/prod-vectors.yml