### PR TITLE
ci: specify agents shouldn't use #N in reviews

### DIFF
--- a/.github/prompts/ai-review.md
+++ b/.github/prompts/ai-review.md
@@ -18,3 +18,8 @@ Consensus-layer considerations:
 
 Be concise and specific. Provide line references when suggesting changes.
 If the code looks good, acknowledge it briefly.
+
+Formatting rules:
+- NEVER use `#N` (e.g. #1, #2) for enumeration — GitHub renders those as issue/PR references. Use `1.`, `2.`, etc. or bullet points instead.
+- When referring back to items, use "Item 1", "Point 2", etc. — never "Issue #1" or "#1".Collapse comment
+


### PR DESCRIPTION
See https://github.com/lambdaclass/ethrex/pull/6187 for more context.

Review agents make use of `#N` for numbering comments, which triggers GitHub references, linking all reviewed PRs with links to the first PRs of the repo (see #1 for an example).