### PR TITLE
fix: encode topic len as LE in `compute_message_id`

### DIFF
--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -506,7 +506,7 @@ fn compute_message_id(message: &libp2p::gossipsub::Message) -> libp2p::gossipsub
         Err(_) => (MESSAGE_DOMAIN_INVALID_SNAPPY, &message.data),
     };
     let topic = message.topic.as_str().as_bytes();
-    let topic_len = (topic.len() as u64).to_be_bytes();
+    let topic_len = (topic.len() as u64).to_le_bytes();
     hasher.update(domain);
     hasher.update(topic_len);
     hasher.update(topic);


### PR DESCRIPTION
According to the spec, for computing the message ID, we should encode the topic len in little-endian: https://github.com/leanEthereum/leanSpec/blob/ad2df9a602e1e57e178d453cd4f943e5b9ee31ce/src/lean_spec/subspecs/networking/gossipsub/message.py#L173

Encoding it as big-endian doesn't make a practical difference, but it's better to follow the spec.