### PR TITLE
chore: remove from_ssz_bytes_compat for devnet-3 serialization compatibility

### DIFF
--- a/crates/net/p2p/src/req_resp/codec.rs
+++ b/crates/net/p2p/src/req_resp/codec.rs
@@ -7,12 +7,13 @@ use tracing::{debug, trace};
 use super::{
     encoding::{decode_payload, write_payload},
     messages::{
-        BLOCKS_BY_ROOT_PROTOCOL_V1, BlocksByRootRequest, ErrorMessage, Request, Response,
-        ResponseCode, ResponsePayload, STATUS_PROTOCOL_V1, Status,
+        BLOCKS_BY_ROOT_PROTOCOL_V1, ErrorMessage, Request, Response, ResponseCode, ResponsePayload,
+        STATUS_PROTOCOL_V1, Status,
     },
 };
 
 use ethlambda_types::block::SignedBlockWithAttestation;
+use ethlambda_types::primitives::ssz::Decode as SszDecode;
 
 #[derive(Debug, Clone, Default)]
 pub struct Codec;
@@ -41,10 +42,9 @@ impl libp2p::request_response::Codec for Codec {
                 Ok(Request::Status(status))
             }
             BLOCKS_BY_ROOT_PROTOCOL_V1 => {
-                let request =
-                    BlocksByRootRequest::from_ssz_bytes_compat(&payload).map_err(|err| {
-                        io::Error::new(io::ErrorKind::InvalidData, format!("{err:?}"))
-                    })?;
+                let request = SszDecode::from_ssz_bytes(&payload).map_err(|err| {
+                    io::Error::new(io::ErrorKind::InvalidData, format!("{err:?}"))
+                })?;
                 Ok(Request::BlocksByRoot(request))
             }
             _ => Err(io::Error::new(

--- a/crates/net/p2p/src/req_resp/messages.rs
+++ b/crates/net/p2p/src/req_resp/messages.rs
@@ -2,7 +2,7 @@ use ethlambda_types::{
     block::SignedBlockWithAttestation,
     primitives::{
         H256,
-        ssz::{Decode, Decode as SszDecode, Encode},
+        ssz::{Decode, Encode},
     },
     state::Checkpoint,
 };
@@ -138,56 +138,4 @@ pub fn error_message(msg: impl AsRef<str>) -> ErrorMessage {
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct BlocksByRootRequest {
     pub roots: RequestedBlockRoots,
-}
-
-impl BlocksByRootRequest {
-    /// Decode from SSZ bytes with backward compatibility.
-    ///
-    /// Tries to decode as new format (container with `roots` field) first.
-    /// Falls back to old format (transparent - direct list of roots) if that fails.
-    pub fn from_ssz_bytes_compat(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        // Try new format (container) first
-        SszDecode::from_ssz_bytes(bytes).or_else(|_| {
-            // Fall back to old format (transparent/direct list)
-            SszDecode::from_ssz_bytes(bytes).map(|roots| Self { roots })
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ssz::Encode as SszEncode;
-
-    #[test]
-    fn test_blocks_by_root_backward_compatibility() {
-        // Create some test roots
-        let root1 = H256::from_slice(&[1u8; 32]);
-        let root2 = H256::from_slice(&[2u8; 32]);
-        let roots_list =
-            RequestedBlockRoots::new(vec![root1, root2]).expect("Failed to create roots list");
-
-        // Encode as old format (direct list, similar to transparent)
-        let old_format_bytes = roots_list.as_ssz_bytes();
-
-        // Encode as new format (container)
-        let new_request = BlocksByRootRequest {
-            roots: roots_list.clone(),
-        };
-        let new_format_bytes = new_request.as_ssz_bytes();
-
-        // Both formats should decode successfully
-        let decoded_from_old = BlocksByRootRequest::from_ssz_bytes_compat(&old_format_bytes)
-            .expect("Failed to decode old format");
-        let decoded_from_new = BlocksByRootRequest::from_ssz_bytes_compat(&new_format_bytes)
-            .expect("Failed to decode new format");
-
-        // Both should have the same roots
-        assert_eq!(decoded_from_old.roots.len(), 2);
-        assert_eq!(decoded_from_new.roots.len(), 2);
-        assert_eq!(decoded_from_old.roots[0], root1);
-        assert_eq!(decoded_from_old.roots[1], root2);
-        assert_eq!(decoded_from_new.roots[0], root1);
-        assert_eq!(decoded_from_new.roots[1], root2);
-    }
 }


### PR DESCRIPTION
Change BlocksByRootRequest::from_ssz_bytes_compat to use SszDecode::from_ssz_bytes with the payload.

We don't need to maintain compatibility with devnet-2 format, so we remove the previous serialization.

