### PR TITLE
fix: handle pruned justified root in compute_lmd_ghost_head

### DIFF
--- a/crates/blockchain/fork_choice/src/lib.rs
+++ b/crates/blockchain/fork_choice/src/lib.rs
@@ -23,7 +23,9 @@ pub fn compute_lmd_ghost_head(
             .map(|(root, _)| root)
             .expect("we already checked blocks is non-empty");
     }
-    let start_slot = blocks[&start_root].0;
+    let Some(&(start_slot, _)) = blocks.get(&start_root) else {
+        return start_root;
+    };
     let mut weights: HashMap<H256, u64> = HashMap::new();
 
     for attestation_data in attestations.values() {


### PR DESCRIPTION
## Motivation

ethlambda crashes during devnet operation when `compute_lmd_ghost_head` performs an unchecked dictionary access (`blocks[&start_root]`) and the `start_root` (justified checkpoint root) has already been pruned from the `LiveChain` table.

**Crash sequence:**
1. Node restarts from genesis (justified checkpoint = genesis block at slot 0)
2. Node syncs rapidly to slot ~7200
3. Finalization advances → `prune_live_chain(finalized_slot)` removes entries with `slot < finalized_slot` — genesis (slot 0) is pruned
4. `update_head()` calls `compute_lmd_ghost_head(store.latest_justified().root, &blocks, ...)`
5. `blocks` (from `get_live_chain()`) no longer contains the genesis root
6. **PANIC** at `blocks[&start_root].0` — `"no entry found for key"`

Both `update_head` and `update_safe_target` in `store.rs` are affected since they both call `compute_lmd_ghost_head`.

## Description

Replace the panicking index `blocks[&start_root].0` with `blocks.get(&start_root)` and return `start_root` as a fallback when it is absent from the live chain.

```rust
// Before (panics if start_root not in blocks):
let start_slot = blocks[&start_root].0;

// After (return start_root if not in blocks):
let Some(&(start_slot, _)) = blocks.get(&start_root) else {
    return start_root;
};
```

**Rationale:** If the justified checkpoint root is not in the live chain, fork choice cannot traverse beyond it. Returning `start_root` is the safe fallback — it matches the existing early-return behavior for `blocks.is_empty()` (line 16–18) and ensures the head stays at the justified root until more blocks are available. Normal operation (justified root present in LiveChain) is unaffected since `.get()` returns `Some` and destructures identically.

## How to test

```bash
make lint   # No warnings
make test   # All tests pass (26/26 forkchoice spec tests pass)
```

The fix only changes the error case — when `start_root` is absent from `blocks`, which currently panics.