### PR TITLE
Remove checkpoint sync from incoming features

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Support for older devnet releases is discontinued when the next devnet version i
 
 Some features we are looking to implement in the near future, in order of priority:
 
-- [Checkpoint sync for long-lived networks](https://github.com/lambdaclass/ethlambda/issues/80)
 - [pq-devnet-3 support](https://github.com/lambdaclass/ethlambda/issues/73)
 - [Fetching of unknown blocks referenced by attestations](https://github.com/lambdaclass/ethlambda/issues/91)
 - [Discarding blocks with invalid signatures](https://github.com/lambdaclass/ethlambda/issues/78)


### PR DESCRIPTION
## Motivation

Checkpoint sync for long-lived networks (#80) has been implemented, so it should no longer appear in the incoming features list.

## Description

Remove the checkpoint sync entry from the "Incoming features" section in the README.