### PR TITLE
fix: stop appending endpoint path to checkpoint sync URL

### DIFF
--- a/bin/ethlambda/src/checkpoint_sync.rs
+++ b/bin/ethlambda/src/checkpoint_sync.rs
@@ -63,12 +63,10 @@ pub enum CheckpointSyncError {
 /// disconnect even for valid downloads if the state is simply too large to
 /// transfer within the time limit.
 pub async fn fetch_checkpoint_state(
-    base_url: &str,
+    url: &str,
     expected_genesis_time: u64,
     expected_validators: &[Validator],
 ) -> Result<State, CheckpointSyncError> {
-    let base_url = base_url.trim_end_matches('/');
-    let url = format!("{base_url}/lean/v0/states/finalized");
     // Use .read_timeout() to detect stalled downloads (inactivity timer).
     // This allows large states to complete as long as data keeps flowing.
     let client = Client::builder()
@@ -77,7 +75,7 @@ pub async fn fetch_checkpoint_state(
         .build()?;
 
     let response = client
-        .get(&url)
+        .get(url)
         .header("Accept", "application/octet-stream")
         .send()
         .await?

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -47,7 +47,7 @@ struct CliOptions {
     /// The node ID to look up in annotated_validators.yaml (e.g., "ethlambda_0")
     #[arg(long)]
     node_id: String,
-    /// URL of a peer to download checkpoint state from (e.g., http://peer:5052)
+    /// URL to download checkpoint state from (e.g., http://peer:5052/lean/v0/states/finalized)
     /// When set, skips genesis initialization and syncs from checkpoint.
     #[arg(long)]
     checkpoint_sync_url: Option<String>,

--- a/docs/checkpoint_sync.md
+++ b/docs/checkpoint_sync.md
@@ -26,7 +26,7 @@ When `--checkpoint-sync-url` is omitted, the node initializes from genesis.
 
 ### Direct peer
 
-Any running node that serves the `/lean/v0/states/finalized` endpoint can be used as a checkpoint source, not just ethlambda.
+Any running node that serves the finalized state as SSZ can be used as a checkpoint source, not just ethlambda. For ethlambda nodes, the endpoint is `/lean/v0/states/finalized`.
 
 This is the simplest option, with no additional infrastructure needed. The trade-off is that you trust a single peer to provide a correct finalized state.
 
@@ -38,7 +38,7 @@ This is the recommended option for production deployments since it reduces trust
 
 ## How It Works
 
-1. **Fetch and verify**: The node sends an HTTP GET to `{url}/lean/v0/states/finalized` requesting the SSZ-encoded finalized state. Once downloaded, the state is decoded and verified against the local genesis config (see [Verification Checks](#verification-checks) below).
+1. **Fetch and verify**: The node sends an HTTP GET to the provided URL requesting the SSZ-encoded finalized state. Once downloaded, the state is decoded and verified against the local genesis config (see [Verification Checks](#verification-checks) below).
 
    Timeouts:
    - **Connect**: 15 seconds (fail fast if peer is unreachable)


### PR DESCRIPTION
## Summary

- `--checkpoint-sync-url` now expects the full URL (e.g., `http://peer:5052/lean/v0/states/finalized`) instead of just the base URL with `/lean/v0/states/finalized` appended automatically
- Decouples the CLI from a specific API path convention, so it works with any checkpoint provider regardless of endpoint layout

## Test plan

- [x] `cargo check` passes
- [ ] Verify checkpoint sync works end-to-end with the full URL in a devnet