### PR TITLE
Use into_owned() instead of to_string() on Cow<str>

### DIFF
--- a/crates/net/p2p/src/req_resp/codec.rs
+++ b/crates/net/p2p/src/req_resp/codec.rs
@@ -173,7 +173,7 @@ where
                 format!("Invalid error message: {err:?}"),
             )
         })?;
-        let error_str = String::from_utf8_lossy(&message).to_string();
+        let error_str = String::from_utf8_lossy(&message).into_owned();
         trace!(?code, %error_str, "Received error response");
         return Ok(Response::error(code, message));
     }
@@ -227,7 +227,7 @@ where
 
         if code != ResponseCode::SUCCESS {
             let error_message = ErrorMessage::from_ssz_bytes(&payload)
-                .map(|msg| String::from_utf8_lossy(&msg).to_string())
+                .map(|msg| String::from_utf8_lossy(&msg).into_owned())
                 .unwrap_or_else(|_| "<invalid error message>".to_string());
             debug!(?code, %error_message, "Skipping block chunk with non-success code");
             continue;


### PR DESCRIPTION
## Summary

- Replace `.to_string()` with `.into_owned()` on `Cow<str>` returned by `String::from_utf8_lossy()` in the req/resp codec
- Avoids going through the `Display` trait for the `String` conversion
- Two instances in `crates/net/p2p/src/req_resp/codec.rs` (lines 176 and 230)

## Test plan

- [x] `cargo check` passes