### PR TITLE
Return pruned entry count from prune_live_chain()

### DIFF
--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -367,15 +367,15 @@ impl Store {
         if let Some(finalized) = checkpoints.finalized
             && finalized.slot > old_finalized_slot
         {
-            self.prune_live_chain(finalized.slot);
+            let pruned_chain = self.prune_live_chain(finalized.slot);
 
             // Prune signatures and payloads for finalized slots
             let pruned_sigs = self.prune_gossip_signatures(finalized.slot);
             let pruned_payloads = self.prune_aggregated_payloads(finalized.slot);
-            if pruned_sigs > 0 || pruned_payloads > 0 {
+            if pruned_chain > 0 || pruned_sigs > 0 || pruned_payloads > 0 {
                 info!(
                     finalized_slot = finalized.slot,
-                    pruned_sigs, pruned_payloads, "Pruned finalized signatures"
+                    pruned_chain, pruned_sigs, pruned_payloads, "Pruned finalized data"
                 );
             }
         }
@@ -419,7 +419,9 @@ impl Store {
     ///
     /// Blocks/states are retained for historical queries, only the
     /// LiveChain index is pruned.
-    pub fn prune_live_chain(&mut self, finalized_slot: u64) {
+    ///
+    /// Returns the number of entries pruned.
+    pub fn prune_live_chain(&mut self, finalized_slot: u64) -> usize {
         let view = self.backend.begin_read().expect("read view");
 
         // Collect keys to delete - stop once we hit finalized_slot
@@ -436,8 +438,9 @@ impl Store {
             .collect();
         drop(view);
 
-        if keys_to_delete.is_empty() {
-            return;
+        let count = keys_to_delete.len();
+        if count == 0 {
+            return 0;
         }
 
         let mut batch = self.backend.begin_write().expect("write batch");
@@ -445,6 +448,7 @@ impl Store {
             .delete_batch(Table::LiveChain, keys_to_delete)
             .expect("delete non-finalized chain entries");
         batch.commit().expect("commit");
+        count
     }
 
     /// Prune gossip signatures for slots <= finalized_slot.


### PR DESCRIPTION
## Summary

- Make `prune_live_chain()` return `usize` (number of entries pruned) to match `prune_gossip_signatures()` and `prune_aggregated_payloads()`
- Update the caller in `update_checkpoints()` to log all three pruned counts together

## Test plan

- [x] `cargo check` passes