### PR TITLE
Document on_block() validate-then-mutate structure and resolve stale TODOs

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -402,9 +402,11 @@ pub fn on_block(
                 validator_id,
                 data: att.data.clone(),
             };
-            // Block body attestations may contain stale data (e.g., source advancing
-            // past target during justification changes). Invalid attestations are
-            // skipped rather than rejecting the block.
+            // Block body attestations can fail validation for legitimate reasons
+            // (e.g., referencing blocks from forks we haven't seen, or source
+            // exceeding target when the attester's justified checkpoint advanced
+            // past their chosen target). Invalid attestations are skipped rather
+            // than rejecting the block.
             let _ = on_attestation(store, attestation, true)
                 .inspect(|_| metrics::inc_attestations_valid("block"))
                 .inspect_err(|err| {
@@ -436,9 +438,9 @@ pub fn on_block(
     }
 
     // Process proposer attestation (enters "new" stage, not "known").
-    // Like block body attestations, the proposer's vote may become stale if
-    // justification advances during state transition, so errors are logged
-    // rather than rejecting the block.
+    // Like block body attestations, this can fail validation for legitimate
+    // reasons (e.g., referencing the block being processed, or stale checkpoint
+    // data). Errors are logged rather than rejecting the block.
     let _ = on_attestation(store, proposer_attestation, false)
         .inspect(|_| metrics::inc_attestations_valid("gossip"))
         .inspect_err(|err| {


### PR DESCRIPTION
## Summary

- Documents the existing two-phase (validate-then-mutate) structure of `on_block()` that was previously implicit
- Removes 3 stale TODOs that proposed changes incompatible with the protocol
- Replaces each TODO with an accurate comment explaining why the current behavior is correct

## Context

This is a follow-up to the investigation started in #113 by @MegaRedHand (which addresses #78). That PR proposed extracting signature verification from `on_block()` into a separate `precheck_block_signatures()` function called earlier in the pipeline. Four automated reviewers flagged a critical issue: removing `verify_signatures()` from `on_block()` means any caller that forgets to call `precheck_block_signatures()` first can import blocks without cryptographic validation. There are 3 call sites for `on_block()` (production `process_block()`, and 2 test files), and only 1 would get the precheck.

During this rework, we also attempted the two other TODOs in the function: rejecting blocks when block body or proposer attestations fail validation. **Both turned out to be incorrect** — forkchoice spec tests revealed that attestation validation failures are normal and expected:

- **Block body attestations** can legitimately have `source.slot > target.slot` when the attesting validator's justified checkpoint (source) advanced past their chosen target. 3 spec tests (`test_reorg_on_newly_justified_slot`, `test_all_validators_attest_in_single_aggregation`, `test_multiple_specs_same_target_merge_into_one`) exercise this exact scenario.
- **Proposer attestations** can reference the block being processed as their head, which doesn't exist in the store at pre-validation time.

The current warn-and-skip behavior (`let _ = on_attestation(...)`) is the correct design.

## Changes

**`crates/blockchain/src/store.rs`** (comments only, zero executable code changes):

1. **Updated `on_block()` docstring** — documents the two-phase structure:
   - Phase 1 (read-only): parent state lookup, signature verification, state transition
   - Phase 2 (mutations): store block/state, process attestations, update head

2. **Removed TODO: "extract signature verification to a pre-checks function"** (was at line 352) — signature verification stays inside `on_block()`, which is the only safe design. Extracting it creates a "forgotten precheck" risk across all 3 call sites.

3. **Removed TODO: "fail the block if an attestation is invalid"** (was at line 385) — replaced with a comment explaining that block body attestations fail validation for legitimate reasons (unseen forks, source exceeding target after justification advances).

4. **Removed TODO: "validate attestations before processing"** (was at line 434) — replaced with a comment explaining that proposer attestations can reference the block being processed or have stale checkpoint data.

5. **Added phase boundary marker** (`// === Store mutations ===`) at the exact point where store mutations begin, making the validate-then-mutate structure grep-able.

## Relationship to #113 and #78

This PR supersedes #113's approach. Rather than extracting verification to a separate precheck (which creates safety risks), it documents that the current structure already achieves the goal: all validation happens before any store mutations, so `on_block()` either rejects early (no side effects) or succeeds fully. Issue #78's concern about "accepting blocks with invalid attestations" is addressed by documenting that this is intentional protocol behavior, not a bug.

## Test plan

- [x] `make fmt` passes
- [x] `make lint` passes
- [x] 26/26 forkchoice spectests pass
- [x] All workspace unit tests pass
- [x] Verified the 3 failing tests that motivated keeping `let _ =` (`test_reorg_on_newly_justified_slot`, `test_all_validators_attest_in_single_aggregation`, `test_multiple_specs_same_target_merge_into_one`)
- [x] Confirmed signature spectests fail identically on `main` (pre-existing fixture deserialization issue, unrelated)