### PR TITLE
docs: add CONTRIBUTING.md link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Press `Ctrl+C` to stop all nodes.
 
 For custom devnet configurations, go to `lean-quickstart/local-devnet/genesis/validator-config.yaml` and edit the file before running the command above. See `lean-quickstart`'s documentation for more details on how to configure the devnet.
 
+## Contributing
+
+We welcome contributions! Please read our [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to get involved.
+
 ## Philosophy
 
 Many long-established clients accumulate bloat over time. This often occurs due to the need to support legacy features for existing users or through attempts to implement overly ambitious software. The result is often complex, difficult-to-maintain, and error-prone systems.


### PR DESCRIPTION
## Summary

- Adds a "Contributing" section to `README.md` that links to `CONTRIBUTING.md`
- Improves discoverability of contribution guidelines for new contributors

## Changes

**`README.md`**
- Inserted a new "Contributing" section between the "Getting started" and "Philosophy" sections
- Section contains a direct link to `CONTRIBUTING.md` for easy navigation

## Test plan

- Open `README.md` and verify the "Contributing" section appears between "Getting started" and "Philosophy"
- Confirm the link to `CONTRIBUTING.md` renders correctly and points to the right file
- If viewing on GitHub, click the link to ensure it resolves without a 404

---
*Created via [Tekton Dashboard](https://dashboard.hipermegared.link/tasks/5d4e63e5-413c-4d14-956d-bd43c12be2e0)*