### PR TITLE
Rename SignedAttestation.message to .data to align with leanSpec

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -223,7 +223,7 @@ impl BlockChainServer {
             // Create signed attestation
             let signed_attestation = SignedAttestation {
                 validator_id,
-                message: attestation_data.clone(),
+                data: attestation_data.clone(),
                 signature,
             };
 

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -353,7 +353,7 @@ pub fn on_gossip_attestation(
     let validator_id = signed_attestation.validator_id;
     let attestation = Attestation {
         validator_id,
-        data: signed_attestation.message,
+        data: signed_attestation.data,
     };
     validate_attestation_data(store, &attestation.data)
         .inspect_err(|_| metrics::inc_attestations_invalid("gossip"))?;

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -37,8 +37,8 @@ pub struct AttestationData {
 pub struct SignedAttestation {
     /// The index of the validator making the attestation.
     pub validator_id: u64,
-    /// The attestation message signed by the validator.
-    pub message: AttestationData,
+    /// The attestation data signed by the validator.
+    pub data: AttestationData,
     /// Signature aggregation produced by the leanVM (SNARKs in the future).
     pub signature: XmssSignature,
 }

--- a/crates/net/p2p/src/gossipsub/handler.rs
+++ b/crates/net/p2p/src/gossipsub/handler.rs
@@ -89,16 +89,16 @@ pub async fn handle_gossipsub_message(server: &mut P2PServer, event: Event) {
             else {
                 return;
             };
-            let slot = signed_attestation.message.slot;
+            let slot = signed_attestation.data.slot;
             let validator = signed_attestation.validator_id;
             info!(
                 %slot,
                 validator,
-                head_root = %ShortRoot(&signed_attestation.message.head.root.0),
-                target_slot = signed_attestation.message.target.slot,
-                target_root = %ShortRoot(&signed_attestation.message.target.root.0),
-                source_slot = signed_attestation.message.source.slot,
-                source_root = %ShortRoot(&signed_attestation.message.source.root.0),
+                head_root = %ShortRoot(&signed_attestation.data.head.root.0),
+                target_slot = signed_attestation.data.target.slot,
+                target_root = %ShortRoot(&signed_attestation.data.target.root.0),
+                source_slot = signed_attestation.data.source.slot,
+                source_root = %ShortRoot(&signed_attestation.data.source.root.0),
                 "Received attestation from gossip"
             );
             server
@@ -113,7 +113,7 @@ pub async fn handle_gossipsub_message(server: &mut P2PServer, event: Event) {
 }
 
 pub async fn publish_attestation(server: &mut P2PServer, attestation: SignedAttestation) {
-    let slot = attestation.message.slot;
+    let slot = attestation.data.slot;
     let validator = attestation.validator_id;
 
     // Encode to SSZ
@@ -131,10 +131,10 @@ pub async fn publish_attestation(server: &mut P2PServer, attestation: SignedAtte
         .inspect(|_| info!(
             %slot,
             validator,
-            target_slot = attestation.message.target.slot,
-            target_root = %ShortRoot(&attestation.message.target.root.0),
-            source_slot = attestation.message.source.slot,
-            source_root = %ShortRoot(&attestation.message.source.root.0),
+            target_slot = attestation.data.target.slot,
+            target_root = %ShortRoot(&attestation.data.target.root.0),
+            source_slot = attestation.data.source.slot,
+            source_root = %ShortRoot(&attestation.data.source.root.0),
             "Published attestation to gossipsub"
         ))
         .inspect_err(|err| {


### PR DESCRIPTION
## Motivation

The [leanSpec](https://github.com/leanEthereum/leanSpec) reference implementation changed `SignedAttestation` to inherit from `Attestation`, which uses `data` instead of `message` for the `AttestationData` field ([commit `3b9d054`](https://github.com/leanEthereum/leanSpec/commit/3b9d054)). This is part of the post-devnet-3 alignment work tracked in #155.

## Description

Pure field rename: `SignedAttestation.message` → `SignedAttestation.data` across 4 files, 13 call sites.

**No behavioral or wire-format change.** SSZ encodes by field position, not field name, so the serialization is identical before and after this PR.

### Changes by file

| File | Change |
|------|--------|
| `crates/common/types/src/attestation.rs` | Field declaration `message` → `data` |
| `crates/blockchain/src/lib.rs` | Construction site: `message:` → `data:` |
| `crates/blockchain/src/store.rs` | Access: `signed_attestation.message` → `.data` |
| `crates/net/p2p/src/gossipsub/handler.rs` | All `.message.` accesses → `.data.` (10 occurrences) |

### Why `data` instead of `message`?

In the leanSpec, `SignedAttestation` now inherits from `Attestation`:

```python
# Before (devnet-3)
class SignedAttestation(Container):
    validator_id: ValidatorIndex
    message: AttestationData      # ← standalone field
    signature: Signature

# After (latest leanSpec)
class SignedAttestation(Attestation):   # ← inherits from Attestation
    signature: Signature

class Attestation(Container):
    validator_id: ValidatorIndex
    data: AttestationData         # ← field name is "data"
```

Rust doesn't have inheritance, so we keep the flat struct but align the field name.

## How to test

```bash
cargo check --workspace   # Compiles clean
cargo clippy --workspace -- -D warnings   # No warnings
cargo test --workspace --release   # All 92 tests pass (5 pre-existing ignores)
```

## Related issues

- Part of #155 (pq-devnet-4 preparation)