### PR TITLE
Update README roadmap: remove completed items, add WIP link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,7 @@ Support for older devnet releases is discontinued when the next devnet version i
 Some features we are looking to implement in the near future, in order of priority:
 
 - [Add support for pq-devnet-4](https://github.com/lambdaclass/ethlambda/issues/155)
-- [Use spawned for our P2P event loop](https://github.com/lambdaclass/ethlambda/issues/165)
-- [Prune finalized states and old blocks](https://github.com/lambdaclass/ethlambda/issues/166)
-- [Non-finalization hardening: bound memory usage during long periods of non-finalization](https://github.com/lambdaclass/ethlambda/issues/103)
+- [Use spawned for our P2P event loop](https://github.com/lambdaclass/ethlambda/issues/165) - [WIP](https://github.com/lambdaclass/ethlambda/pull/188)
 - [Observability: more metrics from leanMetrics](https://github.com/lambdaclass/ethlambda/issues/76)
 - [RPC endpoints for chain data consumption](https://github.com/lambdaclass/ethlambda/issues/75)
 - [Add guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)


### PR DESCRIPTION
## Summary
- Remove "Prune finalized states and old blocks" and "Non-finalization hardening" from the roadmap (already merged: #170, #179)
- Add WIP link to the P2P spawned event loop item (PR #188)

## Test plan
- Documentation-only change, no testing needed