### PR TITLE
Improve sync resilience: periodic pending retry, better backoff, peer status tracking

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -69,6 +69,11 @@ impl BlockChain {
             .duration_since(SystemTime::now())
             .unwrap_or_default();
         send_after(time_until_genesis, handle.clone(), CastMessage::Tick);
+        send_after(
+            time_until_genesis + PENDING_RETRY_INTERVAL,
+            handle.clone(),
+            CastMessage::RetryPendingBlocks,
+        );
         BlockChain { handle }
     }
 
@@ -474,6 +479,41 @@ impl BlockChainServer {
         }
     }
 
+    /// Re-request missing parents for all pending blocks.
+    ///
+    /// After P2P retries exhaust (~21s), pending_requests is cleaned up but
+    /// pending_blocks keeps the orphaned entries forever. This periodic scan
+    /// collects unique missing ancestor roots and re-requests them.
+    fn retry_pending_blocks(&mut self) {
+        if self.pending_blocks.is_empty() {
+            return;
+        }
+
+        // Collect unique missing ancestor roots by resolving the chain
+        let mut missing_roots = HashSet::new();
+        for &block_root in self.pending_blocks.keys() {
+            // Walk up through pending_block_parents to find the deepest missing root
+            // (same resolution logic as process_or_pend_block)
+            let mut missing_root = block_root;
+            while let Some(&ancestor) = self.pending_block_parents.get(&missing_root) {
+                missing_root = ancestor;
+            }
+            missing_roots.insert(missing_root);
+        }
+
+        let pending_count = self.pending_blocks.values().map(|s| s.len()).sum::<usize>();
+        info!(
+            pending_count,
+            missing_roots = missing_roots.len(),
+            "Retrying pending block fetches"
+        );
+        metrics::update_pending_blocks(pending_count as u64);
+
+        for root in missing_roots {
+            self.request_missing_block(root);
+        }
+    }
+
     fn on_gossip_attestation(&mut self, attestation: SignedAttestation) {
         if !self.is_aggregator {
             warn!("Received unaggregated attestation but node is not an aggregator");
@@ -489,12 +529,16 @@ impl BlockChainServer {
     }
 }
 
+/// Interval between periodic pending block retries (3 slot durations).
+const PENDING_RETRY_INTERVAL: Duration = Duration::from_secs(12);
+
 #[derive(Clone, Debug)]
 enum CastMessage {
     NewBlock(SignedBlockWithAttestation),
     NewAttestation(SignedAttestation),
     NewAggregatedAttestation(SignedAggregatedAttestation),
     Tick,
+    RetryPendingBlocks,
 }
 
 impl GenServer for BlockChainServer {
@@ -541,6 +585,10 @@ impl GenServer for BlockChainServer {
             CastMessage::NewAttestation(attestation) => self.on_gossip_attestation(attestation),
             CastMessage::NewAggregatedAttestation(attestation) => {
                 self.on_gossip_aggregated_attestation(attestation);
+            }
+            CastMessage::RetryPendingBlocks => {
+                self.retry_pending_blocks();
+                send_after(PENDING_RETRY_INTERVAL, handle.clone(), message);
             }
         }
         CastResponse::NoReply

--- a/crates/blockchain/src/metrics.rs
+++ b/crates/blockchain/src/metrics.rs
@@ -43,6 +43,17 @@ pub fn update_validators_count(count: u64) {
     LEAN_VALIDATORS_COUNT.set(count.try_into().unwrap());
 }
 
+pub fn update_pending_blocks(count: u64) {
+    static LEAN_PENDING_BLOCKS: std::sync::LazyLock<IntGauge> = std::sync::LazyLock::new(|| {
+        register_int_gauge!(
+            "lean_pending_blocks",
+            "Number of blocks waiting for missing parents"
+        )
+        .unwrap()
+    });
+    LEAN_PENDING_BLOCKS.set(count.try_into().unwrap());
+}
+
 pub fn update_safe_target_slot(slot: u64) {
     static LEAN_SAFE_TARGET_SLOT: std::sync::LazyLock<IntGauge> = std::sync::LazyLock::new(|| {
         register_int_gauge!("lean_safe_target_slot", "Safe target slot").unwrap()

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     req_resp::{
         BLOCKS_BY_ROOT_PROTOCOL_V1, Codec, MAX_COMPRESSED_PAYLOAD_SIZE, Request,
-        STATUS_PROTOCOL_V1, build_status, fetch_block_from_peer,
+        STATUS_PROTOCOL_V1, Status, build_status, fetch_block_from_peer,
     },
 };
 
@@ -40,10 +40,11 @@ mod req_resp;
 
 pub use metrics::populate_name_registry;
 
-// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1280ms, 2560ms
+// 50ms, 100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s, 5s, 5s, 5s (~21s total)
 const MAX_FETCH_RETRIES: u32 = 10;
-const INITIAL_BACKOFF_MS: u64 = 5;
+const INITIAL_BACKOFF_MS: u64 = 50;
 const BACKOFF_MULTIPLIER: u64 = 2;
+const MAX_BACKOFF_MS: u64 = 5_000;
 const PEER_REDIAL_INTERVAL_SECS: u64 = 12;
 
 enum RetryMessage {
@@ -214,6 +215,7 @@ pub async fn start_p2p(
         connected_peers: HashSet::new(),
         pending_requests: HashMap::new(),
         request_id_map: HashMap::new(),
+        peer_statuses: HashMap::new(),
         bootnode_addrs,
         retry_tx,
         retry_rx,
@@ -230,6 +232,8 @@ pub(crate) struct Behaviour {
     req_resp: request_response::Behaviour<Codec>,
 }
 
+const STATUS_EXCHANGE_INTERVAL_SECS: u64 = 30;
+
 pub(crate) struct P2PServer {
     pub(crate) swarm: libp2p::Swarm<Behaviour>,
     pub(crate) blockchain: BlockChain,
@@ -241,6 +245,8 @@ pub(crate) struct P2PServer {
     pub(crate) connected_peers: HashSet<PeerId>,
     pub(crate) pending_requests: HashMap<ethlambda_types::primitives::H256, PendingRequest>,
     pub(crate) request_id_map: HashMap<OutboundRequestId, ethlambda_types::primitives::H256>,
+    /// Latest status reported by each connected peer
+    pub(crate) peer_statuses: HashMap<PeerId, Status>,
     /// Bootnode addresses for redialing when disconnected
     bootnode_addrs: HashMap<PeerId, Multiaddr>,
     /// Channel for scheduling retries (block fetches and peer redials)
@@ -251,6 +257,12 @@ pub(crate) struct P2PServer {
 /// Event loop for the P2P crate.
 /// Processes swarm events, incoming requests, responses, gossip, and outgoing messages from blockchain.
 async fn event_loop(mut server: P2PServer) {
+    let mut status_interval =
+        tokio::time::interval(Duration::from_secs(STATUS_EXCHANGE_INTERVAL_SECS));
+    // The first tick completes immediately; skip it so we don't send status
+    // requests right at startup (we already send one on ConnectionEstablished).
+    status_interval.tick().await;
+
     loop {
         tokio::select! {
             biased;
@@ -272,6 +284,9 @@ async fn event_loop(mut server: P2PServer) {
                     RetryMessage::BlockFetch(root) => handle_retry(&mut server, root).await,
                     RetryMessage::PeerRedial(peer_id) => handle_peer_redial(&mut server, peer_id).await,
                 }
+            }
+            _ = status_interval.tick() => {
+                send_status_to_all_peers(&mut server);
             }
         }
     }
@@ -350,6 +365,7 @@ async fn handle_swarm_event(server: &mut P2PServer, event: SwarmEvent<BehaviourE
             };
             if num_established == 0 {
                 server.connected_peers.remove(&peer_id);
+                server.peer_statuses.remove(&peer_id);
                 let peer_count = server.connected_peers.len();
                 metrics::notify_peer_disconnected(&Some(peer_id), direction, reason);
 
@@ -463,6 +479,49 @@ pub(crate) fn schedule_peer_redial(retry_tx: mpsc::UnboundedSender<RetryMessage>
         tokio::time::sleep(Duration::from_secs(PEER_REDIAL_INTERVAL_SECS)).await;
         let _ = retry_tx.send(RetryMessage::PeerRedial(peer_id));
     });
+}
+
+/// Send a Status request to all connected peers.
+fn send_status_to_all_peers(server: &mut P2PServer) {
+    if server.connected_peers.is_empty() {
+        return;
+    }
+    let our_status = build_status(&server.store);
+    let peers: Vec<_> = server.connected_peers.iter().copied().collect();
+    for peer in peers {
+        server
+            .swarm
+            .behaviour_mut()
+            .req_resp
+            .send_request_with_protocol(
+                &peer,
+                Request::Status(our_status.clone()),
+                libp2p::StreamProtocol::new(STATUS_PROTOCOL_V1),
+            );
+    }
+    trace!(
+        peer_count = server.connected_peers.len(),
+        "Sent status requests to all peers"
+    );
+}
+
+/// Update sync gap metrics from current peer statuses and our head.
+pub(crate) fn update_sync_metrics(server: &P2PServer) {
+    let our_head_slot = server
+        .store
+        .get_block_header(&server.store.head())
+        .map(|h| h.slot)
+        .unwrap_or(0);
+
+    let max_peer_head_slot = server
+        .peer_statuses
+        .values()
+        .map(|s| s.head.slot)
+        .max()
+        .unwrap_or(0);
+
+    metrics::update_max_peer_head_slot(max_peer_head_slot);
+    metrics::update_sync_slot_gap(max_peer_head_slot.saturating_sub(our_head_slot));
 }
 
 pub struct Bootnode {

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -94,3 +94,25 @@ pub fn notify_peer_disconnected(peer_id: &Option<PeerId>, direction: &str, reaso
     let name = resolve(peer_id);
     LEAN_CONNECTED_PEERS.with_label_values(&[name]).dec();
 }
+
+pub fn update_max_peer_head_slot(slot: u64) {
+    static LEAN_MAX_PEER_HEAD_SLOT: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge!(
+            "lean_max_peer_head_slot",
+            "Highest head slot reported by any connected peer"
+        )
+        .unwrap()
+    });
+    LEAN_MAX_PEER_HEAD_SLOT.set(slot as i64);
+}
+
+pub fn update_sync_slot_gap(gap: u64) {
+    static LEAN_SYNC_SLOT_GAP: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge!(
+            "lean_sync_slot_gap",
+            "Slot gap between max peer head and our head (positive = behind)"
+        )
+        .unwrap()
+    });
+    LEAN_SYNC_SLOT_GAP.set(gap as i64);
+}

--- a/crates/net/p2p/src/req_resp/handlers.rs
+++ b/crates/net/p2p/src/req_resp/handlers.rs
@@ -14,8 +14,8 @@ use super::{
     BLOCKS_BY_ROOT_PROTOCOL_V1, BlocksByRootRequest, Request, Response, ResponsePayload, Status,
 };
 use crate::{
-    BACKOFF_MULTIPLIER, INITIAL_BACKOFF_MS, MAX_FETCH_RETRIES, P2PServer, PendingRequest,
-    RetryMessage, req_resp::RequestedBlockRoots,
+    BACKOFF_MULTIPLIER, INITIAL_BACKOFF_MS, MAX_BACKOFF_MS, MAX_FETCH_RETRIES, P2PServer,
+    PendingRequest, RetryMessage, req_resp::RequestedBlockRoots,
 };
 
 pub async fn handle_req_resp_message(
@@ -40,7 +40,7 @@ pub async fn handle_req_resp_message(
             } => match response {
                 Response::Success { payload } => match payload {
                     ResponsePayload::Status(status) => {
-                        handle_status_response(status, peer).await;
+                        handle_status_response(server, status, peer).await;
                     }
                     ResponsePayload::BlocksByRoot(blocks) => {
                         handle_blocks_by_root_response(server, blocks, peer, request_id).await;
@@ -88,6 +88,10 @@ async fn handle_status_request(
     peer: PeerId,
 ) {
     info!(finalized_slot=%request.finalized.slot, head_slot=%request.head.slot, "Received status request from peer {peer}");
+    // Store the peer's status from the request
+    server.peer_statuses.insert(peer, request);
+    crate::update_sync_metrics(server);
+
     let our_status = build_status(&server.store);
     server
         .swarm
@@ -100,8 +104,10 @@ async fn handle_status_request(
         .unwrap();
 }
 
-async fn handle_status_response(status: Status, peer: PeerId) {
+async fn handle_status_response(server: &mut P2PServer, status: Status, peer: PeerId) {
     info!(finalized_slot=%status.finalized.slot, head_slot=%status.head.slot, "Received status response from peer {peer}");
+    server.peer_statuses.insert(peer, status);
+    crate::update_sync_metrics(server);
 }
 
 async fn handle_blocks_by_root_request(
@@ -284,7 +290,8 @@ async fn handle_fetch_failure(server: &mut P2PServer, root: H256, peer: PeerId) 
         return;
     }
 
-    let backoff_ms = INITIAL_BACKOFF_MS * BACKOFF_MULTIPLIER.pow(pending.attempts - 1);
+    let backoff_ms =
+        (INITIAL_BACKOFF_MS * BACKOFF_MULTIPLIER.pow(pending.attempts - 1)).min(MAX_BACKOFF_MS);
     let backoff = Duration::from_millis(backoff_ms);
 
     warn!(%root, %peer, attempts=%pending.attempts, ?backoff, "Block fetch failed, scheduling retry");


### PR DESCRIPTION
## Motivation

In the 6-node devnet run on 2026-03-06, ethlambda stopped advancing at slot ~7037 out of ~17,180 total slots. The root cause was a **cascading fork** where other clients (qlean, ream) diverged or crashed, reducing participation below the finalization threshold. ethlambda itself was healthy — producing blocks, gossiping attestations — but couldn't keep advancing because it received blocks from qlean referencing parents it never imported, and had no mechanism to recover.

### Why the node got stuck

The failure mode involved three compounding gaps in the block fetch pipeline:

1. **Block fetch retry window too short (~5s):** The exponential backoff started at 5ms and doubled 10 times (`5ms, 10ms, 20ms, ..., 2560ms`), totaling only ~5 seconds. In a network partition or cascading fork scenario, 5 seconds is not enough time for peers to sync the block themselves. Once retries exhausted, `pending_requests` was cleaned up in the P2P layer but `pending_blocks` in the blockchain crate kept the orphaned entries forever.

2. **No re-request mechanism for pending blocks:** After the P2P layer gave up (`handle_fetch_failure` → `pending_requests.remove`), the blockchain's `pending_blocks` HashMap retained the orphan block entries indefinitely. There was no periodic scan to detect these stuck entries and re-request their missing parents. The `pending_requests.contains_key()` dedup check in `handle_p2p_message` would correctly *allow* a re-request (since P2P already removed the entry), but nothing ever triggered one.

3. **Peer status responses ignored:** `handle_status_response()` logged peer head/finalized slots but discarded the information. Operators had no way to detect that the node was falling behind peers — no metric showed the gap between our head and the network's head.

### Timeline of the failure

```
Slot ~7030: qlean nodes diverge, some crash
Slot ~7035: ethlambda receives blocks from surviving qlean with unknown parents
Slot ~7035: FetchBlock requests sent → 10 retries over ~5s → all fail
Slot ~7037: Retries exhausted, pending_requests cleaned up
Slot ~7037+: pending_blocks HashMap holds orphans forever, no recovery
Slot ~7037 → ~17,180: ethlambda stuck at slot 7037 for the remaining ~2.5 hours
```

## Description

Three independent improvements that together prevent the failure mode observed in devnet-4.

### 1. Periodic pending block retry (highest impact)

**This single change would have prevented the slot 7037 failure.**

New `CastMessage::RetryPendingBlocks` variant in the blockchain GenServer, scheduled every 12 seconds (3 slot durations). The `retry_pending_blocks()` method:

1. Returns early if `pending_blocks` is empty (common case, zero cost)
2. Iterates `pending_blocks` keys and resolves each through `pending_block_parents` to find the deepest missing ancestor (same chain-walking logic as `process_or_pend_block`)
3. Collects unique missing roots into a `HashSet` (deduplicates — many pending blocks may share the same missing ancestor)
4. Updates the `lean_pending_blocks` metric
5. Calls `request_missing_block()` for each unique root, which sends `P2PMessage::FetchBlock` to the P2P layer

The P2P layer's dedup check (`pending_requests.contains_key`) correctly allows these re-requests since the previous `pending_requests` entry was already removed after max retries.

**Why 12 seconds:** 3× the slot duration (4s). Long enough to avoid spamming peers during normal operation, short enough to recover pending blocks within ~24 seconds in the worst case (12s wait + 21s retry window).

#### Files changed

| File | Change |
|------|--------|
| `crates/blockchain/src/lib.rs` | Add `CastMessage::RetryPendingBlocks` variant, schedule at genesis, handle in `handle_cast`, implement `retry_pending_blocks()` |
| `crates/blockchain/src/metrics.rs` | Add `lean_pending_blocks` IntGauge |

#### Detailed code walkthrough

**Scheduling (lib.rs:71-75):** Scheduled with `send_after(time_until_genesis + PENDING_RETRY_INTERVAL, ...)` at genesis, alongside the existing `CastMessage::Tick`. The offset by `PENDING_RETRY_INTERVAL` ensures the first retry fires 12s after genesis rather than immediately.

**Handler (lib.rs:586-589):** After executing `retry_pending_blocks()`, re-schedules itself with `send_after(PENDING_RETRY_INTERVAL, handle.clone(), message)`. This mirrors the existing `Tick` self-scheduling pattern.

**Resolution (lib.rs:494-500):** The chain-walking loop `while let Some(&ancestor) = self.pending_block_parents.get(&missing_root)` resolves stale cached ancestors. Example: if block C depends on B which depends on A (missing), and B was received after C, then C's `pending_block_parents` entry points to B. The loop resolves C → B → A, so only A is requested.

---

### 2. Better retry parameters

The previous backoff progression exhausted in ~5 seconds, which is too short for transient network issues or peers that need time to sync the block themselves.

| Parameter | Before | After |
|-----------|--------|-------|
| `INITIAL_BACKOFF_MS` | 5 | 50 |
| `MAX_BACKOFF_MS` | (none, unbounded) | 5,000 |
| Progression | 5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560 | 50, 100, 200, 400, 800, 1600, 3200, 5000, 5000, 5000 |
| Total window | ~5.1s | ~21.4s |
| `MAX_FETCH_RETRIES` | 10 (unchanged) | 10 (unchanged) |

The cap at 5s prevents the geometric progression from producing excessively long individual waits at high attempt counts (attempt 10 without cap would be 2560ms, which was coincidentally fine, but future changes to the retry count would blow up without a cap).

#### Files changed

| File | Change |
|------|--------|
| `crates/net/p2p/src/lib.rs` | Change `INITIAL_BACKOFF_MS` 5→50, add `MAX_BACKOFF_MS = 5_000` |
| `crates/net/p2p/src/req_resp/handlers.rs` | Cap backoff with `.min(MAX_BACKOFF_MS)` in `handle_fetch_failure` |

---

### 3. Status-driven sync detection

Previously, `handle_status_response()` logged and discarded peer status. This change stores peer statuses, exchanges them periodically, and exposes sync gap metrics for operator observability.

#### What changed

**Peer status storage:** New `peer_statuses: HashMap<PeerId, Status>` field on `P2PServer`. Updated on every status request/response:
- `handle_status_request`: stores the requesting peer's status (the request message contains their status)
- `handle_status_response`: stores the responding peer's status
- `ConnectionClosed` (num_established == 0): removes the peer's status entry

**Periodic status exchange:** New `tokio::time::interval(30s)` arm in the event loop's `select!`. Every 30 seconds, sends a Status request to all connected peers. The first tick is consumed at startup (`.tick().await` before the loop) to avoid duplicate requests — we already send Status on `ConnectionEstablished`.

**Sync gap metrics:** `update_sync_metrics()` computes and exposes:
- `lean_max_peer_head_slot`: highest head slot reported by any connected peer
- `lean_sync_slot_gap`: `max_peer_head - our_head` (positive = we're behind)

Called after every status insert (both request and response handlers).

#### Files changed

| File | Change |
|------|--------|
| `crates/net/p2p/src/lib.rs` | Add `peer_statuses` field, `STATUS_EXCHANGE_INTERVAL_SECS`, periodic status exchange in event loop, cleanup on disconnect, `send_status_to_all_peers()`, `update_sync_metrics()` |
| `crates/net/p2p/src/req_resp/handlers.rs` | Store peer status in both `handle_status_request` and `handle_status_response`, call `update_sync_metrics()` |
| `crates/net/p2p/src/metrics.rs` | Add `lean_max_peer_head_slot` and `lean_sync_slot_gap` IntGauges |

#### Design decisions

**Detection only, no automatic sync:** This PR deliberately does NOT trigger automatic block downloads based on the sync gap. The combination of the periodic pending retry (change 1) and better backoff (change 2) already covers the failure mode we observed. The sync gap metrics provide **observability** — operators can alert on `lean_sync_slot_gap > N` and investigate.

**30-second exchange interval:** Balances freshness vs overhead. Status messages are tiny (two Checkpoint structs = 80 bytes) so bandwidth is negligible, but the request-response round-trip does consume connection resources.

**Storing status from requests too:** When a peer sends us a Status *request*, the request payload includes their status. We store it to get the most complete picture without waiting for our response to trigger their next update.

---

### New Prometheus metrics summary

| Metric | Type | Module | Description |
|--------|------|--------|-------------|
| `lean_pending_blocks` | IntGauge | blockchain | Number of blocks waiting for missing parents |
| `lean_max_peer_head_slot` | IntGauge | p2p | Highest head slot reported by any connected peer |
| `lean_sync_slot_gap` | IntGauge | p2p | Slot gap between max peer head and our head (positive = behind) |

## What this does NOT include

- **BlocksByRange sync protocol**: Full range-based sync for large gaps (>100 slots). Much larger scope, not needed for this failure mode where gaps are typically 1-5 blocks.
- **Peer scoring**: Deprioritizing unreliable peers. Good hygiene but orthogonal to the root cause.
- **Checkpoint sync**: For late-joining nodes. Different problem entirely.
- **Automatic block download from sync gap**: Intentionally omitted — the periodic retry already covers the observed failure, and automatic sync based on status would add complexity and risk (e.g., requesting blocks we can't verify yet).

## How to test

```bash
make fmt                         # Formatting passes
make lint                        # Clippy with -D warnings passes
cargo test --workspace --release # All 90 tests pass (6 pre-existing ignores)
```

For production validation, deploy to a multi-client devnet with `make run-devnet`, then:

1. **Verify periodic retry:** Kill one validator node mid-run. Observe `lean_pending_blocks` metric increasing, then decreasing as the retry mechanism fetches the missing blocks. Look for `"Retrying pending block fetches"` log lines every 12s.
2. **Verify backoff:** Watch block fetch retry logs — backoff should show `50ms, 100ms, 200ms, ..., 5s` progression instead of the old `5ms, 10ms, ...` sequence.
3. **Verify sync gap metrics:** Check `/metrics` endpoint for `lean_max_peer_head_slot` and `lean_sync_slot_gap`. When the node is in sync, gap should be 0-1. When a node is behind (e.g., after restart), gap should reflect the actual difference.