### PR TITLE
Use checked arithmetic in pronic number justifiability check

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -474,5 +474,8 @@ pub fn slot_is_justifiable_after(slot: u64, finalized_slot: u64) -> bool {
         // Mathematical insight: For pronic delta = n(n+1), we have:
         //   4*delta + 1 = 4n(n+1) + 1 = (2n+1)^2
         // Check: 4*delta+1 is an odd perfect square
-        || (4*delta + 1).isqrt().pow(2) == 4*delta + 1 && (4*delta + 1) % 2 == 1
+        || delta
+            .checked_mul(4)
+            .and_then(|v| v.checked_add(1))
+            .is_some_and(|val| val.isqrt().pow(2) == val && val % 2 == 1)
 }


### PR DESCRIPTION
## Motivation

A security audit identified an integer overflow in `slot_is_justifiable_after()` in the 3SF-mini finalization logic. The pronic number check computes `4*delta + 1` using wrapping u64 arithmetic. When `delta >= 2^62 + 1`, `4*delta` overflows and wraps to a small value that can incorrectly satisfy the justifiability condition.

### Concrete exploit example

- `delta = 4611686018427387904` (= 2^62)
- `4 * delta` wraps to `0`
- `4 * delta + 1 = 1`
- `1.isqrt().pow(2) == 1` → true
- `1 % 2 == 1` → true
- **Result:** non-justifiable slot incorrectly treated as justifiable

This could allow a Byzantine validator to manipulate which slots are considered justifiable, potentially affecting finalization decisions.

## Description

Replace the wrapping `4*delta + 1` computation with `checked_mul(4).and_then(|v| v.checked_add(1))`. If either operation overflows, `is_some_and` returns `false` — the slot is correctly treated as non-justifiable.

**Before:**
```rust
|| (4*delta + 1).isqrt().pow(2) == 4*delta + 1 && (4*delta + 1) % 2 == 1
```

**After:**
```rust
|| delta
    .checked_mul(4)
    .and_then(|v| v.checked_add(1))
    .is_some_and(|val| val.isqrt().pow(2) == val && val % 2 == 1)
```

Note: The perfect square check on line 470 (`delta.isqrt().pow(2) == delta`) is safe — `isqrt()` of any u64 fits in u32, and squaring a u32 value always fits in u64.

## How to Test

```bash
make fmt
make lint
cargo test --workspace --release
```

Single-line change, all 120 tests pass unchanged.