### PR TITLE
Reject blocks with mismatched attestation aggregation_bits and proof participants

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1324,8 +1324,7 @@ mod tests {
         let proof = AggregatedSignatureProof::empty(proof_bits);
 
         let attestations = AggregatedAttestations::new(vec![attestation]).unwrap();
-        let attestation_signatures =
-            ssz_types::VariableList::new(vec![proof]).unwrap();
+        let attestation_signatures = ssz_types::VariableList::new(vec![proof]).unwrap();
 
         let signed_block = SignedBlockWithAttestation {
             message: BlockWithAttestation {


### PR DESCRIPTION
## Motivation

`StoreError::ParticipantsMismatch` was defined (`store.rs:899`) but never raised anywhere in the codebase. During block signature verification, `verify_signatures` extracts validator IDs from `attestation.aggregation_bits` and verifies the crypto proof against those public keys — but never checks that `aggregated_proof.participants` matches `aggregation_bits`.

This is a problem because the block-building path uses `proof.participants` (not `aggregation_bits`) as the source of truth for which validators a stored proof covers.

### Why these two bitfields exist

A `SignedBlockWithAttestation` contains both:

- **`block.body.attestations[i].aggregation_bits`** — in the block body, declares "these validators attested"
- **`signature.attestation_signatures[i].participants`** — in the signatures section, declares "this proof covers these validators"

For an honest block, these are always identical. But since they come from untrusted network input (a peer's block), they can be crafted to differ.

### The data flow that makes this exploitable

```
RECEIVE PATH (on_block_core, verify_signatures)
────────────────────────────────────────────────
1. verify_signatures extracts validator IDs from aggregation_bits
2. Collects public keys for those validators
3. Verifies crypto proof against those public keys → passes
4. Stores the WHOLE proof object (including proof.participants) in the cache

BUILD PATH (select_aggregated_proofs, line 1118-1135)
─────────────────────────────────────────────────────
1. Reads stored proofs from cache
2. Uses proof.participants to determine coverage (line 1121)
3. Sets new block's aggregation_bits = proof.participants (line 1135)

If participants ≠ aggregation_bits, the stored proof has wrong metadata,
and the receiver will build blocks with incorrect aggregation_bits.
```

### Attack scenario

A malicious proposer (who is legitimately the proposer for a slot) crafts a block where:

| Field | Value |
|-------|-------|
| `attestation.aggregation_bits` | `{1, 2, 3}` |
| `proof.participants` | `{1, 2, 3, 4, 5}` |
| `proof.proof_data` | valid proof for `{1, 2, 3}` |

**What happens on the victim node:**

1. `verify_signatures` checks proof against `aggregation_bits` = `{1, 2, 3}` → **passes** ✅
2. Proof is stored in the cache with `participants = {1, 2, 3, 4, 5}` → **poisoned cache**
3. Victim later becomes proposer, calls `select_aggregated_proofs`
4. `select_aggregated_proofs` reads `proof.participants` → thinks proof covers 5 validators
5. New block sets `aggregation_bits = {1, 2, 3, 4, 5}` (from `proof.participants`, line 1135)
6. Other nodes verify this block: proof checked against 5 public keys, but proof only covers 3
7. **Block is rejected** → victim produces invalid blocks

**Impact:** The victim node builds invalid blocks that the rest of the network rejects. This damages the victim's reputation and causes missed proposal rewards. Requires the attacker to be a legitimate proposer for at least one slot.

### Other clients

Both Zeam and Lantern enforce this check:

- **Zeam** compares the two bitfields element-by-element in `verifySignatures()`, returns `InvalidBlockSignatures` on mismatch
- **Lantern** does `memcmp` on the participant/aggregation bitfields in `signed_block_signatures_are_valid()`

## Description

Add a `BitList` equality check in `verify_signatures` (before the crypto verification loop body) that compares `attestation.aggregation_bits` against `aggregated_proof.participants`. On mismatch, return the already-defined `StoreError::ParticipantsMismatch`.

```rust
// Added at the top of the loop, before any expensive operations
if attestation.aggregation_bits != aggregated_proof.participants {
    return Err(StoreError::ParticipantsMismatch);
}
```

This runs before the public key collection and crypto verification, so invalid blocks are rejected cheaply without wasting CPU on signature verification.

## How to test

All spec tests pass:

```bash
cargo test -p ethlambda-blockchain --test forkchoice_spectests --release     # 26/26 passed
cargo test -p ethlambda-state-transition --test stf_spectests --release      # 14/14 passed
cargo test -p ethlambda-blockchain --test signature_spectests --release      #  8/8 passed
make lint                                                                    # clean
```

## Related

- #198 — Removes the `proof_data.len() < 10` bypass in `verify_aggregated_signature` (separate but related fix)