### PR TITLE
fix: use updated latest_finalized.slot for justifiability checks

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -273,13 +273,7 @@ fn process_attestations(
 
             justifications.remove(&target.root);
 
-            try_finalize(
-                state,
-                source,
-                target,
-                &mut justifications,
-                &root_to_slot,
-            );
+            try_finalize(state, source, target, &mut justifications, &root_to_slot);
         }
     }
 
@@ -297,11 +291,7 @@ fn process_attestations(
 /// 4. Both checkpoints exist in historical_block_hashes
 /// 5. Target slot > source slot
 /// 6. Target slot is justifiable after the finalized slot
-fn is_valid_vote(
-    state: &State,
-    source: Checkpoint,
-    target: Checkpoint,
-) -> bool {
+fn is_valid_vote(state: &State, source: Checkpoint, target: Checkpoint) -> bool {
     // Check that the source is already justified
     if !justified_slots_ops::is_slot_justified(
         &state.justified_slots,


### PR DESCRIPTION
https://github.com/leanEthereum/leanSpec/pull/443

The above PR in leanSpec removed the use of the original_finalized_slot snapshot and changed it to using the updated latest_finalized.slot from state. A difference in this implementation within clients leads to some state root mismatches at certain blocks. 

I am making this PR so we can get consistency across clients prior to the devnet run in about 6-8 hours. Please feel to request changes, merge or close this PR.

