### PR TITLE
Zero state_root in finalized state endpoint for checkpoint sync interop

### DIFF
--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use axum::{Json, Router, http::HeaderValue, http::header, response::IntoResponse, routing::get};
 use ethlambda_storage::Store;
-use ethlambda_types::primitives::ssz::Encode;
+use ethlambda_types::primitives::{H256, ssz::Encode};
 
 pub(crate) const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
 pub(crate) const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
@@ -57,9 +57,16 @@ async fn get_latest_finalized_state(
     axum::extract::State(store): axum::extract::State<Store>,
 ) -> impl IntoResponse {
     let finalized = store.latest_finalized();
-    let state = store
+    let mut state = store
         .get_state(&finalized.root)
         .expect("finalized state exists");
+
+    // Zero state_root to match the canonical post-state representation.
+    // The spec's state_transition sets state_root to zero during process_block_header,
+    // and only fills it in lazily at the next slot's process_slots.
+    // Serving the canonical form ensures checkpoint sync interoperability.
+    state.latest_block_header.state_root = H256::ZERO;
+
     ssz_response(state.as_ssz_bytes())
 }
 
@@ -178,15 +185,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_latest_finalized_state() {
-        use ethlambda_types::primitives::ssz::Encode;
+        use ethlambda_types::primitives::{H256, ssz::Encode};
 
         let state = create_test_state();
         let backend = Arc::new(InMemoryBackend::new());
         let store = Store::from_anchor_state(backend, state);
 
-        // Get the expected state from the store
+        // Build expected SSZ with zeroed state_root (canonical post-state form)
         let finalized = store.latest_finalized();
-        let expected_state = store.get_state(&finalized.root).unwrap();
+        let mut expected_state = store.get_state(&finalized.root).unwrap();
+        expected_state.latest_block_header.state_root = H256::ZERO;
         let expected_ssz = expected_state.as_ssz_bytes();
 
         let app = build_api_router(store);


### PR DESCRIPTION
## Summary

Fixes #205

The `/lean/v0/states/finalized` endpoint was serving `latest_block_header.state_root` as a non-zero value, diverging from the canonical post-state representation defined in the leanSpec. This caused checkpoint sync interoperability issues with other clients.

## Root Cause

The leanSpec defines the canonical post-state as follows:

1. `process_block_header` sets `latest_block_header.state_root = Bytes32.zero()` to break the circular dependency (state root depends on header, which would depend on state root)
2. `state_transition` validates `block.state_root == hash_tree_root(new_state)` but **never writes** the state root back into the header
3. `process_slots` fills it in lazily only when the **next** slot is processed

ethlambda, however, fills in `state_root` immediately after `state_transition` completes (`store.rs:568-569`):

```rust
post_state.latest_block_header.state_root = state_root;
```

This is a convenience for internal use, but it means the stored state diverges from the canonical form. When the RPC endpoint serves this state, other clients receive a non-canonical representation.

## Evidence

Live endpoint comparison across all devnet clients (all at slot 4399):

| Client | Nodes | `latest_block_header.state_root` |
|--------|-------|----------------------------------|
| **ethlambda** | 3/3 | `fe30c5bc...` (non-zero) |
| **Qlean** | 1/1 | `00000000...` (zero) |
| **Ream** | 2/2 | `00000000...` (zero) |
| **leanSpec** | — | **zero (canonical)** |

ethlambda was the only client serving the non-canonical form.

## Impact

Clients checkpoint-syncing **from** ethlambda would compute a different anchor block root if they don't zero `state_root` before hashing. For example, Qlean computes `tree_hash_root(state)` directly without zeroing first — it would get a different root and potentially reject the state or use a wrong anchor.

Note: ethlambda's own checkpoint sync **consumer** (`Store::from_anchor_state`) already handles both forms correctly — it zeros `state_root` before computing the root. So ethlambda syncing from others was fine; the issue was others syncing from ethlambda.

## Fix

Zero `latest_block_header.state_root` in the RPC response before SSZ serialization. Internal storage is unchanged.

```rust
state.latest_block_header.state_root = H256::ZERO;
ssz_response(state.as_ssz_bytes())
```

This is the minimal fix (Option A). A deeper refactor to store the canonical form internally is possible but not necessary — the RPC endpoint is the only external-facing surface.

## Test Plan

- [x] Existing RPC test updated to assert the zeroed canonical form
- [x] `cargo test -p ethlambda-rpc` — all 4 tests pass
- [x] `make lint` — clean
- [ ] Deploy to devnet and verify `/lean/v0/states/finalized` returns `state_root = 0x00...00` in the header
- [ ] Test checkpoint sync from ethlambda to Qlean/Ream