### PR TITLE
Use original finalized slot for justifiability and finalization gap checks

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -212,6 +212,11 @@ fn process_attestations(
     let _timing = metrics::time_attestations_processing();
     let validator_count = state.validators.len();
     let mut attestations_processed: u64 = 0;
+    // Capture the original finalized slot before attestation processing.
+    // The spec uses self.latest_finalized.slot (immutable) for justifiability
+    // checks (Rule 6) and finalization gap checks, while using a local mutable
+    // finalized_slot for is_slot_justified (Rules 1-2) and window shifts.
+    let original_finalized_slot = state.latest_finalized.slot;
     let mut justifications: HashMap<H256, Vec<bool>> = state
         .justifications_roots
         .iter()
@@ -246,7 +251,7 @@ fn process_attestations(
         let source = attestation_data.source;
         let target = attestation_data.target;
 
-        if !is_valid_vote(state, source, target) {
+        if !is_valid_vote(state, source, target, original_finalized_slot) {
             continue;
         }
 
@@ -288,7 +293,14 @@ fn process_attestations(
 
             justifications.remove(&target.root);
 
-            try_finalize(state, source, target, &mut justifications, &root_to_slot);
+            try_finalize(
+                state,
+                source,
+                target,
+                original_finalized_slot,
+                &mut justifications,
+                &root_to_slot,
+            );
         }
     }
 
@@ -306,7 +318,12 @@ fn process_attestations(
 /// 4. Both checkpoints exist in historical_block_hashes
 /// 5. Target slot > source slot
 /// 6. Target slot is justifiable after the finalized slot
-fn is_valid_vote(state: &State, source: Checkpoint, target: Checkpoint) -> bool {
+fn is_valid_vote(
+    state: &State,
+    source: Checkpoint,
+    target: Checkpoint,
+    original_finalized_slot: u64,
+) -> bool {
     // Check that the source is already justified
     if !justified_slots_ops::is_slot_justified(
         &state.justified_slots,
@@ -342,7 +359,9 @@ fn is_valid_vote(state: &State, source: Checkpoint, target: Checkpoint) -> bool 
     }
 
     // Ensure the target falls on a slot that can be justified after the finalized one.
-    if !slot_is_justifiable_after(target.slot, state.latest_finalized.slot) {
+    // Uses the original finalized slot from before attestation processing, matching
+    // the spec's use of self.latest_finalized.slot (immutable).
+    if !slot_is_justifiable_after(target.slot, original_finalized_slot) {
         return false;
     }
 
@@ -358,12 +377,15 @@ fn try_finalize(
     state: &mut State,
     source: Checkpoint,
     target: Checkpoint,
+    original_finalized_slot: u64,
     justifications: &mut HashMap<H256, Vec<bool>>,
     root_to_slot: &HashMap<H256, u64>,
 ) {
     // Consider whether finalization can advance.
+    // Uses the original finalized slot from before attestation processing, matching
+    // the spec's use of self.latest_finalized.slot (immutable).
     if ((source.slot + 1)..target.slot)
-        .any(|slot| slot_is_justifiable_after(slot, state.latest_finalized.slot))
+        .any(|slot| slot_is_justifiable_after(slot, original_finalized_slot))
     {
         metrics::inc_finalizations("error");
         return;


### PR DESCRIPTION
## Motivation

A spec-to-code compliance audit identified a **consensus-critical divergence** between ethlambda and the leanSpec Python reference implementation in how `process_attestations` references the finalized slot.

The leanSpec (`state.py`) uses **two distinct references** to the finalized slot during attestation processing:

| Reference | Mutability | Used for |
|-----------|------------|----------|
| `self.latest_finalized.slot` | **Immutable** (original value at start of `process_attestations`) | Justifiability check — Rule 6 (`state.py` L516), Finalization gap check (`state.py` L570) |
| `finalized_slot` (local variable) | **Mutable** (updated when finalization advances at L575) | `is_slot_justified` — Rules 1-2 (`state.py` L459, L466), `set_justified` (L550), window shift (L584) |

The Rust code was using `state.latest_finalized.slot` for **all** of these. Because `state` is `&mut State`, this value changes when finalization advances mid-processing (at the former `lib.rs` L373), making it behave like the spec's local mutable `finalized_slot` everywhere — including the two places where the spec deliberately uses the original immutable value.

## The divergence

When a block contains multiple attestation groups and the first group triggers finalization (advancing `latest_finalized.slot`), subsequent attestations are checked against the **new** finalized slot instead of the **original**. This affects:

1. **Vote validation Rule 6** (`slot_is_justifiable_after`): A target slot's justifiability depends on its delta from the finalized slot. Changing the finalized slot changes the delta, which can flip the justifiability result (e.g., delta=11 is not justifiable, but delta=6 is — it's a pronic number).

2. **Finalization gap check**: Whether finalization can advance depends on there being no justifiable slots in the gap between source and target. Using the wrong finalized slot reference changes which slots are considered justifiable in that gap.

### Concrete example

Consider `finalized_slot=0`, and a block with two attestation groups:
- Group 1 triggers finalization, advancing `latest_finalized.slot` from 0 to 5
- Group 2 has a target at slot 11

For Rule 6 on Group 2:
- **Spec** (original finalized=0): `delta = 11 - 0 = 11` → NOT justifiable (not ≤5, not a perfect square, not pronic) → vote **rejected**
- **Code before fix** (updated finalized=5): `delta = 11 - 5 = 6` → IS justifiable (6 = 2×3, pronic) → vote **accepted**

This produces different post-states (different `justified_slots`, `latest_justified`, `latest_finalized`), leading to different state roots and a **consensus split** between implementations.

### Exploitability

A block builder who includes attestations in a specific order can trigger this divergence. The attacker constructs a block where one attestation group causes finalization, and a subsequent group's validity changes based on which finalized slot reference is used.

## Description

The fix captures the original finalized slot before the attestation loop and passes it explicitly to the two functions that need it:

- **`process_attestations`**: Captures `let original_finalized_slot = state.latest_finalized.slot;` before the loop
- **`is_valid_vote`**: Accepts `original_finalized_slot` as a parameter, uses it for Rule 6 (`slot_is_justifiable_after`). Rules 1-2 (`is_slot_justified`) continue using `state.latest_finalized.slot` (mutable), correctly matching the spec's local `finalized_slot`
- **`try_finalize`**: Accepts `original_finalized_slot` as a parameter, uses it for the finalization gap check

### Spec references

- `leanSpec/src/lean_spec/subspecs/containers/state/state.py`
  - L428-430: `latest_finalized = self.latest_finalized` / `finalized_slot = latest_finalized.slot` (local mutable copy)
  - L459, L466: `justified_slots.is_slot_justified(finalized_slot, ...)` (local mutable — Rules 1-2)
  - L516: `target.slot.is_justifiable_after(self.latest_finalized.slot)` (original immutable — Rule 6)
  - L570: `Slot(slot).is_justifiable_after(self.latest_finalized.slot)` (original immutable — gap check)
  - L575: `finalized_slot = latest_finalized.slot` (local mutable updated after finalization)

## How to Test

1. `cargo test --workspace --release` — all 108 tests pass (5 ignored: slow crypto tests)
2. `cargo clippy --workspace -- -D warnings` — clean
3. `cargo fmt --all -- --check` — clean
4. The divergence requires a block with multiple attestation groups where the first triggers finalization — this is a rare but constructible scenario in multi-validator devnets. A targeted spec test exercising this path would further strengthen coverage.