### PR TITLE
Update leanSpec commit to d39d101

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-LEAN_SPEC_COMMIT_HASH:=8b7636bb8a95fe4bec414cc4c24e74079e6256b6
+LEAN_SPEC_COMMIT_HASH:=d39d10195414921e979e2fdd43723d89cee13c8b
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch


### PR DESCRIPTION
## Summary
- Bump `LEAN_SPEC_COMMIT_HASH` in Makefile from `8b7636b` to `d39d101`

## Test plan
- [ ] `rm -rf leanSpec && make leanSpec/fixtures` succeeds with the new commit
- [ ] `make test` passes with regenerated fixtures