### PR TITLE
Reject blocks with zero hash in justifications_roots

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -32,6 +32,8 @@ pub enum Error {
         current: usize,
         max: usize,
     },
+    #[error("zero hash found in justifications_roots")]
+    ZeroHashInJustificationRoots,
 }
 
 /// Transition the given pre-state to the block's post-state.
@@ -220,6 +222,14 @@ fn process_attestations(
     attestations: &AggregatedAttestations,
 ) -> Result<(), Error> {
     let _timing = metrics::time_attestations_processing();
+    // Precondition: justifications_roots must not contain zero hashes (spec state.py L389).
+    if state
+        .justifications_roots
+        .iter()
+        .any(|root| root == &H256::ZERO)
+    {
+        return Err(Error::ZeroHashInJustificationRoots);
+    }
     let validator_count = state.validators.len();
     let mut attestations_processed: u64 = 0;
     let mut justifications: HashMap<H256, Vec<bool>> = state


### PR DESCRIPTION
## Motivation

A spec-to-code compliance audit (FINDING-004) identified a missing invariant check. The leanSpec Python reference asserts at the start of `process_attestations` that no justification root is the zero hash:

```python
# state.py L389-391
assert not any(root == ZERO_HASH for root in self.justifications_roots), (
    "zero hash is not allowed in justifications roots"
)
```

The Rust code had no equivalent check.

### Why this matters

Under **normal operation**, zero hashes cannot enter `justifications_roots` because `is_valid_vote` Rule 3 rejects any attestation with `target.root == H256::ZERO` before it reaches the justifications HashMap. So the zero hash is filtered at the input boundary and never persisted by `serialize_justifications`.

However, this assertion guards against **corrupt state ingestion** — specifically, when a node receives a state via checkpoint sync from a malicious peer that has a zero hash already embedded in `justifications_roots`. Without this check, the node would silently operate on corrupted state. With this check, it rejects the block immediately, matching the spec's behavior.

This is a defense-in-depth measure: even though the normal code path prevents zero hashes from accumulating, an explicit precondition check catches the case where state arrives from an external source with the invariant already violated.

## Description

Adds a precondition check at the top of `process_attestations` (before deserialization into the HashMap) that returns `Error::ZeroHashInJustificationRoots` if any root in `state.justifications_roots` is `H256::ZERO`.

Changes:
- **`Error` enum**: New variant `ZeroHashInJustificationRoots`
- **`process_attestations`**: Early return with error if any justification root is zero, placed before the HashMap deserialization to match the spec's assertion ordering

### Spec reference

- `leanSpec/src/lean_spec/subspecs/containers/state/state.py` L389-391 (commit `d39d101`)

## How to Test

1. `cargo test --workspace --release` — all tests pass
2. `cargo clippy --workspace -- -D warnings` — clean
3. `cargo fmt --all -- --check` — clean
4. The check is a precondition on incoming state, so it is not exercised by existing spec test fixtures (which produce valid states). A targeted test constructing a state with a zero hash in `justifications_roots` and verifying the error would further strengthen coverage.