### PR TITLE
Document historical_block_hashes bounds check as defensive guard

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -150,6 +150,10 @@ fn process_block_header(state: &mut State, block: &Block) -> Result<(), Error> {
         state.latest_finalized.root = parent_root;
     }
 
+    // Guard: reject blocks whose slot gap would overflow historical_block_hashes.
+    // The spec relies on the SSZ list limit (HISTORICAL_ROOTS_LIMIT) to enforce
+    // this implicitly during serialization. We check explicitly before allocating
+    // to prevent OOM from a crafted block with a large slot gap.
     let num_empty_slots = (block.slot - parent_header.slot - 1) as usize;
     let current_len = state.historical_block_hashes.len();
     let new_total = current_len + 1 + num_empty_slots; // +1 for parent_root push


### PR DESCRIPTION
## Motivation

A spec-to-code compliance audit (FINDING-005) identified that `process_block_header` adds an explicit bounds check on `historical_block_hashes` that the spec does not have.

The spec (`state.py` L281) appends to `historical_block_hashes` without an explicit length check, relying on the SSZ list limit (`HISTORICAL_ROOTS_LIMIT = 2^18 = 262144`) to enforce the bound implicitly during serialization.

The Rust code checks before allocating and returns `SlotGapTooLarge` if the new length would exceed the limit. This prevents OOM from a crafted block with a large slot gap. The check was correct but lacked explanation of why it exists and that it goes beyond the spec.

## Description

Adds a comment on the bounds check in `process_block_header` explaining:

- The spec relies on SSZ list limits to enforce the bound at serialization time
- We check explicitly before allocating to prevent OOM from crafted blocks
- This is a defensive addition, not spec behavior

## How to Test

Documentation-only change. `cargo test --workspace --release` passes.