### PR TITLE
Fix intervals per slot in CLAUDE.md from 4 to 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,18 +45,19 @@ crates/
 - Communication via `mpsc::unbounded_channel`
 - Shared storage via `Arc<dyn StorageBackend>` (clone Store, share backend)
 
-### Tick-Based Validator Duties (4-second slots, 4 intervals per slot)
+### Tick-Based Validator Duties (4-second slots, 5 intervals per slot)
 ```
-Interval 0: Proposer check → accept attestations → build/publish block
-Interval 1: Non-proposers produce attestations
-Interval 2: Safe target update (fork choice with 2/3 threshold)
-Interval 3: Accept accumulated attestations
+Interval 0: Block proposal → accept attestations if proposal exists
+Interval 1: Vote propagation (no action)
+Interval 2: Aggregation (aggregators create proofs from gossip signatures)
+Interval 3: Safe target update (fork choice)
+Interval 4: Accept accumulated attestations
 ```
 
 ### Attestation Pipeline
 ```
 Gossip → Signature verification → new_attestations (pending)
-  ↓ (intervals 0/3)
+  ↓ (intervals 0/4)
 promote → known_attestations (fork choice active)
   ↓
 Fork choice head update


### PR DESCRIPTION
## Motivation

A spec-to-code compliance audit (FINDING-006) identified stale documentation in CLAUDE.md. The spec (`config.py` INTERVALS_PER_SLOT=5) and the Rust code (`lib.rs:35`) both use 5 intervals per slot, but CLAUDE.md documented only 4 with incorrect interval descriptions.

## Description

Updates two sections in CLAUDE.md:

**Tick-Based Validator Duties** — fixes the header from "4 intervals per slot" to "5 intervals per slot" and corrects the interval descriptions to match the actual implementation:

| Interval | Old (incorrect) | New (correct) |
|----------|----------------|---------------|
| 0 | Proposer check → accept attestations → build/publish block | Block proposal → accept attestations if proposal exists |
| 1 | Non-proposers produce attestations | Vote propagation (no action) |
| 2 | Safe target update (fork choice with 2/3 threshold) | Aggregation (aggregators create proofs from gossip signatures) |
| 3 | Accept accumulated attestations | Safe target update (fork choice) |
| 4 | _(missing)_ | Accept accumulated attestations |

**Attestation Pipeline** — fixes the interval reference from "intervals 0/3" to "intervals 0/4" for attestation promotion.

## How to Test

Documentation-only change.