### PR TITLE
Verify proposer attestation identity matches block proposer

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -909,6 +909,14 @@ pub enum StoreError {
 
     #[error("Validator {validator_index} is not the proposer for slot {slot}")]
     NotProposer { validator_index: u64, slot: u64 },
+
+    #[error(
+        "Proposer attestation validator_id {attestation_id} does not match block proposer_index {proposer_index}"
+    )]
+    ProposerAttestationMismatch {
+        attestation_id: u64,
+        proposer_index: u64,
+    },
 }
 
 /// Build an AggregationBits bitfield from a list of validator indices.
@@ -1210,6 +1218,13 @@ fn verify_signatures(
     }
 
     let proposer_attestation = &signed_block.message.proposer_attestation;
+
+    if proposer_attestation.validator_id != block.proposer_index {
+        return Err(StoreError::ProposerAttestationMismatch {
+            attestation_id: proposer_attestation.validator_id,
+            proposer_index: block.proposer_index,
+        });
+    }
 
     let proposer_signature =
         ValidatorSignature::from_bytes(&signed_block.signature.proposer_signature)


### PR DESCRIPTION
## Motivation

A spec-to-code compliance audit identified a missing validation check in `verify_signatures()`. The [leanSpec reference implementation](https://github.com/leanEthereum/leanSpec/blob/d39d10195414921e979e2fdd43723d89cee13c8b/src/lean_spec/subspecs/containers/block/block.py#L184-L188) requires:

```python
# Critical safety check: the attestation must be from the actual proposer.
# Without this, an attacker could substitute another validator's attestation.
assert proposer_attestation.validator_id == block.proposer_index, (
    "Proposer attestation must be from the block proposer"
)
```

Our implementation was missing this check.

## The problem

In `verify_signatures()`, the proposer's signature is verified using the public key looked up via `block.proposer_index` (L1218-1224). This correctly proves the *proposer* signed the attestation, but it does not verify that `proposer_attestation.validator_id` matches `block.proposer_index`.

Later, in `on_block_core()` (L614), the attestation is stored using the `validator_id` from the attestation itself:

```rust
let proposer_vid = proposer_attestation.validator_id;
```

This value is then used as the key when inserting the attestation into the fork choice store (L634 or L640-644).

## Attack scenario

Without this check, a malicious proposer for slot N could:

1. Set `block.proposer_index = 5` (their real index, required for slot assignment)
2. Set `proposer_attestation.validator_id = 7` (a different validator)
3. Sign the attestation with their own key (validator 5)

**What passes:** Signature verification succeeds because it uses `block.proposer_index` (5) to look up the key, and validator 5 did sign the attestation.

**What goes wrong:** The attestation is stored under validator 7's identity in the fork choice latest-attestation map. This:
- Overwrites validator 7's legitimate fork choice vote
- Points validator 7's vote wherever the proposer wants
- Gives the proposer influence over 2 fork choice votes instead of 1 (their own at interval 1, plus the hijacked one)

In a small validator set (e.g., 4-node devnet), this represents a 25% advantage per malicious proposal. In larger sets the impact shrinks proportionally.

## Fix

One check added to `verify_signatures()`, directly matching the spec assertion:

```rust
if proposer_attestation.validator_id != block.proposer_index {
    return Err(StoreError::ProposerAttestationMismatch {
        attestation_id: proposer_attestation.validator_id,
        proposer_index: block.proposer_index,
    });
}
```

## Test plan

- [x] `make fmt` passes
- [x] `make lint` passes (clippy with `-D warnings`)
- [x] `make test` passes (all 112 tests, including forkchoice and signature spec tests)
- [ ] Devnet test: verify blocks are still produced and finalized normally