### PR TITLE
Fix health endpoint service name to match spec

### DIFF
--- a/crates/net/rpc/src/metrics.rs
+++ b/crates/net/rpc/src/metrics.rs
@@ -7,7 +7,7 @@ pub fn start_prometheus_metrics_api() -> Router {
 }
 
 pub(crate) async fn get_health() -> impl IntoResponse {
-    let mut response = r#"{"status":"healthy","service":"lean-spec-api"}"#.into_response();
+    let mut response = r#"{"status":"healthy","service":"lean-rpc-api"}"#.into_response();
     response.headers_mut().insert(
         header::CONTENT_TYPE,
         HeaderValue::from_static(crate::JSON_CONTENT_TYPE),


### PR DESCRIPTION
## Motivation

A spec-to-code compliance audit (F-07) identified that the health endpoint's `service` field doesn't match the spec.

- **Spec** (`leanSpec/src/lean_spec/subspecs/api/endpoints/health.py`): `"service": "lean-rpc-api"`
- **Code** (`crates/net/rpc/src/metrics.rs:10`): `"service": "lean-spec-api"`

Everything else in the health endpoint already matches: route (`/lean/v0/health`), status code (200), content type (`application/json`), and the `status` field (`"healthy"`).

## Description

One-line change in `crates/net/rpc/src/metrics.rs`: updates the `service` field in the health endpoint JSON response from `"lean-spec-api"` to `"lean-rpc-api"`.

Before:
```json
{"status":"healthy","service":"lean-spec-api"}
```

After:
```json
{"status":"healthy","service":"lean-rpc-api"}
```

## How to Test

- `make fmt` — passes
- `make lint` — passes
- `make test` — all tests pass
- `curl http://localhost:5052/lean/v0/health` on a running node should return `{"status":"healthy","service":"lean-rpc-api"}`