### PR TITLE
Add timing logs for block processing and XMSS signature verification

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -559,7 +559,7 @@ fn on_block_core(
         // Validate cryptographic signatures
         verify_signatures(&parent_state, &signed_block)?;
     }
-    let sig_verification_ms = sig_verification_start.elapsed().as_millis() as u64;
+    let sig_verification = sig_verification_start.elapsed();
 
     let block = signed_block.block.block.clone();
     let proposer_attestation = signed_block.block.proposer_attestation.clone();
@@ -568,7 +568,7 @@ fn on_block_core(
     let state_transition_start = std::time::Instant::now();
     let mut post_state = parent_state;
     ethlambda_state_transition::state_transition(&mut post_state, &block)?;
-    let state_transition_ms = state_transition_start.elapsed().as_millis() as u64;
+    let state_transition = state_transition_start.elapsed();
 
     // Cache the state root in the latest block header
     let state_root = block.state_root;
@@ -652,14 +652,14 @@ fn on_block_core(
         );
     }
 
-    let block_total_ms = block_start.elapsed().as_millis() as u64;
+    let block_total = block_start.elapsed();
     info!(
         %slot,
         %block_root,
         %state_root,
-        sig_verification_ms,
-        state_transition_ms,
-        block_total_ms,
+        ?sig_verification,
+        ?state_transition,
+        ?block_total,
         "Processed new block"
     );
     Ok(())
@@ -1243,6 +1243,8 @@ fn verify_signatures(
     }
     let aggregated_elapsed = aggregated_start.elapsed();
 
+    let proposer_start = std::time::Instant::now();
+
     let proposer_attestation = &signed_block.block.proposer_attestation;
 
     if proposer_attestation.validator_id != block.proposer_index {
@@ -1271,7 +1273,6 @@ fn verify_signatures(
         .expect("slot exceeds u32");
     let message = proposer_attestation.data.tree_hash_root();
 
-    let proposer_start = std::time::Instant::now();
     if !proposer_signature.is_valid(&proposer_pubkey, slot, &message) {
         return Err(StoreError::ProposerSignatureVerificationFailed);
     }
@@ -1281,9 +1282,9 @@ fn verify_signatures(
     info!(
         slot = block.slot,
         attestation_count = attestations.len(),
-        aggregated_sigs_ms = aggregated_elapsed.as_millis() as u64,
-        proposer_sig_ms = proposer_elapsed.as_millis() as u64,
-        total_ms = total_elapsed.as_millis() as u64,
+        ?aggregated_elapsed,
+        ?proposer_elapsed,
+        ?total_elapsed,
         "Signature verification timing"
     );
 


### PR DESCRIPTION
## Summary

- Instruments `on_block_core()` with per-phase timing breakdown of full block processing
- Instruments `verify_signatures()` with per-phase timing breakdown of XMSS signature verification
- Helps diagnose #197 where `lean_fork_choice_block_processing_time_seconds` shows constant ~1s on devnet dashboards

## Context

Issue #197 reports that block processing time on the devnet Grafana dashboard is always approximately 1 second. Investigation revealed that:

1. The `lean_fork_choice_block_processing_time_seconds` histogram has a bucket gap between `0.1s` and `1.0s`, which could cause Grafana's `histogram_quantile` to interpolate misleadingly
2. The actual bottleneck is likely in XMSS signature verification (post-quantum crypto), but there's no visibility into how long each phase takes

This PR adds structured timing logs at two levels to pinpoint exactly where time is spent, without changing any behavior.

## Example output

Each block produces two log lines — first the signature detail, then the block summary:

```
2026-03-13T15:30:42.123456Z  INFO ethlambda_blockchain::store: Signature verification timing slot=42 attestation_count=3 aggregated_sigs_ms=450 proposer_sig_ms=120 total_ms=572
2026-03-13T15:30:42.140123Z  INFO ethlambda_blockchain::store: Processed new block slot=42 block_root=0xabcd1234 state_root=0xef567890 sig_verification_ms=572 state_transition_ms=15 block_total_ms=590
```

In this example you can see:
- **Signature verification dominates** — `sig_verification_ms=572` out of `block_total_ms=590`
- **Aggregated sigs are the bottleneck** — `aggregated_sigs_ms=450` vs `proposer_sig_ms=120`
- **State transition is fast** — `state_transition_ms=15`
- **Minimal overhead** — `590 - 572 - 15 = 3ms` for storage, fork choice, etc.

## Logged fields

### Block processing breakdown (`on_block_core`)

| Field | Description |
|-------|-------------|
| `sig_verification_ms` | Time spent in `verify_signatures()` (0 when verification is skipped) |
| `state_transition_ms` | Time spent in `state_transition()` (process_slots + process_block) |
| `block_total_ms` | Wall-clock time for the entire `on_block_core()` function |

### Signature verification breakdown (`verify_signatures`)

| Field | Description |
|-------|-------------|
| `attestation_count` | Number of aggregated attestation signatures verified |
| `aggregated_sigs_ms` | Total time verifying all aggregated attestation proofs (leanVM calls) |
| `proposer_sig_ms` | Time verifying the proposer's individual XMSS signature |
| `total_ms` | Wall-clock time for the entire `verify_signatures()` function |

## How to use

```bash
# Full block processing breakdown
grep "Processed new block" node.log

# Signature verification detail
grep "Signature verification timing" node.log

# Key questions these logs answer:
# - Is sig verification the bottleneck? (sig_verification_ms ≈ block_total_ms)
# - Is state transition the bottleneck? (state_transition_ms >> sig_verification_ms)
# - Within sigs, is it aggregated or proposer? (aggregated_sigs_ms vs proposer_sig_ms)
# - Is there overhead outside both phases? (block_total_ms >> sig + state_transition)
```

## Test plan

- [x] `cargo check -p ethlambda-blockchain` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p ethlambda-blockchain -- -D warnings` passes
- [ ] Deploy to devnet and observe log output during block production
- [ ] Compare timing fields to identify the dominant bottleneck

Closes #197 (diagnostic step — may need follow-up based on findings)