### PR TITLE
Devnet4: separate attestation and proposal keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-LEAN_SPEC_COMMIT_HASH:=d39d10195414921e979e2fdd43723d89cee13c8b
+LEAN_SPEC_COMMIT_HASH:=ad9a3226f55e1ba143e0991010ff1f6c2de62941
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch


### PR DESCRIPTION
## Motivation

leanSpec commit [`ad9a322`](https://github.com/leanEthereum/leanSpec/pull/449) introduces the devnet4 spec: **separate attestation and proposal keys**. Each validator now has two independent XMSS keys — one for attestation signing and one for block proposal signing.

This solves a fundamental OTS (one-time signature) conflict: in devnet3, a proposer needed to sign both its attestation and the block using the same XMSS key in the same slot. With dual keys, the attestation key and proposal key advance independently, eliminating this constraint.

Additionally, the proposer's attestation is removed from the block structure entirely. The proposer now attests through the normal gossip pipeline at interval 1, like every other validator. This simplifies block processing and removes a circular fork-choice weight advantage where the proposer's attestation could influence its own block's weight.

## Description

### Commit 1: Upgrade leanSpec to ad9a322

Updates `LEAN_SPEC_COMMIT_HASH` in the Makefile. Fixture generation is blocked until [`leansig-test-keys`](https://github.com/leanEthereum/leansig-test-keys) publishes keys in the new dual-key format.

### Commit 2: Implement devnet4 dual-key model

**23 files changed, 326 insertions, 500 deletions** — net reduction of 174 lines because the proposer attestation wrapper was removed.

Changes organized by area:

#### Core Types (`crates/common/types/`)

| Change | Details |
|--------|---------|
| `Validator` struct | Single `pubkey` → `attestation_pubkey` + `proposal_pubkey`. New methods `get_attestation_pubkey()` and `get_proposal_pubkey()` |
| `SignedBlockWithAttestation` → `SignedBlock` | `message` is now `Block` directly (was `BlockWithAttestation`) |
| `BlockWithAttestation` | **Deleted** — proposer attestation no longer embedded in block |
| `BlockSignaturesWithAttestation` | **Deleted** — storage uses `BlockSignatures` directly |
| `BlockSignatures.proposer_signature` | Semantics changed: now signs the **block root** with the **proposal key** (was: signed attestation data with single key) |
| Genesis config format | `GENESIS_VALIDATORS` changed from list of hex strings to list of `{attestation_pubkey, proposal_pubkey}` objects |

#### Key Manager (`crates/blockchain/src/key_manager.rs`)

- Introduced `ValidatorKeyPair` struct holding `attestation_key` and `proposal_key`
- `KeyManager` stores `HashMap<u64, ValidatorKeyPair>` instead of single keys
- Added `sign_block_root()` method that uses the proposal key
- `sign_attestation()` now internally routes to the attestation key

#### Block Proposal (`crates/blockchain/src/lib.rs`)

- `propose_block()`: signs block root with proposal key, no longer creates proposer attestation
- `produce_attestations()`: removed proposer skip — all validators (including proposer) attest at interval 1
- All `SignedBlockWithAttestation` → `SignedBlock` type cascade
- All `.message.block.X` → `.message.X` field access fixes

#### Store & Verification (`crates/blockchain/src/store.rs`)

- `verify_signatures()`: attestation proofs verified with `get_attestation_pubkey()`, proposer signature verified with `get_proposal_pubkey()` over block root
- `on_block_core()`: removed entire proposer attestation processing block (~40 lines) — no more gossip signature insert, no more dummy proof for proposer
- Removed `StoreError::ProposerAttestationMismatch` variant
- Gossip attestation/aggregation verification uses `get_attestation_pubkey()`

#### Storage (`crates/storage/src/store.rs`)

- `write_signed_block()`: destructures `SignedBlock { message: block, signature }` directly, stores `BlockSignatures` without wrapper
- `get_signed_block()`: deserializes `BlockSignatures` directly, reconstructs `SignedBlock`
- Table docs updated

#### Network (`crates/net/`)

- Type rename across all 6 network files (api, gossipsub handler/encoding, req_resp codec/handlers/messages)
- Field access `.message.block.X` → `.message.X` in gossip handler and req_resp handlers

#### Binary (`bin/ethlambda/src/main.rs`)

- `AnnotatedValidator`: now expects `attestation_pubkey_hex`, `proposal_pubkey_hex`, `attestation_privkey_file`, `proposal_privkey_file`
- `read_validator_keys()`: reads two key files per validator, constructs `ValidatorKeyPair`
- Checkpoint sync: validates both `attestation_pubkey` and `proposal_pubkey` match

#### Tests

- Unit tests updated and passing (34 tests across types, blockchain, checkpoint_sync)
- Spec test types updated to compile with new format
- Fork choice test `BlockStepData`: removed `proposer_attestation` field
- Signature test `TestSignedBlock`: simplified from `TestSignedBlockWithAttestation`

## Blockers

- **Test fixtures**: `leansig-test-keys` has not published dual-key format keys yet. Fixture generation (`make leanSpec/fixtures`) fails with `KeyError: 'attestation_public'`. Spec tests (fork_choice, verify_signatures, stf) cannot run until keys are available.
- **lean-quickstart**: needs to be updated to generate devnet4 genesis configs with dual keys and dual key files per validator

## Potential split

This PR could be split into smaller parts if preferred:

1. **Types only** — `Validator` dual pubkeys, `SignedBlock` rename, genesis config format (Phase 1)
2. **Key manager + proposal flow** — `ValidatorKeyPair`, `sign_block_root`, proposer attestation removal (Phase 2)
3. **Store + verification** — dual-key verification, remove proposer attestation from `on_block_core` (Phase 3)
4. **Network + tests** — type cascade through network layer, test harness updates (Phase 4+5)

Note: Phase 1 is SSZ-breaking, so Phases 2-4 won't compile independently without Phase 1.

## How to Test

```bash
# Verify compilation
cargo check --workspace

# Run unit tests (spec tests blocked on fixtures)
cargo test -p ethlambda-types
cargo test -p ethlambda-blockchain --lib
cargo test -p ethlambda

# Lint
cargo clippy --workspace --all-targets -- -D warnings
```

Full devnet testing requires lean-quickstart devnet4 support.