### PR TITLE
Increase STATES_TO_KEEP from 900 to 3000

### DIFF
--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -1486,7 +1486,7 @@ mod tests {
         let head_root = root(total_states as u64 - 1);
         store.update_checkpoints(ForkCheckpoints::head_only(head_root));
 
-        // 905 headers total. Top 3000 by slot are kept in the retention window,
+        // 3005 headers total. Top 3000 by slot are kept in the retention window,
         // leaving 5 candidates. 2 are protected (finalized + justified),
         // so 3 are pruned → 3005 - 3 = 3002 states remaining.
         assert_eq!(


### PR DESCRIPTION
## Motivation

Increase state retention window from ~1 hour (900 slots) to ~3.3 hours (3000 slots) at 4-second slot times. This reduces the gap between state retention and block retention (`BLOCKS_TO_KEEP=21600`), making state-header mismatches less likely during finalization stalls.

## Changes

Single constant change in `crates/storage/src/store.rs`:

```rust
// Before
const STATES_TO_KEEP: usize = 900;

// After
const STATES_TO_KEEP: usize = 3_000;
```

## How to Test

`make test` — all tests pass.

Closes #239
