### PR TITLE
Add --data-dir CLI parameter for configuring storage path

### DIFF
--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -136,7 +136,7 @@ async fn main() -> eyre::Result<()> {
     std::fs::create_dir_all(&options.data_dir).expect("Failed to create data directory");
     let backend =
         Arc::new(RocksDBBackend::open(&options.data_dir).expect("Failed to open RocksDB"));
-    info!(data_dir = %options.data_dir.display(), "Opened storage");
+    info!(data_dir = %options.data_dir.display(), "Initialized DB");
 
     let store = fetch_initial_state(
         options.checkpoint_sync_url.as_deref(),


### PR DESCRIPTION
## Motivation

The RocksDB storage path was hardcoded to `./data`, making it impossible to configure where the node stores its data on disk. Other lean clients (e.g., Zeam) already expose a `--data-dir` parameter for this purpose.

This is especially important for:
- **Server deployments** where operators want to store data on a specific disk/partition
- **Running multiple nodes** on the same machine with separate data directories
- **Docker setups** where the data directory needs to match volume mounts

## Description

- Add `--data-dir` CLI argument to `CliOptions` (type: `PathBuf`, default: `./data`)
- Replace the hardcoded `"./data"` string in `RocksDBBackend::open()` with the CLI-provided value
- Fully backward compatible — existing deployments that don't pass `--data-dir` get the same `./data` default

### Usage

```bash
# Default (same as before)
ethlambda --custom-network-config-dir /config --node-key /config/node.key --node-id ethlambda_0 --gossipsub-port 9001

# Custom data directory
ethlambda --data-dir /mnt/ssd/ethlambda-data --custom-network-config-dir /config --node-key /config/node.key --node-id ethlambda_0 --gossipsub-port 9001
```

### CLI help output

| Flag | Default | Description |
|------|---------|-------------|
| `--data-dir` | `./data` | Directory for RocksDB storage |

## Files changed

- `bin/ethlambda/src/main.rs` — new CLI arg + use it when opening RocksDB

## How to Test

1. Run without `--data-dir` → data is stored in `./data` (no behavior change)
2. Run with `--data-dir /tmp/test-data` → data is stored in `/tmp/test-data`
3. Verify `--help` shows the new flag

## Related Issues

Closes #79