### PR TITLE
Rename SignedBlockWithAttestation.message to .block to match leanSpec

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -247,7 +247,7 @@ impl BlockChainServer {
 
         // Assemble SignedBlockWithAttestation
         let signed_block = SignedBlockWithAttestation {
-            message: BlockWithAttestation {
+            block: BlockWithAttestation {
                 block,
                 proposer_attestation,
             },
@@ -317,10 +317,10 @@ impl BlockChainServer {
         signed_block: SignedBlockWithAttestation,
         queue: &mut VecDeque<SignedBlockWithAttestation>,
     ) {
-        let slot = signed_block.message.block.slot;
-        let block_root = signed_block.message.block.tree_hash_root();
-        let parent_root = signed_block.message.block.parent_root;
-        let proposer = signed_block.message.block.proposer_index;
+        let slot = signed_block.block.block.slot;
+        let block_root = signed_block.block.block.tree_hash_root();
+        let parent_root = signed_block.block.block.parent_root;
+        let proposer = signed_block.block.block.proposer_index;
 
         // Check if parent state exists before attempting to process
         if !self.store.has_state(&parent_root) {
@@ -442,7 +442,7 @@ impl BlockChainServer {
                 continue;
             };
 
-            let slot = child_block.message.block.slot;
+            let slot = child_block.block.block.slot;
             trace!(%parent_root, %slot, "Processing pending child block");
 
             queue.push_back(child_block);

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -552,7 +552,7 @@ fn on_block_core(
 ) -> Result<(), StoreError> {
     let _timing = metrics::time_fork_choice_block_processing();
 
-    let block = &signed_block.message.block;
+    let block = &signed_block.block.block;
     let block_root = block.tree_hash_root();
     let slot = block.slot;
 
@@ -577,8 +577,8 @@ fn on_block_core(
         verify_signatures(&parent_state, &signed_block)?;
     }
 
-    let block = signed_block.message.block.clone();
-    let proposer_attestation = signed_block.message.proposer_attestation.clone();
+    let block = signed_block.block.block.clone();
+    let proposer_attestation = signed_block.block.proposer_attestation.clone();
 
     // Execute state transition function to compute post-block state
     let mut post_state = parent_state;
@@ -1200,7 +1200,7 @@ fn verify_signatures(
     use ethlambda_crypto::verify_aggregated_signature;
     use ethlambda_types::signature::ValidatorSignature;
 
-    let block = &signed_block.message.block;
+    let block = &signed_block.block.block;
     let attestations = &block.body.attestations;
     let attestation_signatures = &signed_block.signature.attestation_signatures;
 
@@ -1250,7 +1250,7 @@ fn verify_signatures(
         }
     }
 
-    let proposer_attestation = &signed_block.message.proposer_attestation;
+    let proposer_attestation = &signed_block.block.proposer_attestation;
 
     if proposer_attestation.validator_id != block.proposer_index {
         return Err(StoreError::ProposerAttestationMismatch {
@@ -1375,7 +1375,7 @@ mod tests {
         let attestation_signatures = ssz_types::VariableList::new(vec![proof]).unwrap();
 
         let signed_block = SignedBlockWithAttestation {
-            message: BlockWithAttestation {
+            block: BlockWithAttestation {
                 block: Block {
                     slot: 0,
                     proposer_index: 0,

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -58,8 +58,8 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
 
                     let signed_block = build_signed_block(block_data);
 
-                    let block_time_ms = genesis_time * 1000
-                        + signed_block.message.block.slot * MILLISECONDS_PER_SLOT;
+                    let block_time_ms =
+                        genesis_time * 1000 + signed_block.block.block.slot * MILLISECONDS_PER_SLOT;
 
                     // NOTE: the has_proposal argument is set to true, following the spec
                     store::on_tick(&mut store, block_time_ms, true, false);
@@ -109,7 +109,7 @@ fn build_signed_block(block_data: types::BlockStepData) -> SignedBlockWithAttest
     let proposer_attestation: Attestation = block_data.proposer_attestation.into();
 
     SignedBlockWithAttestation {
-        message: BlockWithAttestation {
+        block: BlockWithAttestation {
             block,
             proposer_attestation,
         },

--- a/crates/blockchain/tests/signature_spectests.rs
+++ b/crates/blockchain/tests/signature_spectests.rs
@@ -51,7 +51,7 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
 
         // Advance time to the block's slot
         let block_time_ms =
-            genesis_time * 1000 + signed_block.message.block.slot * MILLISECONDS_PER_SLOT;
+            genesis_time * 1000 + signed_block.block.block.slot * MILLISECONDS_PER_SLOT;
         store::on_tick(&mut st, block_time_ms, true, false);
 
         // Process the block (this includes signature verification)

--- a/crates/blockchain/tests/signature_types.rs
+++ b/crates/blockchain/tests/signature_types.rs
@@ -56,7 +56,7 @@ pub struct TestSignedBlockWithAttestation {
 
 impl From<TestSignedBlockWithAttestation> for SignedBlockWithAttestation {
     fn from(value: TestSignedBlockWithAttestation) -> Self {
-        let message = BlockWithAttestation {
+        let block = BlockWithAttestation {
             block: value.message.block.into(),
             proposer_attestation: value.message.proposer_attestation.into(),
         };
@@ -82,7 +82,7 @@ impl From<TestSignedBlockWithAttestation> for SignedBlockWithAttestation {
             .expect("too many attestation signatures");
 
         SignedBlockWithAttestation {
-            message,
+            block,
             signature: BlockSignatures {
                 attestation_signatures,
                 proposer_signature,

--- a/crates/common/types/src/block.rs
+++ b/crates/common/types/src/block.rs
@@ -16,13 +16,13 @@ use crate::{
 #[derive(Clone, Encode, Decode)]
 pub struct SignedBlockWithAttestation {
     /// The block plus an attestation from proposer being signed.
-    pub message: BlockWithAttestation,
+    pub block: BlockWithAttestation,
 
     /// Aggregated signature payload for the block.
     ///
     /// Signatures remain in attestation order followed by the proposer signature
-    /// over entire message. For devnet 1, however the proposer signature is just
-    /// over message.proposer_attestation since leanVM is not yet performant enough
+    /// over entire block. For devnet 1, however the proposer signature is just
+    /// over block.proposer_attestation since leanVM is not yet performant enough
     /// to aggregate signatures with sufficient throughput.
     ///
     /// Eventually this field will be replaced by a SNARK (which represents the
@@ -34,7 +34,7 @@ pub struct SignedBlockWithAttestation {
 impl core::fmt::Debug for SignedBlockWithAttestation {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("SignedBlockWithAttestation")
-            .field("message", &self.message)
+            .field("block", &self.block)
             .field("signature", &"...")
             .finish()
     }
@@ -140,7 +140,7 @@ impl BlockSignaturesWithAttestation {
     /// Takes ownership to avoid cloning large signature data.
     pub fn from_signed_block(signed_block: SignedBlockWithAttestation) -> Self {
         Self {
-            proposer_attestation: signed_block.message.proposer_attestation,
+            proposer_attestation: signed_block.block.proposer_attestation,
             signatures: signed_block.signature,
         }
     }
@@ -150,7 +150,7 @@ impl BlockSignaturesWithAttestation {
     /// Consumes self to avoid cloning large signature data.
     pub fn to_signed_block(self, block: Block) -> SignedBlockWithAttestation {
         SignedBlockWithAttestation {
-            message: BlockWithAttestation {
+            block: BlockWithAttestation {
                 block,
                 proposer_attestation: self.proposer_attestation,
             },

--- a/crates/net/p2p/src/gossipsub/handler.rs
+++ b/crates/net/p2p/src/gossipsub/handler.rs
@@ -36,11 +36,11 @@ pub async fn handle_gossipsub_message(server: &mut P2PServer, event: Event) {
             else {
                 return;
             };
-            let slot = signed_block.message.block.slot;
-            let block_root = signed_block.message.block.tree_hash_root();
-            let proposer = signed_block.message.block.proposer_index;
-            let parent_root = signed_block.message.block.parent_root;
-            let attestation_count = signed_block.message.block.body.attestations.len();
+            let slot = signed_block.block.block.slot;
+            let block_root = signed_block.block.block.tree_hash_root();
+            let proposer = signed_block.block.block.proposer_index;
+            let parent_root = signed_block.block.block.parent_root;
+            let attestation_count = signed_block.block.block.body.attestations.len();
             info!(
                 %slot,
                 proposer,
@@ -146,11 +146,11 @@ pub async fn publish_attestation(server: &mut P2PServer, attestation: SignedAtte
 }
 
 pub async fn publish_block(server: &mut P2PServer, signed_block: SignedBlockWithAttestation) {
-    let slot = signed_block.message.block.slot;
-    let proposer = signed_block.message.block.proposer_index;
-    let block_root = signed_block.message.block.tree_hash_root();
-    let parent_root = signed_block.message.block.parent_root;
-    let attestation_count = signed_block.message.block.body.attestations.len();
+    let slot = signed_block.block.block.slot;
+    let proposer = signed_block.block.block.proposer_index;
+    let block_root = signed_block.block.block.tree_hash_root();
+    let parent_root = signed_block.block.block.parent_root;
+    let attestation_count = signed_block.block.block.body.attestations.len();
 
     // Encode to SSZ
     let ssz_bytes = signed_block.as_ssz_bytes();

--- a/crates/net/p2p/src/req_resp/handlers.rs
+++ b/crates/net/p2p/src/req_resp/handlers.rs
@@ -146,7 +146,7 @@ async fn handle_blocks_by_root_response(
     }
 
     for block in blocks {
-        let root = block.message.block.tree_hash_root();
+        let root = block.block.block.tree_hash_root();
 
         // Validate that this block matches what we requested
         if root != requested_root {

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -1128,11 +1128,10 @@ fn write_signed_block(
     signed_block: SignedBlockWithAttestation,
 ) -> Block {
     let SignedBlockWithAttestation {
-        message:
-            BlockWithAttestation {
-                block,
-                proposer_attestation,
-            },
+        block: BlockWithAttestation {
+            block,
+            proposer_attestation,
+        },
         signature,
     } = signed_block;
 


### PR DESCRIPTION
## Motivation

[leanSpec#465](https://github.com/leanEthereum/leanSpec/pull/465) renamed the `SignedBlock` container field from `message` to `block`. As noted in that PR:

> This PR changes the ssz container field name from SignedBlock.message to SignedBlock.block. It doesn't affect ssz compatibility because ssz is schemaless, but I believe we rely on the same container namings across all client impls, so it will be hard to sync specs vs impls if not renamed.

This PR makes the corresponding rename in ethlambda to stay aligned with the spec and other client implementations.

## Changes

Renamed `SignedBlockWithAttestation.message` → `SignedBlockWithAttestation.block` across 9 files (39 insertions, 40 deletions):

### Core type definition
- **`crates/common/types/src/block.rs`**: Renamed the struct field, updated the manual `Debug` impl, `from_signed_block()`, `to_signed_block()`, and doc comments that referenced `message`.

### Blockchain crate
- **`crates/blockchain/src/lib.rs`**: Updated block construction in `propose_block()`, field access in `process_or_pend_block()`, and pending block cascade in `process_pending_children()`.
- **`crates/blockchain/src/store.rs`**: Updated `on_block_core()` (block extraction and cloning), `verify_signatures()` (block and proposer attestation access), and a test helper struct construction.

### Storage crate
- **`crates/storage/src/store.rs`**: Updated the destructuring pattern in `write_signed_block()`.

### Networking crate
- **`crates/net/p2p/src/gossipsub/handler.rs`**: Updated all 10 field accesses in `handle_gossipsub_message()` (block receive logging) and `publish_block()` (block publish logging).
- **`crates/net/p2p/src/req_resp/handlers.rs`**: Updated block root computation in `handle_blocks_by_root_response()`.

### Test files
- **`crates/blockchain/tests/forkchoice_spectests.rs`**: Updated `build_signed_block()` construction and slot access.
- **`crates/blockchain/tests/signature_spectests.rs`**: Updated slot access for block timing.
- **`crates/blockchain/tests/signature_types.rs`**: Updated local variable name and struct construction in `From<TestSignedBlockWithAttestation>` impl.

### Not changed
- **`TestSignedBlockWithAttestation.message`** (in `signature_types.rs`): This test deserialization type still uses `message` to match the current YAML test fixture field names. It will need updating when `LEAN_SPEC_COMMIT_HASH` is bumped to a commit that includes leanSpec#465.

## Notes

- **SSZ compatibility**: SSZ is schemaless, so this rename has zero impact on wire format or cross-client interop.
- **No behavioral changes**: This is a pure rename — no logic was added, removed, or modified.
- The resulting access pattern `signed_block.block.block` (outer `.block` is `BlockWithAttestation`, inner `.block` is `Block`) is slightly redundant but matches the spec structure.

## How to Test

```bash
make fmt    # ✅ passes
make lint   # ✅ passes
make test   # ✅ passes
```