### PR TITLE
cli: Log data dir before error

### DIFF
--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -137,11 +137,11 @@ async fn main() -> eyre::Result<()> {
     let validator_keys =
         read_validator_keys(&validators_path, &validator_keys_dir, &options.node_id);
 
-    let data_dir = std::path::absolute(&options.data_dir).unwrap_or_else(|_| options.data_dir.clone());
+    let data_dir =
+        std::path::absolute(&options.data_dir).unwrap_or_else(|_| options.data_dir.clone());
     info!(data_dir = %data_dir.display(), "Initializing DB");
     std::fs::create_dir_all(&data_dir).expect("Failed to create data directory");
-    let backend =
-        Arc::new(RocksDBBackend::open(&data_dir).expect("Failed to open RocksDB"));
+    let backend = Arc::new(RocksDBBackend::open(&data_dir).expect("Failed to open RocksDB"));
 
     let store = fetch_initial_state(
         options.checkpoint_sync_url.as_deref(),


### PR DESCRIPTION
Log absolute data dir before error to see directory path that causes error.
```diff
+2026-03-26T01:51:32.188407Z  INFO ethlambda: Opening data directory data_dir=/app/data
 Failed to create data directory: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
```