### PR TITLE
Avoid unnecessary Vec allocations in greedy proof selection

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -973,24 +973,30 @@ fn extend_proofs_greedily(
     let mut remaining_indices: HashSet<usize> = (0..proofs.len()).collect();
 
     while !remaining_indices.is_empty() {
-        // Pick proof covering the most uncovered validators
+        // Pick proof covering the most uncovered validators (count only, no allocation)
         let best = remaining_indices
             .iter()
             .map(|&idx| {
-                let new_coverage: Vec<u64> = proofs[idx]
+                let count = proofs[idx]
                     .participant_indices()
                     .filter(|vid| !covered.contains(vid))
-                    .collect();
-                (idx, new_coverage)
+                    .count();
+                (idx, count)
             })
-            .max_by_key(|(_, cov)| cov.len());
+            .max_by_key(|&(_, count)| count);
 
-        let Some((best_idx, new_covered)) = best else {
+        let Some((best_idx, best_count)) = best else {
             break;
         };
-        if new_covered.is_empty() {
+        if best_count == 0 {
             break;
         }
+
+        // Collect coverage only for the winning proof
+        let new_covered: Vec<u64> = proofs[best_idx]
+            .participant_indices()
+            .filter(|vid| !covered.contains(vid))
+            .collect();
 
         let proof = &proofs[best_idx];
         attestations.push(AggregatedAttestation {


### PR DESCRIPTION
## Motivation

The `extend_proofs_greedily` function (introduced in #251) uses a greedy set-cover algorithm to select aggregated signature proofs that maximize validator coverage. On each iteration of the selection loop, it was allocating a `Vec<u64>` for **every** remaining candidate proof just to compare coverage counts via `.len()`. Only the winning proof's coverage Vec is actually needed -- to extend the covered set and record the attestation count.

With N remaining proofs per iteration, this means N-1 unnecessary heap allocations that are immediately discarded. Since this runs on the block production hot path (every 4 seconds), reducing throwaway allocations is worthwhile.

## Description

Split the greedy selection into two phases:

1. **Selection pass** -- computes only a `.count()` (no allocation) for each candidate proof to find the one covering the most uncovered validators.
2. **Collection pass** -- collects the actual `Vec<u64>` of newly covered validator IDs only for the winning proof.

This trades one extra iteration over the best proof's participant indices for avoiding N-1 `Vec` allocations per loop iteration.

## How to Test

- `make test` -- all existing tests pass (no behavioral change)
- `make lint` -- clippy clean