### PR TITLE
Simplify signature verification and document gossip counter safety

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1150,18 +1150,15 @@ fn verify_signatures(
             return Err(StoreError::ParticipantsMismatch);
         }
 
-        let validator_ids: Vec<_> = validator_indices(&attestation.aggregation_bits).collect();
-        if validator_ids.iter().any(|vid| *vid >= num_validators) {
-            return Err(StoreError::InvalidValidatorIndex);
-        }
-
         let slot: u32 = attestation.data.slot.try_into().expect("slot exceeds u32");
         let message = attestation.data.tree_hash_root();
 
-        // Collect public keys for all participating validators
-        let public_keys: Vec<_> = validator_ids
-            .iter()
-            .map(|&vid| {
+        // Collect public keys with bounds check in a single pass
+        let public_keys: Vec<_> = validator_indices(&attestation.aggregation_bits)
+            .map(|vid| {
+                if vid >= num_validators {
+                    return Err(StoreError::InvalidValidatorIndex);
+                }
                 validators[vid as usize]
                     .get_pubkey()
                     .map_err(|_| StoreError::PubkeyDecodingFailed(vid))

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -227,6 +227,10 @@ pub struct Store {
     backend: Arc<dyn StorageBackend>,
     new_payloads: Arc<Mutex<PayloadBuffer>>,
     known_payloads: Arc<Mutex<PayloadBuffer>>,
+    /// Cached count of GossipSignatures table entries, used only for metrics.
+    /// Safe because all Store mutations happen on the BlockChain actor's single thread.
+    /// If concurrent writes are ever introduced, the read-then-write in
+    /// insert_gossip_signature must be made atomic to prevent counter drift.
     gossip_signatures_count: Arc<AtomicUsize>,
 }
 


### PR DESCRIPTION
## Motivation

Two findings from a full codebase review:

1. **Redundant iteration in signature verification** -- `verify_all_signatures` collected all validator IDs into a `Vec`, iterated it for bounds checking, then iterated it again to collect public keys. This runs on every block verification (hot path), allocating an unnecessary intermediate `Vec<u64>` per attestation.

2. **Undocumented safety assumption on `gossip_signatures_count`** -- The `AtomicUsize` counter tracks `GossipSignatures` table entries for Prometheus metrics. The `insert_gossip_signature` method uses a read-then-write pattern (check if key exists, then conditionally increment) that has a TOCTOU gap. This is safe today because all Store mutations run on the BlockChain actor's single thread, but the `Arc<AtomicUsize>` wrapping suggests the Store is designed to be shared -- making the assumption non-obvious to future contributors.

## Description

- Combine validator ID collection, bounds checking, and public key lookup into a single iterator pass in `verify_all_signatures`, removing one `Vec` allocation and one full iteration per attestation
- Add a comment on the `gossip_signatures_count` field documenting the single-threaded safety assumption and the risk if concurrent writes are ever introduced

## How to Test

- `make test` -- no behavioral change, all tests pass
- `make lint` -- clippy clean