### PR TITLE
Fix attestation source divergence (leanSpec PR #506)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-LEAN_SPEC_COMMIT_HASH:=9c30436bf4c073d1a994f37a3241e83ef5a3ce6f
+LEAN_SPEC_COMMIT_HASH:=d39d10195414921e979e2fdd43723d89cee13c8b
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch


### PR DESCRIPTION
## Summary

- Use `head_state.latest_justified` instead of `store.latest_justified()` as attestation source in `produce_attestation_data`, aligning voting with the block builder's filter
- Handle genesis edge case (zero-hash root substitution) matching existing `build_block` logic
- Add Rust unit test ported from leanSpec PR #506

## Root Cause

`produce_attestation_data` used `store.latest_justified` (the global max across all forks) as the attestation source. `build_block` filters attestations against `head_state.latest_justified` (the head chain's view). When a non-head fork block advances the store-wide justified past the head chain's justified — e.g. a minority fork carrying a supermajority of attestations — every attestation is rejected during block building. This produces blocks with 0 attestations, stalling justification and finalization indefinitely.

**Ref**: [leanSpec PR #506](https://github.com/leanEthereum/leanSpec/pull/506), [3sf-mini reference](https://github.com/ethereum/research/blob/master/3sf-mini/p2p.py) (`Staker.vote()` uses `self.post_states[self.head].latest_justified_hash`)

## Note on spec test fixtures

The leanSpec commit that includes PR #506 also introduces a validator format change (`pubkey` → `attestationPubkey` + `proposalPubkey`) that requires a domain model migration. The spec test fixture update is deferred to a separate PR. The unit test covers the same invariant.

## Test plan

- [x] Unit test `produce_attestation_data_uses_head_state_justified` passes
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p ethlambda-blockchain -- -D warnings` clean
- [ ] Full `make test` with existing fixtures (running)