### PR TITLE
chore: bump libp2p version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,12 +2659,12 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+checksum = "b604752cefc5aa3ab98992a107a8bd99465d2825c1584e0b60cb6957b21e19d7"
 dependencies = [
- "futures-timer",
  "futures-util",
+ "tokio",
 ]
 
 [[package]]
@@ -2998,11 +2998,11 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3873,8 +3873,8 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p"
-version = "0.56.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.57.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "bytes",
  "either",
@@ -3921,8 +3921,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.6.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.7.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3931,10 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.15.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.16.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "either",
  "futures",
@@ -3955,8 +3954,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.6.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.7.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3965,8 +3964,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.43.2"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.44.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "either",
  "fnv",
@@ -3989,8 +3988,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.14.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.15.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4010,10 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.44.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.45.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
- "async-trait",
  "futures",
  "hickory-resolver",
  "libp2p-core",
@@ -4025,8 +4023,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.47.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.48.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4047,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -4077,8 +4075,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.47.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.48.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4122,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.49.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4148,8 +4146,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.48.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.49.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4166,8 +4164,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-memory-connection-limits"
-version = "0.5.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.6.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4179,8 +4177,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.18.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4199,8 +4197,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.46.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.47.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4221,8 +4219,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.47.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.48.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4236,8 +4234,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.43.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.44.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4251,8 +4249,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.26.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.27.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "pin-project",
@@ -4264,8 +4262,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.13.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.14.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4285,8 +4283,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.21.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.22.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4308,14 +4306,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-rendezvous"
-version = "0.17.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.18.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "bimap",
  "futures",
  "futures-timer",
+ "hashlink",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-request-response",
@@ -4330,10 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.29.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.30.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
- "async-trait",
  "cbor4ii",
  "futures",
  "futures-bounded",
@@ -4349,8 +4346,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.48.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "either",
  "fnv",
@@ -4372,8 +4369,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.36.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "heck",
  "quote",
@@ -4382,8 +4379,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.44.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.45.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4397,8 +4394,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.6.2"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.7.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4415,8 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.43.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.44.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4425,8 +4422,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.6.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.7.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4439,8 +4436,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-utils"
-version = "0.4.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.5.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4460,8 +4457,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-websys"
-version = "0.4.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.5.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "bytes",
  "futures",
@@ -4481,8 +4478,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.45.2"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.46.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "either",
  "futures",
@@ -4501,8 +4498,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket-websys"
-version = "0.5.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.6.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "bytes",
  "futures",
@@ -4517,8 +4514,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webtransport-websys"
-version = "0.5.2"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.6.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "js-sys",
@@ -4537,8 +4534,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.47.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.48.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "either",
  "futures",
@@ -5021,8 +5018,8 @@ dependencies = [
 
 [[package]]
 name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.14.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "bytes",
  "futures",
@@ -6177,8 +6174,8 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.4.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6836,8 +6833,8 @@ dependencies = [
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=cd6cc3b1e5db2c5e23e133c2201c23b063fc4895#cd6cc3b1e5db2c5e23e133c2201c23b063fc4895"
+version = "0.5.0"
+source = "git+https://github.com/lambdaclass/rust-libp2p.git?rev=2f14d0ec9665a01cfb6a02326c90628c4bba521c#2f14d0ec9665a01cfb6a02326c90628c4bba521c"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,6 @@ dependencies = [
 name = "ethlambda-p2p"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "ethlambda-metrics",
  "ethlambda-network-api",
  "ethlambda-storage",

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 tokio-stream = "0.1"
 
 # Fork with request-response feature for outbound protocol selection
-libp2p = { git = "https://github.com/lambdaclass/rust-libp2p.git", rev = "cd6cc3b1e5db2c5e23e133c2201c23b063fc4895", features = [
+libp2p = { git = "https://github.com/lambdaclass/rust-libp2p.git", rev = "2f14d0ec9665a01cfb6a02326c90628c4bba521c", features = [
     "full",
 ] }
 

--- a/crates/net/p2p/Cargo.toml
+++ b/crates/net/p2p/Cargo.toml
@@ -17,7 +17,6 @@ ethlambda-types.workspace = true
 
 spawned-concurrency.workspace = true
 
-async-trait = "0.1"
 futures = "0.3"
 tokio-stream = "0.1"
 

--- a/crates/net/p2p/src/req_resp/codec.rs
+++ b/crates/net/p2p/src/req_resp/codec.rs
@@ -17,7 +17,6 @@ use ethlambda_types::block::SignedBlock;
 #[derive(Debug, Clone, Default)]
 pub struct Codec;
 
-#[async_trait::async_trait]
 impl libp2p::request_response::Codec for Codec {
     type Protocol = libp2p::StreamProtocol;
     type Request = Request;


### PR DESCRIPTION
This PR bumps the libp2p version to 2f14d0ec9665a01cfb6a02326c90628c4bba521c (the commit is in our fork).

# Changelog

Here's the summary of meaningful changes from upstream `master`:

## Gossipsub Changes (likely fixed our issue)

### `5d47d9d` - Port of 55e4a64 (biggest change)
**Multiple gossipsub fixes to `Instant` arithmetic and backoff handling:**
- **GRAFT flood penalty fix**: Replaced unsafe `Instant` subtraction (which can panic/overflow) with `checked_sub` + `saturating_duration_since`. The old code computed `(backoff_time + graft_flood_threshold) - prune_backoff` which could panic if the arithmetic overflowed. This is likely **the fix** that resolved cross-client mesh issues: if a peer's GRAFT was incorrectly penalized due to arithmetic overflow, it would never join the mesh.
- **IWANT followup time**: Added `checked_add` to prevent `Instant` overflow
- **Fanout TTL check**: Replaced `Instant` addition with `saturating_duration_since` 
- **IDONTWANT timeout**: Same pattern, safer arithmetic
- **Max PRUNE backoff cap**: Added `MAX_REMOTE_PRUNE_BACKOFF_SECONDS = 3600` to prevent a remote peer from requesting an absurdly long backoff

### `a7d59cb` - CVE fix (GHSA-gc42-3jg7-rxr2)
**Security fix**: Ignore oversized PRUNE backoff values. A malicious peer could send a PRUNE with a backoff duration so large that `Instant::now() + time` would overflow, causing a panic. Now uses `checked_add` and ignores invalid values.

### `7637c23` - Optimize IDONTWANT send
Only send IDONTWANT for first-seen large messages, deduplicating redundant messages.

### `aa7a9ec` - Partial messages extension
New gossipsub feature for partial message delivery (spec: libp2p/specs#704).

### `055186d` - Fix duplicate metrics
Bug fix for double-counted metrics.

## Other Changes
- `8541b83` - Remove `async_trait` from request_response (this caused our codec.rs compile fix)
- `b6b79b2` - MSRV bump to 1.88.0, Rust edition 2024
- `aad1f8e` - Remove unused `rpc.rs`
- `7cbf7c1` - TLS key logging via SSLKEYLOGFILE
- `3f88b30` - Rendezvous protocol port
- ~35 dependency bumps

## Root Cause Analysis

The GRAFT flood penalty fix in `5d47d9d` is almost certainly what fixed our cross-client block propagation. The old code had unsafe `Instant` arithmetic that could overflow when zeam peers (with slightly different timing) sent GRAFT requests. The overflow would cause the penalty check to always trigger, causing ethlambda to PRUNE zeam peers from the block topic mesh. Attestations worked because they used fanout (bypasses mesh/GRAFT entirely).