### PR TITLE
fix: subscribe non-aggregator validators to their attestation subnets

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -471,8 +471,10 @@ impl BlockChainServer {
     }
 
     fn on_gossip_attestation(&mut self, attestation: &SignedAttestation) {
+        // Non-aggregators subscribe to their attestation subnet for mesh health,
+        // so they see unaggregated attestations arrive. Only aggregators need to
+        // store and aggregate them.
         if !self.is_aggregator {
-            warn!("Received unaggregated attestation but node is not an aggregator");
             return;
         }
         let _ = store::on_gossip_attestation(&mut self.store, attestation)

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -198,7 +198,7 @@ impl BlockChainServer {
             // this the aggregator never sees its own validator's signature in
             // gossip_signatures and it is excluded from aggregated proofs.
             if self.is_aggregator {
-                let _ = store::on_gossip_attestation(&mut self.store, &signed_attestation)
+                let _ = store::on_gossip_attestation(&mut self.store, &signed_attestation, true)
                     .inspect_err(|err| {
                         warn!(%slot, %validator_id, %err, "Self-delivery of attestation failed")
                     });
@@ -471,13 +471,7 @@ impl BlockChainServer {
     }
 
     fn on_gossip_attestation(&mut self, attestation: &SignedAttestation) {
-        // Non-aggregators subscribe to their attestation subnet for mesh health,
-        // so they see unaggregated attestations arrive. Only aggregators need to
-        // store and aggregate them.
-        if !self.is_aggregator {
-            return;
-        }
-        let _ = store::on_gossip_attestation(&mut self.store, attestation)
+        let _ = store::on_gossip_attestation(&mut self.store, attestation, self.is_aggregator)
             .inspect_err(|err| warn!(%err, "Failed to process gossiped attestation"));
     }
 

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -528,11 +528,14 @@ pub fn on_tick(
 
 /// Process a gossiped attestation with signature verification.
 ///
-/// Verifies the validator's XMSS signature and stores it for later aggregation
-/// at interval 2. Only aggregator nodes receive unaggregated gossip attestations.
+/// Every subscriber validates the attestation data and verifies the XMSS
+/// signature so invalid messages get caught at the edge. Only aggregators
+/// store the signature for later aggregation at interval 2; non-aggregators
+/// drop it after verification.
 pub fn on_gossip_attestation(
     store: &mut Store,
     signed_attestation: &SignedAttestation,
+    is_aggregator: bool,
 ) -> Result<(), StoreError> {
     let validator_id = signed_attestation.validator_id;
     let attestation = Attestation {
@@ -570,10 +573,13 @@ pub fn on_gossip_attestation(
     }
     metrics::inc_pq_sig_attestation_signatures_valid();
 
-    // Store gossip signature unconditionally for later aggregation at interval 2.
-    // Subnet filtering is handled at the P2P subscription layer.
-    store.insert_gossip_signature(hashed, validator_id, signature);
-    metrics::update_gossip_signatures(store.gossip_signatures_count());
+    // Only aggregators persist the signature for later aggregation at
+    // interval 2. Non-aggregators drop the validated attestation — they
+    // still participate in the mesh so peers see the message propagate.
+    if is_aggregator {
+        store.insert_gossip_signature(hashed, validator_id, signature);
+        metrics::update_gossip_signatures(store.gossip_signatures_count());
+    }
 
     metrics::inc_attestations_valid(1);
 

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -223,11 +223,13 @@ pub fn build_swarm(
 
     let mut subscription_subnets = validator_subnets;
     if config.is_aggregator {
-        if subscription_subnets.is_empty() {
-            subscription_subnets.insert(0);
-        }
         if let Some(ref explicit_ids) = config.aggregate_subnet_ids {
             subscription_subnets.extend(explicit_ids);
+        }
+        // Fall back to subnet 0 only when the aggregator has no validators
+        // and no explicit subnets — otherwise leave the set as configured.
+        if subscription_subnets.is_empty() {
+            subscription_subnets.insert(0);
         }
     }
 

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -206,48 +206,38 @@ pub fn build_swarm(
         .subscribe(&aggregation_topic)
         .unwrap();
 
-    // Aggregators subscribe to attestation subnets to receive unaggregated
-    // attestations. Non-aggregators don't need to subscribe; they publish via
-    // gossipsub fanout.
-    if config.is_aggregator {
-        let mut aggregate_subnets: HashSet<u64> = config
-            .validator_ids
-            .iter()
-            .map(|vid| vid % config.attestation_committee_count)
-            .collect();
-        if let Some(ref explicit_ids) = config.aggregate_subnet_ids {
-            aggregate_subnets.extend(explicit_ids);
-        }
-        // Aggregator with no validators and no explicit subnets: fallback to subnet 0
-        if aggregate_subnets.is_empty() {
-            aggregate_subnets.insert(0);
-        }
-        for &subnet_id in &aggregate_subnets {
-            let topic = attestation_subnet_topic(subnet_id);
-            swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
-            info!(subnet_id, "Subscribed to attestation subnet");
-        }
-    }
+    // Subscribe to attestation subnets per leanSpec (`src/lean_spec/__main__.py`):
+    // every validator subscribes to its own subnet for mesh health; aggregators
+    // additionally subscribe to explicit `aggregate_subnet_ids` and fall back to
+    // subnet 0 when they have no validators of their own.
+    let validator_subnets: HashSet<u64> = config
+        .validator_ids
+        .iter()
+        .map(|vid| vid % config.attestation_committee_count)
+        .collect();
 
-    // Build topic cache (avoids string allocation on every publish).
-    // Includes validator subnets and any explicit aggregate_subnet_ids.
-    let mut attestation_topics: HashMap<u64, libp2p::gossipsub::IdentTopic> = HashMap::new();
-    for &vid in &config.validator_ids {
-        let subnet_id = vid % config.attestation_committee_count;
-        attestation_topics
-            .entry(subnet_id)
-            .or_insert_with(|| attestation_subnet_topic(subnet_id));
-    }
-    if let Some(ref explicit_ids) = config.aggregate_subnet_ids {
-        for &subnet_id in explicit_ids {
-            attestation_topics
-                .entry(subnet_id)
-                .or_insert_with(|| attestation_subnet_topic(subnet_id));
-        }
-    }
-
-    let metric_subnet = attestation_topics.keys().copied().min().unwrap_or(0);
+    // The committee metric should reflect validator membership only, not
+    // aggregator-only subscriptions.
+    let metric_subnet = validator_subnets.iter().copied().min().unwrap_or(0);
     metrics::set_attestation_committee_subnet(metric_subnet);
+
+    let mut subscription_subnets = validator_subnets;
+    if config.is_aggregator {
+        if subscription_subnets.is_empty() {
+            subscription_subnets.insert(0);
+        }
+        if let Some(ref explicit_ids) = config.aggregate_subnet_ids {
+            subscription_subnets.extend(explicit_ids);
+        }
+    }
+
+    let mut attestation_topics: HashMap<u64, libp2p::gossipsub::IdentTopic> = HashMap::new();
+    for &subnet_id in &subscription_subnets {
+        let topic = attestation_subnet_topic(subnet_id);
+        swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
+        info!(subnet_id, "Subscribed to attestation subnet");
+        attestation_topics.insert(subnet_id, topic);
+    }
 
     info!(socket=%config.listening_socket, "P2P node started");
 


### PR DESCRIPTION
## Summary

- Restore spec-compliant attestation-subnet subscription: every validator subscribes to its own subnet regardless of the `--is-aggregator` flag, so non-aggregator validator nodes join the gossipsub mesh and forward attestations instead of relying on fanout alone.
- Process but don't store gossip signatures in non-aggregator nodes.
- Restore the `lean_attestation_committee_subnet` metric to derive from validator subnets only, matching its pre-#265 semantics (the metric reports this node's committee membership, not aggregator-only subscriptions).

## Motivation

On a multi-client devnet (ethlambda_0 aggregator + ethlambda_1 + grandine_0 + gean_0, single attestation subnet), finalization stalled at slot ~50 with validators voting three different attestation targets. gean's attestations never reached ethlambda_0 once peer churn thinned the attestation subnet mesh: gean was publishing via fanout, but with only one subscriber (ethlambda_0) and transient peer drops, the mesh collapsed and could not recover.

`libp2p-gossipsub` (including the v1.2/v1.3 features in our fork) couples subscription with mesh participation. A node that does not `subscribe()` to a topic cannot be GRAFTed by peers and therefore cannot relay messages for it. `flood_publish` is publisher-side only and does not change this.

leanSpec (`src/lean_spec/__main__.py`) prescribes: any node with registered validators subscribes to its validator-derived subnets, so all validator peers contribute to the mesh. This PR aligns ethlambda with that rule.
