### PR TITLE
chore: bump leanSpec commit to e9ddede (2026-04-16)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-# 2026-04-14
-LEAN_SPEC_COMMIT_HASH:=76d4792ecd9d5bbcab60bfb022b72b590946b511
+# 2026-04-16
+LEAN_SPEC_COMMIT_HASH:=e9ddede89f87a46da585bcbce6b5080fad08d5de
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch


### PR DESCRIPTION
## Summary
- Updates `LEAN_SPEC_COMMIT_HASH` in the Makefile from `76d4792` (2026-04-14) to `e9ddede` (2026-04-16), picking up the latest upstream leanSpec changes used to regenerate fork choice, signature, and state transition test fixtures.

## Test plan
- [ ] `rm -rf leanSpec && make test` passes locally against the refreshed fixtures
- [ ] CI is green