### PR TITLE
Document sysctl tuning for QUIC UDP buffer sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ make run-devnet
 This generates fresh genesis files and starts all configured clients with metrics enabled.
 Press `Ctrl+C` to stop all nodes.
 
+> **Note:** On Linux, QUIC performance benefits from larger UDP receive buffers. If you see warnings about buffer sizes, increase the kernel limit:
+> ```sh
+> sudo sysctl -w net.core.rmem_max=7340032
+> sudo sysctl -w net.core.wmem_max=7340032
+> ```
+> To persist across reboots, add to `/etc/sysctl.conf`. For Docker, pass `--sysctl net.core.rmem_max=7340032 --sysctl net.core.wmem_max=7340032`.
+
 > **Important:** When running nodes manually (outside `make run-devnet`), at least one node must be started with `--is-aggregator` for attestations to be aggregated and included in blocks. Without this flag, the network will produce blocks but never finalize.
 
 For custom devnet configurations, go to `lean-quickstart/local-devnet/genesis/validator-config.yaml` and edit the file before running the command above. See `lean-quickstart`'s documentation for more details on how to configure the devnet.


### PR DESCRIPTION
## Motivation

Fixes #295. QUIC clients (both Rust/quinn and Go/quic-go) request ~7 MiB UDP receive buffers from the OS, but Linux defaults cap `SO_RCVBUF` at ~208 KiB. This causes warnings and can degrade networking performance under load.

The underlying `SO_RCVBUF`/`SO_SNDBUF` socket options aren't configurable through the libp2p/quinn API chain — they require OS-level sysctl tuning.

## Description

Adds a note in the README devnet section documenting:
- `net.core.rmem_max` and `net.core.wmem_max` sysctl settings (7 MiB)
- How to persist across reboots (`/etc/sysctl.conf`)
- Docker `--sysctl` flags for containerized deployments

## How to Test

Documentation-only change — verify the README renders correctly.

## Closes

Closes #295