### PR TITLE
refactor(p2p): drop NoPeersSubscribedToTopic suppression path

### DIFF
--- a/crates/net/p2p/src/gossipsub/handler.rs
+++ b/crates/net/p2p/src/gossipsub/handler.rs
@@ -145,18 +145,7 @@ pub async fn publish_attestation(server: &mut P2PServer, attestation: SignedAtte
         .cloned()
         .unwrap_or_else(|| attestation_subnet_topic(subnet_id));
 
-    // Publish to the attestation subnet topic.
-    // Aggregators are subscribed to the subnet, so gossipsub uses mesh (not fanout).
-    // In small networks where no other node subscribes, this returns
-    // NoPeersSubscribedToTopic. Use best-effort to suppress the expected warning;
-    // the aggregator already self-delivered its attestation locally.
-    if server.is_aggregator {
-        server
-            .swarm_handle
-            .publish_ignore_no_peers(topic, compressed);
-    } else {
-        server.swarm_handle.publish(topic, compressed);
-    }
+    server.swarm_handle.publish(topic, compressed);
     info!(
         %slot,
         validator,

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -92,7 +92,6 @@ pub struct BuiltSwarm {
     pub(crate) block_topic: libp2p::gossipsub::IdentTopic,
     pub(crate) aggregation_topic: libp2p::gossipsub::IdentTopic,
     pub(crate) bootnode_addrs: HashMap<PeerId, Multiaddr>,
-    pub(crate) is_aggregator: bool,
 }
 
 /// Build and configure the libp2p swarm, dial bootnodes, subscribe to topics.
@@ -250,7 +249,6 @@ pub fn build_swarm(
         block_topic,
         aggregation_topic,
         bootnode_addrs,
-        is_aggregator: config.is_aggregator,
     })
 }
 
@@ -274,7 +272,6 @@ impl P2P {
             attestation_committee_count: built.attestation_committee_count,
             block_topic: built.block_topic,
             aggregation_topic: built.aggregation_topic,
-            is_aggregator: built.is_aggregator,
             connected_peers: HashSet::new(),
             pending_requests: HashMap::new(),
             request_id_map: HashMap::new(),
@@ -309,7 +306,6 @@ pub struct P2PServer {
     pub(crate) attestation_committee_count: u64,
     pub(crate) block_topic: libp2p::gossipsub::IdentTopic,
     pub(crate) aggregation_topic: libp2p::gossipsub::IdentTopic,
-    pub(crate) is_aggregator: bool,
 
     pub(crate) connected_peers: HashSet<PeerId>,
     pub(crate) pending_requests: HashMap<H256, PendingRequest>,

--- a/crates/net/p2p/src/swarm_adapter.rs
+++ b/crates/net/p2p/src/swarm_adapter.rs
@@ -1,7 +1,6 @@
 use libp2p::{
     Multiaddr, PeerId, StreamProtocol,
     futures::StreamExt,
-    gossipsub::PublishError,
     request_response::{self, OutboundRequestId},
     swarm::SwarmEvent,
 };
@@ -14,8 +13,6 @@ pub enum SwarmCommand {
     Publish {
         topic: libp2p::gossipsub::IdentTopic,
         data: Vec<u8>,
-        /// When true, suppress NoPeersSubscribedToTopic errors (other errors still warn).
-        ignore_no_peers: bool,
     },
     Dial(Multiaddr),
     SendRequest {
@@ -40,25 +37,7 @@ impl SwarmHandle {
     pub fn publish(&self, topic: libp2p::gossipsub::IdentTopic, data: Vec<u8>) {
         let _ = self
             .cmd_tx
-            .send(SwarmCommand::Publish {
-                topic,
-                data,
-                ignore_no_peers: false,
-            })
-            .inspect_err(|_| warn!("Swarm adapter closed, cannot publish"));
-    }
-
-    /// Publish, suppressing NoPeersSubscribedToTopic errors. Used when the sender
-    /// is also subscribed to the topic (e.g., aggregator publishing its own
-    /// attestation to a subnet it subscribes to) and no other peer subscribes.
-    pub fn publish_ignore_no_peers(&self, topic: libp2p::gossipsub::IdentTopic, data: Vec<u8>) {
-        let _ = self
-            .cmd_tx
-            .send(SwarmCommand::Publish {
-                topic,
-                data,
-                ignore_no_peers: true,
-            })
+            .send(SwarmCommand::Publish { topic, data })
             .inspect_err(|_| warn!("Swarm adapter closed, cannot publish"));
     }
 
@@ -144,17 +123,13 @@ async fn swarm_loop(
 
 fn execute_command(swarm: &mut libp2p::Swarm<Behaviour>, cmd: SwarmCommand) {
     match cmd {
-        SwarmCommand::Publish {
-            topic,
-            data,
-            ignore_no_peers,
-        } => {
-            let result = swarm.behaviour_mut().gossipsub.publish(topic, data);
-            if let Err(err) = result
-                && !(ignore_no_peers && matches!(err, PublishError::NoPeersSubscribedToTopic))
-            {
-                warn!(%err, "Swarm adapter: publish failed");
-            }
+        SwarmCommand::Publish { topic, data } => {
+            swarm
+                .behaviour_mut()
+                .gossipsub
+                .publish(topic, data)
+                .inspect_err(|err| warn!(%err, "Swarm adapter: publish failed"))
+                .ok();
         }
         SwarmCommand::Dial(addr) => {
             let _ = swarm


### PR DESCRIPTION
## Summary

Follow-up to #293. Now that every validator subscribes to its own attestation subnet, the `NoPeersSubscribedToTopic` error path is no longer an expected-and-ignorable case on any publish site. Remove the suppression machinery and unify on a single publish path.

## Motivation

Before #293 only aggregators subscribed to attestation subnets. A non-aggregator publishing via fanout, or an aggregator in a single-subscriber mesh, could legitimately get `PublishError::NoPeersSubscribedToTopic` and we handled this by gating `publish_ignore_no_peers` on `is_aggregator`. This was already slightly misaligned (Codex flagged this on #293) and is now fully obsolete: every validator that publishes an attestation is itself in the mesh for that subnet, so if gossipsub still reports no remote subscribers, it means something is actually wrong (partition, misconfigured peer) and we want the warning.

## Changes

| File | Change |
|------|--------|
| `crates/net/p2p/src/swarm_adapter.rs` | Drop `ignore_no_peers` field on `SwarmCommand::Publish` and the `SwarmHandle::publish_ignore_no_peers` helper. The publish execution now uses a single `inspect_err` path that warns on any failure, including `NoPeersSubscribedToTopic`. Removed the now-unused `PublishError` import. |
| `crates/net/p2p/src/gossipsub/handler.rs` | `publish_attestation` no longer branches on `is_aggregator`; always calls `swarm_handle.publish(...)`. |
| `crates/net/p2p/src/lib.rs` | `is_aggregator` field removed from `BuiltSwarm` and `P2PServer` — the only consumer was the branching in `publish_attestation`. `SwarmConfig.is_aggregator` stays (still drives subscription decisions). |

Net diff: 3 files, +9/-49.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --release --lib` — 60 passed, 6 ignored
- [x] `cargo test -p ethlambda-blockchain --release --test forkchoice_spectests` — 57 passed
- [x] `cargo test -p ethlambda-state-transition --release --test stf_spectests` — 47 passed
- [ ] Devnet: confirm no new publish warnings under normal operation