### PR TITLE
fix: drop HashTreeRoot from XMSS-containing SSZ types

### DIFF
--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -35,7 +35,11 @@ pub struct AttestationData {
 }
 
 /// Validator attestation bundled with its signature.
-#[derive(Debug, Clone, SszEncode, SszDecode, HashTreeRoot)]
+///
+/// `HashTreeRoot` is intentionally not derived: `XmssSignature` is a fixed-size
+/// byte vector for cross-client serialization but the spec Merkleizes it as a
+/// container, so roots would diverge. No code hashes `SignedAttestation`.
+#[derive(Debug, Clone, SszEncode, SszDecode)]
 pub struct SignedAttestation {
     /// The index of the validator making the attestation.
     pub validator_id: u64,

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -36,9 +36,13 @@ pub struct AttestationData {
 
 /// Validator attestation bundled with its signature.
 ///
+/// <div class="warning">
+///
 /// `HashTreeRoot` is intentionally not derived: `XmssSignature` is a fixed-size
 /// byte vector for cross-client serialization but the spec Merkleizes it as a
 /// container, so roots would diverge. No code hashes `SignedAttestation`.
+///
+/// </div>
 #[derive(Debug, Clone, SszEncode, SszDecode)]
 pub struct SignedAttestation {
     /// The index of the validator making the attestation.

--- a/crates/common/types/src/block.rs
+++ b/crates/common/types/src/block.rs
@@ -13,10 +13,14 @@ use primitives::HashTreeRoot as _;
 
 /// Envelope carrying a block and its aggregated signatures.
 ///
+/// <div class="warning">
+///
 /// `HashTreeRoot` is intentionally not derived: `XmssSignature` is encoded as a
 /// fixed-size byte vector for cross-client serialization compatibility, but the
 /// spec treats it as a container for Merkleization. We never hash a
 /// `SignedBlock` directly — consumers always hash the inner `Block`.
+///
+/// </div>
 #[derive(Clone, SszEncode, SszDecode)]
 pub struct SignedBlock {
     /// The block being signed.
@@ -41,7 +45,11 @@ impl core::fmt::Debug for SignedBlock {
 
 /// Signature payload for the block.
 ///
+/// <div class="warning">
+///
 /// See the note on [`SignedBlock`] for why `HashTreeRoot` is omitted.
+///
+/// </div>
 #[derive(Clone, SszEncode, SszDecode)]
 pub struct BlockSignatures {
     /// Attestation signatures for the aggregated attestations in the block body.

--- a/crates/common/types/src/block.rs
+++ b/crates/common/types/src/block.rs
@@ -12,7 +12,12 @@ use crate::{
 use primitives::HashTreeRoot as _;
 
 /// Envelope carrying a block and its aggregated signatures.
-#[derive(Clone, SszEncode, SszDecode, HashTreeRoot)]
+///
+/// `HashTreeRoot` is intentionally not derived: `XmssSignature` is encoded as a
+/// fixed-size byte vector for cross-client serialization compatibility, but the
+/// spec treats it as a container for Merkleization. We never hash a
+/// `SignedBlock` directly — consumers always hash the inner `Block`.
+#[derive(Clone, SszEncode, SszDecode)]
 pub struct SignedBlock {
     /// The block being signed.
     pub message: Block,
@@ -35,7 +40,9 @@ impl core::fmt::Debug for SignedBlock {
 }
 
 /// Signature payload for the block.
-#[derive(Clone, SszEncode, SszDecode, HashTreeRoot)]
+///
+/// See the note on [`SignedBlock`] for why `HashTreeRoot` is omitted.
+#[derive(Clone, SszEncode, SszDecode)]
 pub struct BlockSignatures {
     /// Attestation signatures for the aggregated attestations in the block body.
     ///

--- a/crates/common/types/tests/ssz_spectests.rs
+++ b/crates/common/types/tests/ssz_spectests.rs
@@ -108,7 +108,7 @@ where
     let domain_value: D = fixture_value.into();
 
     // Re-encode for the hash computation; cheap relative to the fixture I/O.
-    debug_assert_eq!(
+    assert_eq!(
         <D as libssz::SszEncode>::to_ssz(&domain_value),
         expected_bytes
     );

--- a/crates/common/types/tests/ssz_spectests.rs
+++ b/crates/common/types/tests/ssz_spectests.rs
@@ -55,14 +55,18 @@ fn run_ssz_test(test: &SszTestCase) -> datatest_stable::Result<()> {
         }
         "Block" => run_typed_test::<ssz_types::Block, ethlambda_types::block::Block>(test),
         "State" => run_typed_test::<ssz_types::TestState, ethlambda_types::state::State>(test),
-        "SignedAttestation" => run_typed_test::<
+        // Types containing `XmssSignature` are serialized only — their hash tree
+        // root diverges from the spec because leanSpec Merkleizes the signature
+        // as a container while we treat it as fixed-size bytes.
+        "SignedAttestation" => run_serialization_only_test::<
             ssz_types::SignedAttestation,
             ethlambda_types::attestation::SignedAttestation,
         >(test),
-        "SignedBlock" => {
-            run_typed_test::<ssz_types::SignedBlock, ethlambda_types::block::SignedBlock>(test)
-        }
-        "BlockSignatures" => run_typed_test::<
+        "SignedBlock" => run_serialization_only_test::<
+            ssz_types::SignedBlock,
+            ethlambda_types::block::SignedBlock,
+        >(test),
+        "BlockSignatures" => run_serialization_only_test::<
             ssz_types::BlockSignatures,
             ethlambda_types::block::BlockSignatures,
         >(test),
@@ -95,17 +99,58 @@ where
     F: serde::de::DeserializeOwned + Into<D>,
     D: libssz::SszEncode + libssz::SszDecode + HashTreeRoot,
 {
-    let expected_bytes = decode_hex(&test.serialized)
-        .map_err(|e| format!("Failed to decode serialized hex: {e}"))?;
+    let expected_bytes = check_ssz_roundtrip::<F, D>(test)?;
     let expected_root =
         decode_hex_h256(&test.root).map_err(|e| format!("Failed to decode root hex: {e}"))?;
 
-    // Step 1: Deserialize JSON value into fixture type, then convert to domain type
     let fixture_value: F = serde_json::from_value(test.value.clone())
         .map_err(|e| format!("Failed to deserialize value: {e}"))?;
     let domain_value: D = fixture_value.into();
 
-    // Step 2: SSZ encode and compare with expected serialized bytes
+    // Re-encode for the hash computation; cheap relative to the fixture I/O.
+    debug_assert_eq!(
+        <D as libssz::SszEncode>::to_ssz(&domain_value),
+        expected_bytes
+    );
+
+    let computed_root = HashTreeRoot::hash_tree_root(&domain_value);
+    if computed_root != expected_root {
+        return Err(format!(
+            "Hash tree root mismatch for {}:\n  expected: {expected_root}\n  got:      {computed_root}",
+            test.type_name,
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Run only the serialization portion of the SSZ conformance tests.
+///
+/// Used for types where hash tree root intentionally diverges from the spec
+/// (see `SignedBlock`, `BlockSignatures`, `SignedAttestation`). Encoding and
+/// round-trip are still enforced so cross-client wire format stays in sync.
+fn run_serialization_only_test<F, D>(test: &SszTestCase) -> datatest_stable::Result<()>
+where
+    F: serde::de::DeserializeOwned + Into<D>,
+    D: libssz::SszEncode + libssz::SszDecode,
+{
+    check_ssz_roundtrip::<F, D>(test).map(|_| ())
+}
+
+/// Validates encoding and decoding round-trip, returning the expected bytes.
+fn check_ssz_roundtrip<F, D>(test: &SszTestCase) -> datatest_stable::Result<Vec<u8>>
+where
+    F: serde::de::DeserializeOwned + Into<D>,
+    D: libssz::SszEncode + libssz::SszDecode,
+{
+    let expected_bytes = decode_hex(&test.serialized)
+        .map_err(|e| format!("Failed to decode serialized hex: {e}"))?;
+
+    let fixture_value: F = serde_json::from_value(test.value.clone())
+        .map_err(|e| format!("Failed to deserialize value: {e}"))?;
+    let domain_value: D = fixture_value.into();
+
     let encoded = <D as libssz::SszEncode>::to_ssz(&domain_value);
     if encoded != expected_bytes {
         return Err(format!(
@@ -117,7 +162,6 @@ where
         .into());
     }
 
-    // Step 3: SSZ decode from expected bytes and re-encode (round-trip)
     let decoded = D::from_ssz_bytes(&expected_bytes)
         .map_err(|e| format!("SSZ decode failed for {}: {e:?}", test.type_name))?;
     let re_encoded = <D as libssz::SszEncode>::to_ssz(&decoded);
@@ -131,17 +175,7 @@ where
         .into());
     }
 
-    // Step 4: Verify hash tree root
-    let computed_root = HashTreeRoot::hash_tree_root(&domain_value);
-    if computed_root != expected_root {
-        return Err(format!(
-            "Hash tree root mismatch for {}:\n  expected: {expected_root}\n  got:      {computed_root}",
-            test.type_name,
-        )
-        .into());
-    }
-
-    Ok(())
+    Ok(expected_bytes)
 }
 
 datatest_stable::harness!({


### PR DESCRIPTION
## Summary

- Removes `HashTreeRoot` derive from `SignedAttestation`, `SignedBlock`, and `BlockSignatures` — the three types that embed `XmssSignature`.
- Routes those types through a new `run_serialization_only_test` helper in the SSZ spec-test harness. Encoding and round-trip are still enforced; the hash-tree-root check is skipped for them.

## Why

leanSpec's `Signature` container is SSZ-serialized as fixed bytes (via `is_fixed_size=True`, for cross-client wire compatibility with Ream) but its hash tree root is computed as a Container (merkleized fields). Our Rust `XmssSignature` is `SszVector<u8, SIGNATURE_SIZE>`, whose hash tree root uses `merkleize(pack_bytes(...))` — identical serialization, different root.

Since `SignedAttestation`, `SignedBlock`, and `BlockSignatures` are never hashed directly in production code (only their inner `Block` / `AttestationData` are), dropping the `HashTreeRoot` derive is cheaper than mirroring leanSpec's container layout. If any of them gets hashed later, we'll re-derive and match.

Fixes 4 failing `test_consensus_containers` SSZ tests after the leanSpec bump to `e9ddede`:

- `test_block_signatures_empty`
- `test_block_signatures_with_attestation`
- `test_signed_attestation_minimal`
- `test_signed_block_minimal`

## Test plan

- [x] `cargo test -p ethlambda-types --release --test ssz_spectests` passes (112/112)
- [ ] CI is green

## Follow-ups

- Two stacked PRs follow this one: #<PR2> adapts the fork-choice harness to the new fixture format, #<PR3> exercises real signature verification end-to-end.