### PR TITLE
ci: skip AI review on draft PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,16 +21,19 @@ on:
 
 jobs:
   kimi-review:
+    if: github.event_name == 'issue_comment' || github.event.pull_request.draft == false
     uses: lambdaclass/actions/.github/workflows/ai-review-kimi.yml@v1
     secrets:
       KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
 
   codex-review:
+    if: github.event_name == 'issue_comment' || github.event.pull_request.draft == false
     uses: lambdaclass/actions/.github/workflows/ai-review-codex.yml@v1
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   claude-review:
+    if: github.event_name == 'issue_comment' || github.event.pull_request.draft == false
     uses: lambdaclass/actions/.github/workflows/ai-review-claude.yml@v1
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Gate the three `ai-review.yml` jobs on `github.event.pull_request.draft == false` so Kimi/Codex/Claude reviews only run once a PR is actually up for review.
- Keep `types: [opened, ready_for_review]` so PRs opened directly as non-draft still trigger (only `opened` fires in that case; `ready_for_review` fires on draft → ready).
- Issue-comment triggers (`/kimi`, `/codex`, `/claude`) are preserved via `github.event_name == 'issue_comment'` in the gate.

## Test plan
- [ ] Open a draft PR — no AI review jobs run.
- [ ] Open a non-draft PR — all three AI review jobs run.
- [ ] Open a draft PR, then mark ready — all three jobs run on the `ready_for_review` event.
- [ ] Comment `/claude` (or `/kimi`, `/codex`) on any PR — the corresponding job still runs.