### PR TITLE
build: compile docker image for x86-64-v3 target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+    "-Ctarget-cpu=x86-64-v3",
+    "-Ctarget-feature=+avx2,+sse2,+ssse3,+sse4.1,+sse4.2,+bmi1,+lzcnt,+pclmulqdq",
+]

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,4 @@
 !crates/
 !LICENSE
 !.git/
-
-# cargo build configuration (target-cpu / target-feature rustflags)
 !.cargo/

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,6 @@
 !crates/
 !LICENSE
 !.git/
+
+# cargo build configuration (target-cpu / target-feature rustflags)
+!.cargo/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,6 @@ ENV BUILD_PROFILE=$BUILD_PROFILE
 ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
-# Build dependencies.
-# Rustflags are intentionally sourced from .cargo/config.toml instead of a
-# RUSTFLAGS env var: any set RUSTFLAGS (even an empty string) would override
-# target.<triple>.rustflags from the config, silently dropping target-cpu /
-# target-feature selection.
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json
 
 # Build application

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,24 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
+# Include .cargo/ so [target.*.rustflags] (e.g. -Ctarget-cpu=x86-64-v3) applies to
+# cargo-chef's dep build as well as the final cargo build. Without this the
+# cached deps are compiled with default flags and cargo reuses them.
+COPY .cargo/ .cargo/
+
 # Build profile, release by default
 ARG BUILD_PROFILE=release
 ENV BUILD_PROFILE=$BUILD_PROFILE
-
-# Extra Cargo flags
-ARG RUSTFLAGS=""
-ENV RUSTFLAGS="$RUSTFLAGS"
 
 # Extra Cargo features
 ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
-# Build dependencies
+# Build dependencies.
+# Rustflags are intentionally sourced from .cargo/config.toml instead of a
+# RUSTFLAGS env var: any set RUSTFLAGS (even an empty string) would override
+# target.<triple>.rustflags from the config, silently dropping target-cpu /
+# target-feature selection.
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json
 
 # Build application


### PR DESCRIPTION
## Summary

Switch the release Docker image to the **x86-64-v3** microarchitecture level so the binary uses AVX2, BMI1/2, LZCNT, and PCLMULQDQ. Any host from Haswell (2013) / Zen+ (2018) onward supports this.

On a Skylake-SP server, over a 400-slot devnet:

| Build | Aggregation mean | vs upstream `unstable` |
|---|---|---|
| `unstable` (default x86-64) | 2310 ms | 1.00x |
| `-Ctarget-cpu=native` | 859 ms | 2.69x |
| **`-Ctarget-cpu=x86-64-v3` (this PR)** | **745 ms** | **3.10x** |

v3 beats `native` by ~15% on this CPU because aggressive AVX-512 use on Skylake-SP triggers core downclocking — staying on AVX2 keeps the clock higher. v3 is also portable (native binaries won't run on most non-SP Intel client CPUs or older AMD parts).

The config was copied from the `ethrex` repo: https://github.com/lambdaclass/ethrex/blob/1a2ec50ae6f99dd91046440f7e54e39cfcc01687/.cargo/config.toml

## Two Docker plumbing fixes included

Without these, the `.cargo/config.toml` `target.rustflags` setting is silently ignored:

1. **`COPY .cargo/ .cargo/` before `cargo chef cook`** — otherwise dependency builds emit with default flags, and the final `cargo build` reuses the cached deps rather than rebuilding with the requested CPU features. Verified: without this fix, the resulting binary was byte-identical to the default-flag build (zero AVX2/BMI2 usage).
2. **Drop the `ARG RUSTFLAGS=""` / `ENV RUSTFLAGS="$RUSTFLAGS"` pair.** An empty `RUSTFLAGS` env var *overrides* `target.<triple>.rustflags` from `.cargo/config.toml` (cargo precedence rule: env wins over config). With the old Dockerfile, any build that didn't pass `--build-arg RUSTFLAGS=...` would silently drop target-cpu/target-feature selections.

Instruction count diff (`objdump -d | grep ymm/zmm/bzhi/lzcnt`):

| | default | v3 |
|---|---|---|
| `ymm` (AVX2) | 5,900 | 371,862 |
| `zmm` (AVX-512) | 0 | 0 |
| `bzhi` (BMI2) | 21 | 911 |
| `lzcnt` | 34 | 737 |
| `pclmulqdq` | n/a | 354 |
