### PR TITLE
Add lean_attestations_production_time_seconds metric from leanMetrics PR #30

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -170,6 +170,8 @@ impl BlockChainServer {
     }
 
     fn produce_attestations(&mut self, slot: u64) {
+        let _timing = metrics::time_attestations_production();
+
         // Produce attestation data once for all validators
         let attestation_data = store::produce_attestation_data(&self.store, slot);
 

--- a/crates/blockchain/src/metrics.rs
+++ b/crates/blockchain/src/metrics.rs
@@ -226,6 +226,16 @@ static LEAN_PQ_SIG_ATTESTATION_SIGNING_TIME_SECONDS: std::sync::LazyLock<Histogr
         .unwrap()
     });
 
+static LEAN_ATTESTATIONS_PRODUCTION_TIME_SECONDS: std::sync::LazyLock<Histogram> =
+    std::sync::LazyLock::new(|| {
+        register_histogram!(
+            "lean_attestations_production_time_seconds",
+            "Time taken to produce attestation",
+            vec![0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0]
+        )
+        .unwrap()
+    });
+
 static LEAN_PQ_SIG_ATTESTATION_VERIFICATION_TIME_SECONDS: std::sync::LazyLock<Histogram> =
     std::sync::LazyLock::new(|| {
         register_histogram!(
@@ -381,6 +391,7 @@ pub fn init() {
     std::sync::LazyLock::force(&LEAN_FORK_CHOICE_BLOCK_PROCESSING_TIME_SECONDS);
     std::sync::LazyLock::force(&LEAN_ATTESTATION_VALIDATION_TIME_SECONDS);
     std::sync::LazyLock::force(&LEAN_PQ_SIG_ATTESTATION_SIGNING_TIME_SECONDS);
+    std::sync::LazyLock::force(&LEAN_ATTESTATIONS_PRODUCTION_TIME_SECONDS);
     std::sync::LazyLock::force(&LEAN_PQ_SIG_ATTESTATION_VERIFICATION_TIME_SECONDS);
     std::sync::LazyLock::force(&LEAN_PQ_SIG_AGGREGATED_SIGNATURES_BUILDING_TIME_SECONDS);
     std::sync::LazyLock::force(&LEAN_PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME_SECONDS);
@@ -497,6 +508,11 @@ pub fn inc_pq_sig_attestation_signatures_invalid() {
 /// Start timing individual attestation signing. Records duration when the guard is dropped.
 pub fn time_pq_sig_attestation_signing() -> TimingGuard {
     TimingGuard::new(&LEAN_PQ_SIG_ATTESTATION_SIGNING_TIME_SECONDS)
+}
+
+/// Start timing attestation production. Records duration when the guard is dropped.
+pub fn time_attestations_production() -> TimingGuard {
+    TimingGuard::new(&LEAN_ATTESTATIONS_PRODUCTION_TIME_SECONDS)
 }
 
 /// Start timing individual attestation signature verification. Records duration when the guard is dropped.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -64,10 +64,11 @@ The exposed metrics follow [the leanMetrics specification](https://github.com/le
 
 ## Validator Metrics
 
-| Name   | Type  | Usage | Sample collection event | Labels | Supported |
-|--------|-------|-------|-------------------------|--------|-----------|
-|`lean_validators_count`| Gauge | Number of validators managed by a node | On scrape |  | ✅(*) |
-|`lean_is_aggregator`| Gauge | Validator's `is_aggregator` status. True=1, False=0 | On node start | | ✅ |
+| Name   | Type  | Usage | Sample collection event | Labels | Buckets | Supported |
+|--------|-------|-------|-------------------------|--------|---------|-----------|
+|`lean_validators_count`| Gauge | Number of validators managed by a node | On scrape |  | | ✅(*) |
+|`lean_is_aggregator`| Gauge | Validator's `is_aggregator` status. True=1, False=0 | On node start | | | ✅ |
+|`lean_attestations_production_time_seconds`| Histogram | Time taken to produce attestation | On attestation production | | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | ✅ |
 
 ## Network Metrics
 


### PR DESCRIPTION
## Motivation

Implements the `lean_attestations_production_time_seconds` histogram defined in
[leanEthereum/leanMetrics#30](https://github.com/leanEthereum/leanMetrics/pull/30),
which measures the end-to-end time a node spends producing attestations
for all its validators in a given slot.

## Description

### New Metric

| Metric | Type | Buckets | Sample collection event |
|--------|------|---------|-------------------------|
| `lean_attestations_production_time_seconds` | Histogram | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | On attestation production |

### Implementation

- **`crates/blockchain/src/metrics.rs`**: registers the histogram under the
  `Validator Metrics` family and exposes `time_attestations_production()`,
  which returns a `TimingGuard` that observes the duration on drop. Added
  to the `init()` eager-registration list so the metric appears on
  `/metrics` from process start.
- **`crates/blockchain/src/lib.rs`**: instruments `produce_attestations()`
  with `let _timing = metrics::time_attestations_production();` at the top
  of the function, capturing the full flow:
  1. Attestation data construction (`store::produce_attestation_data`)
  2. Per-validator signing
  3. Self-delivery via `on_gossip_attestation`
  4. Gossip publish

### Documentation

- **`docs/metrics.md`**: adds a `Buckets` column to the Validator Metrics
  table (consistent with the other tables in the doc) and lists the new
  metric alongside `lean_validators_count` and `lean_is_aggregator`.

## How to Test

1. `make fmt` - passes
2. `make lint` - passes (clippy clean)
3. `make test` - passes
4. Run a local devnet and verify the metric appears on the `/metrics`
   endpoint (port 5054):
   ```
   curl -s localhost:5054/metrics | grep lean_attestations_production_time_seconds
   ```
   You should see the histogram buckets populate as the node produces
   attestations each slot.

## Related

- leanMetrics spec: https://github.com/leanEthereum/leanMetrics/pull/30
- Previous metrics PR: #289 (Devnet-4 metrics from leanMetrics PR #29)
