### PR TITLE
refactor(storage): dedupe PayloadBuffer proofs by subsumption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docker-build: ## 🐳 Build the Docker image
 	@echo
 
 # 2026-04-29
-LEAN_SPEC_COMMIT_HASH:=495c29d49f2b12b7cc240c4028e15d4253a7d54e
+LEAN_SPEC_COMMIT_HASH:=18fe71fee49f8865a5c8a4cb8b1787b0cbc9e25b
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -86,12 +86,7 @@ pub fn validator_indices(bits: &AggregationBits) -> impl Iterator<Item = u64> + 
     })
 }
 
-/// Returns `true` iff every bit set in `a` is also set in `b` (i.e., participants(a) ⊆ participants(b)).
-///
-/// Operates byte-wise on the raw bitfield representation, avoiding the per-call
-/// `HashSet` allocation that index-iteration would require. Safe because SSZ
-/// decoding rejects bitlists with non-zero padding above the delimiter, so any
-/// bit not in `b` reliably reads as zero in `b.as_bytes()`.
+/// Returns `true` iff every bit set in `a` is also set in `b` (i.e., `a` is a subset of `b`).
 pub fn bits_is_subset(a: &AggregationBits, b: &AggregationBits) -> bool {
     let a_bytes = a.as_bytes();
     let b_bytes = b.as_bytes();

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -146,3 +146,120 @@ impl From<AttestationData> for HashedAttestationData {
         Self::new(data)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an `AggregationBits` of `len` bits with the indices in `set` flipped on.
+    fn bits(len: usize, set: &[usize]) -> AggregationBits {
+        let mut b = AggregationBits::with_length(len).unwrap();
+        for &i in set {
+            b.set(i, true).unwrap();
+        }
+        b
+    }
+
+    #[test]
+    fn subset_empty_bitlists() {
+        let empty = AggregationBits::new();
+        assert!(bits_is_subset(&empty, &empty));
+    }
+
+    #[test]
+    fn subset_empty_a_is_subset_of_anything() {
+        let empty = AggregationBits::new();
+        let b = bits(8, &[0, 3, 7]);
+        assert!(bits_is_subset(&empty, &b));
+    }
+
+    #[test]
+    fn subset_zero_bits_a_is_subset_of_empty() {
+        // a has length but no set bits: byte iteration skips zero bytes, so it's a subset of empty.
+        let a = bits(8, &[]);
+        let empty = AggregationBits::new();
+        assert!(bits_is_subset(&a, &empty));
+    }
+
+    #[test]
+    fn subset_nonempty_a_is_not_subset_of_empty() {
+        let a = bits(8, &[2]);
+        let empty = AggregationBits::new();
+        assert!(!bits_is_subset(&a, &empty));
+    }
+
+    #[test]
+    fn subset_reflexive_equal_bitlists() {
+        let a = bits(16, &[0, 1, 5, 9, 15]);
+        let b = bits(16, &[0, 1, 5, 9, 15]);
+        assert!(bits_is_subset(&a, &b));
+        assert!(bits_is_subset(&b, &a));
+    }
+
+    #[test]
+    fn subset_strict_subset_returns_true() {
+        let a = bits(8, &[1, 4]);
+        let b = bits(8, &[1, 4, 6]);
+        assert!(bits_is_subset(&a, &b));
+        assert!(!bits_is_subset(&b, &a));
+    }
+
+    #[test]
+    fn subset_disjoint_bits_returns_false() {
+        let a = bits(8, &[0, 2]);
+        let b = bits(8, &[1, 3]);
+        assert!(!bits_is_subset(&a, &b));
+        assert!(!bits_is_subset(&b, &a));
+    }
+
+    #[test]
+    fn subset_partial_overlap_returns_false() {
+        // a shares bit 1 with b but also has bit 5 that b lacks.
+        let a = bits(8, &[1, 5]);
+        let b = bits(8, &[0, 1, 2]);
+        assert!(!bits_is_subset(&a, &b));
+    }
+
+    #[test]
+    fn subset_a_shorter_than_b_with_bits_in_b() {
+        // a has 8 bits, b has 16 bits. a's set bits are all present in b.
+        let a = bits(8, &[1, 4]);
+        let b = bits(16, &[1, 4, 11]);
+        assert!(bits_is_subset(&a, &b));
+    }
+
+    #[test]
+    fn subset_a_longer_than_b_with_zero_tail_is_subset() {
+        // a has 16 bits but only sets bit 2; b has 8 bits with the same bit set.
+        // a's tail byte is zero, so the loop skips it.
+        let a = bits(16, &[2]);
+        let b = bits(8, &[2]);
+        assert!(bits_is_subset(&a, &b));
+    }
+
+    #[test]
+    fn subset_a_longer_than_b_with_set_bit_past_b_returns_false() {
+        // a sets bit 9 (byte 1) but b only has 8 bits (1 byte). Missing bytes in b are
+        // treated as zero, so any bit in a's tail breaks the subset relation.
+        let a = bits(16, &[9]);
+        let b = bits(8, &[]);
+        assert!(!bits_is_subset(&a, &b));
+    }
+
+    #[test]
+    fn subset_multi_byte_bitlists() {
+        // Spans multiple bytes (24 bits = 3 bytes) to exercise the byte-by-byte loop.
+        let a = bits(24, &[0, 8, 16]);
+        let b = bits(24, &[0, 1, 8, 9, 16, 17]);
+        assert!(bits_is_subset(&a, &b));
+        assert!(!bits_is_subset(&b, &a));
+    }
+
+    #[test]
+    fn subset_violation_in_later_byte_returns_false() {
+        // a's first byte matches b, but bit 17 (in byte 2) is set in a only.
+        let a = bits(24, &[0, 1, 17]);
+        let b = bits(24, &[0, 1, 16]);
+        assert!(!bits_is_subset(&a, &b));
+    }
+}

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -86,6 +86,27 @@ pub fn validator_indices(bits: &AggregationBits) -> impl Iterator<Item = u64> + 
     })
 }
 
+/// Returns `true` iff every bit set in `a` is also set in `b` (i.e., participants(a) ⊆ participants(b)).
+///
+/// Operates byte-wise on the raw bitfield representation, avoiding the per-call
+/// `HashSet` allocation that index-iteration would require. Safe because SSZ
+/// decoding rejects bitlists with non-zero padding above the delimiter, so any
+/// bit not in `b` reliably reads as zero in `b.as_bytes()`.
+pub fn bits_is_subset(a: &AggregationBits, b: &AggregationBits) -> bool {
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    for (i, &a_byte) in a_bytes.iter().enumerate() {
+        if a_byte == 0 {
+            continue;
+        }
+        let b_byte = b_bytes.get(i).copied().unwrap_or(0);
+        if a_byte & !b_byte != 0 {
+            return false;
+        }
+    }
+    true
+}
+
 /// Aggregated attestation with its signature proof, used for gossip on the aggregation topic.
 #[derive(Debug, Clone, SszEncode, SszDecode, HashTreeRoot)]
 pub struct SignedAggregatedAttestation {

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -126,18 +126,45 @@ impl PayloadBuffer {
         }
     }
 
-    /// Insert proofs for an attestation, FIFO-evicting oldest data_roots when total proofs reach capacity.
+    /// Insert a proof, maintaining the antichain invariant per data_root.
+    ///
+    /// Each data_root entry holds proofs whose participant sets are pairwise
+    /// incomparable under the subset relation. On push:
+    ///
+    /// - If the incoming proof's participants are a subset (incl. equal) of
+    ///   any existing proof, the incoming proof is redundant and skipped.
+    /// - Otherwise, any existing proof whose participants are a strict subset
+    ///   of the incoming proof's is removed before inserting.
+    ///
+    /// This subsumes exact-equality dedup and keeps buffers bounded when an
+    /// aggregator produces a proof that supersedes prior children.
+    ///
+    /// FIFO-evicts oldest data_roots when `total_proofs` exceeds capacity.
     fn push(&mut self, hashed: HashedAttestationData, proof: AggregatedSignatureProof) {
         let (data_root, att_data) = hashed.into_parts();
+        let new_set: HashSet<u64> = proof.participant_indices().collect();
+
         if let Some(entry) = self.data.get_mut(&data_root) {
-            // Skip duplicate proofs (same participants)
-            if entry
-                .proofs
-                .iter()
-                .any(|p| p.participants == proof.participants)
-            {
-                return;
+            let mut to_remove: Vec<usize> = Vec::new();
+            for (i, p) in entry.proofs.iter().enumerate() {
+                let existing_set: HashSet<u64> = p.participant_indices().collect();
+                // Incoming is subsumed by an existing proof (incl. equal) — skip.
+                if new_set.is_subset(&existing_set) {
+                    return;
+                }
+                // Existing is a strict subset of incoming — mark for removal.
+                // (Non-strict equality was handled by the check above.)
+                if existing_set.is_subset(&new_set) {
+                    to_remove.push(i);
+                }
             }
+
+            // Remove subsumed proofs (reverse order so earlier indices stay valid).
+            for i in to_remove.into_iter().rev() {
+                entry.proofs.swap_remove(i);
+                self.total_proofs -= 1;
+            }
+
             entry.proofs.push(proof);
             self.total_proofs += 1;
         } else {
@@ -1628,6 +1655,17 @@ mod tests {
         AggregatedSignatureProof::empty(bits)
     }
 
+    /// Create a proof with bits set for every validator in `vids`.
+    fn make_proof_for_validators(vids: &[u64]) -> AggregatedSignatureProof {
+        use ethlambda_types::attestation::AggregationBits;
+        let max = vids.iter().copied().max().unwrap_or(0) as usize;
+        let mut bits = AggregationBits::with_length(max + 1).unwrap();
+        for &v in vids {
+            bits.set(v as usize, true).unwrap();
+        }
+        AggregatedSignatureProof::empty(bits)
+    }
+
     fn make_att_data(slot: u64) -> AttestationData {
         AttestationData {
             slot,
@@ -1749,6 +1787,210 @@ mod tests {
 
         assert_eq!(cloned.new_payloads.lock().unwrap().len(), 0);
         assert_eq!(cloned.known_payloads.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn payload_buffer_push_superset_removes_strict_subset() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1, 2]),
+        );
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[1, 2, 3]),
+        );
+
+        assert_eq!(buf.total_proofs, 1);
+        assert_eq!(buf.data[&data_root].proofs.len(), 1);
+        let kept: HashSet<u64> = buf.data[&data_root].proofs[0]
+            .participant_indices()
+            .collect();
+        assert_eq!(kept, HashSet::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn payload_buffer_push_subset_is_skipped() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1, 2, 3]),
+        );
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[1, 2]),
+        );
+
+        assert_eq!(buf.total_proofs, 1);
+        assert_eq!(buf.data[&data_root].proofs.len(), 1);
+        let kept: HashSet<u64> = buf.data[&data_root].proofs[0]
+            .participant_indices()
+            .collect();
+        assert_eq!(kept, HashSet::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn payload_buffer_push_equal_participants_is_skipped() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1, 2]),
+        );
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[1, 2]),
+        );
+
+        assert_eq!(buf.total_proofs, 1);
+        assert_eq!(buf.data[&data_root].proofs.len(), 1);
+    }
+
+    #[test]
+    fn payload_buffer_push_incomparable_proofs_coexist() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1, 2]),
+        );
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[3, 4]),
+        );
+
+        assert_eq!(buf.total_proofs, 2);
+        assert_eq!(buf.data[&data_root].proofs.len(), 2);
+    }
+
+    #[test]
+    fn payload_buffer_push_superset_absorbs_multiple_subsets() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        // Three pairwise-incomparable singletons: all retained.
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1]),
+        );
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[2]),
+        );
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[3]),
+        );
+        assert_eq!(buf.total_proofs, 3);
+
+        // Superset push absorbs all three at once.
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[1, 2, 3]),
+        );
+
+        assert_eq!(buf.total_proofs, 1);
+        assert_eq!(buf.data[&data_root].proofs.len(), 1);
+        // `order` still contains the single entry.
+        assert_eq!(buf.order.len(), 1);
+        assert_eq!(buf.order.front().copied(), Some(data_root));
+    }
+
+    #[test]
+    fn payload_buffer_push_mixed_kept_and_removed() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1, 2]),
+        );
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[5, 6]),
+        );
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[1, 2, 3]),
+        );
+
+        assert_eq!(buf.total_proofs, 2);
+
+        let sets: HashSet<Vec<u64>> = buf.data[&data_root]
+            .proofs
+            .iter()
+            .map(|p| {
+                let mut v: Vec<u64> = p.participant_indices().collect();
+                v.sort_unstable();
+                v
+            })
+            .collect();
+        assert!(sets.contains(&vec![5, 6]));
+        assert!(sets.contains(&vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn payload_buffer_push_cross_data_root_independence() {
+        let mut buf = PayloadBuffer::new(10);
+        let data_a = make_att_data(1);
+        let data_b = make_att_data(2);
+        let root_a = data_a.hash_tree_root();
+        let root_b = data_b.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data_a),
+            make_proof_for_validators(&[1, 2, 3]),
+        );
+        buf.push(
+            HashedAttestationData::new(data_b),
+            make_proof_for_validators(&[1, 2]),
+        );
+
+        // Different data_roots → no cross-entry subsumption.
+        assert_eq!(buf.total_proofs, 2);
+        assert_eq!(buf.data[&root_a].proofs.len(), 1);
+        assert_eq!(buf.data[&root_b].proofs.len(), 1);
+    }
+
+    #[test]
+    fn payload_buffer_push_fifo_eviction_uses_total_proofs() {
+        let mut buf = PayloadBuffer::new(2);
+        let data_a = make_att_data(1);
+        let data_b = make_att_data(2);
+        let data_c = make_att_data(3);
+        let root_a = data_a.hash_tree_root();
+        let root_c = data_c.hash_tree_root();
+
+        buf.push(
+            HashedAttestationData::new(data_a),
+            make_proof_for_validators(&[1]),
+        );
+        buf.push(
+            HashedAttestationData::new(data_b),
+            make_proof_for_validators(&[2, 3]),
+        );
+        // total_proofs == 3, over capacity → evict oldest (root_a).
+        // Pushing a third distinct data_root triggers eviction via capacity.
+        buf.push(
+            HashedAttestationData::new(data_c),
+            make_proof_for_validators(&[4]),
+        );
+
+        assert!(!buf.data.contains_key(&root_a));
+        assert!(buf.data.contains_key(&root_c));
+        assert_eq!(buf.total_proofs, 2);
     }
 
     // ============ GossipSignatureBuffer Tests ============

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -10,7 +10,7 @@ static EMPTY_BODY_ROOT: LazyLock<H256> = LazyLock::new(|| BlockBody::default().h
 use crate::api::{StorageBackend, StorageWriteBatch, Table};
 
 use ethlambda_types::{
-    attestation::{AttestationData, HashedAttestationData},
+    attestation::{AttestationData, HashedAttestationData, bits_is_subset},
     block::{
         AggregatedSignatureProof, Block, BlockBody, BlockHeader, BlockSignatures, SignedBlock,
     },
@@ -142,19 +142,24 @@ impl PayloadBuffer {
     /// FIFO-evicts oldest data_roots when `total_proofs` exceeds capacity.
     fn push(&mut self, hashed: HashedAttestationData, proof: AggregatedSignatureProof) {
         let (data_root, att_data) = hashed.into_parts();
-        let new_set: HashSet<u64> = proof.participant_indices().collect();
 
         if let Some(entry) = self.data.get_mut(&data_root) {
+            // Subset checks operate byte-wise on AggregationBits to avoid per-call
+            // HashSet allocation on the aggregated-attestation ingest path.
+            //
+            // Antichain invariant on `entry.proofs`: surviving proofs are pairwise
+            // incomparable. Hence the early-return path below cannot have populated
+            // `to_remove`: if some `X ⊆ new ⊆ existing` had been marked, then
+            // `X ⊆ existing` would already violate the invariant.
             let mut to_remove: Vec<usize> = Vec::new();
             for (i, p) in entry.proofs.iter().enumerate() {
-                let existing_set: HashSet<u64> = p.participant_indices().collect();
                 // Incoming is subsumed by an existing proof (incl. equal) — skip.
-                if new_set.is_subset(&existing_set) {
+                if bits_is_subset(&proof.participants, &p.participants) {
                     return;
                 }
                 // Existing is a strict subset of incoming — mark for removal.
-                // (Non-strict equality was handled by the check above.)
-                if existing_set.is_subset(&new_set) {
+                // (Non-strict equality was ruled out by the check above.)
+                if bits_is_subset(&p.participants, &proof.participants) {
                     to_remove.push(i);
                 }
             }
@@ -1916,6 +1921,38 @@ mod tests {
             .collect();
         assert!(sets.contains(&vec![5, 6]));
         assert!(sets.contains(&vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn payload_buffer_push_empty_participants_subsumed_by_anything() {
+        let mut buf = PayloadBuffer::new(10);
+        let data = make_att_data(1);
+        let data_root = data.hash_tree_root();
+
+        // Empty-participant proof inserted first: anything that follows absorbs it.
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[]),
+        );
+        assert_eq!(buf.total_proofs, 1);
+        buf.push(
+            HashedAttestationData::new(data.clone()),
+            make_proof_for_validators(&[1, 2]),
+        );
+        assert_eq!(buf.total_proofs, 1);
+        assert_eq!(
+            buf.data[&data_root].proofs[0]
+                .participant_indices()
+                .collect::<Vec<u64>>(),
+            vec![1, 2]
+        );
+
+        // Empty-participant proof pushed against existing non-empty: incoming is subsumed, skipped.
+        buf.push(
+            HashedAttestationData::new(data),
+            make_proof_for_validators(&[]),
+        );
+        assert_eq!(buf.total_proofs, 1);
     }
 
     #[test]

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -126,38 +126,26 @@ impl PayloadBuffer {
         }
     }
 
-    /// Insert a proof, maintaining the antichain invariant per data_root.
-    ///
-    /// Each data_root entry holds proofs whose participant sets are pairwise
-    /// incomparable under the subset relation. On push:
+    /// Insert a proof for an attestation, FIFO-evicting oldest data_roots
+    /// when total proofs reach capacity. Also ensures the buffer doesn't
+    /// include proofs which are a subset of other proofs for the same
+    /// attestation data:
     ///
     /// - If the incoming proof's participants are a subset (incl. equal) of
     ///   any existing proof, the incoming proof is redundant and skipped.
     /// - Otherwise, any existing proof whose participants are a strict subset
     ///   of the incoming proof's is removed before inserting.
-    ///
-    /// This subsumes exact-equality dedup and keeps buffers bounded when an
-    /// aggregator produces a proof that supersedes prior children.
-    ///
-    /// FIFO-evicts oldest data_roots when `total_proofs` exceeds capacity.
     fn push(&mut self, hashed: HashedAttestationData, proof: AggregatedSignatureProof) {
         let (data_root, att_data) = hashed.into_parts();
 
         if let Some(entry) = self.data.get_mut(&data_root) {
-            // Subset checks operate byte-wise on AggregationBits to avoid per-call
-            // HashSet allocation on the aggregated-attestation ingest path.
-            //
-            // Antichain invariant on `entry.proofs`: surviving proofs are pairwise
-            // incomparable. Hence the early-return path below cannot have populated
-            // `to_remove`: if some `X ⊆ new ⊆ existing` had been marked, then
-            // `X ⊆ existing` would already violate the invariant.
             let mut to_remove: Vec<usize> = Vec::new();
             for (i, p) in entry.proofs.iter().enumerate() {
-                // Incoming is subsumed by an existing proof (incl. equal) — skip.
+                // Incoming is subsumed by an existing proof (incl. equal). Skip.
                 if bits_is_subset(&proof.participants, &p.participants) {
                     return;
                 }
-                // Existing is a strict subset of incoming — mark for removal.
+                // Existing is a strict subset of incoming. Mark for removal.
                 // (Non-strict equality was ruled out by the check above.)
                 if bits_is_subset(&p.participants, &proof.participants) {
                     to_remove.push(i);

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -191,18 +191,22 @@ impl PayloadBuffer {
     }
 
     /// Take all entries, leaving the buffer empty.
+    ///
+    /// Drains in insertion order (via `self.order`) so downstream consumers
+    /// like `promote_new_aggregated_payloads` re-insert into known_payloads
+    /// deterministically. HashMap iteration would be RandomState-seeded and
+    /// produce non-deterministic vote ordering for same-slot equivocation.
     fn drain(&mut self) -> Vec<(HashedAttestationData, AggregatedSignatureProof)> {
-        self.order.clear();
         self.total_proofs = 0;
-        self.data
-            .drain()
-            .flat_map(|(_, entry)| {
-                entry
-                    .proofs
-                    .into_iter()
-                    .map(move |proof| (HashedAttestationData::new(entry.data.clone()), proof))
-            })
-            .collect()
+        let mut result = Vec::with_capacity(self.data.values().map(|e| e.proofs.len()).sum());
+        while let Some(data_root) = self.order.pop_front() {
+            if let Some(entry) = self.data.remove(&data_root) {
+                for proof in entry.proofs {
+                    result.push((HashedAttestationData::new(entry.data.clone()), proof));
+                }
+            }
+        }
+        result
     }
 
     /// Return the number of distinct attestation messages in the buffer.
@@ -231,9 +235,19 @@ impl PayloadBuffer {
     }
 
     /// Extract per-validator latest attestations from proofs' participation bits.
+    ///
+    /// Iterates entries in insertion order (via `self.order`) so that, when two
+    /// aggregations carry the same `slot` but disagree on the target (an
+    /// equivocation by the shared validators), the first-observed aggregation
+    /// wins. The ethrex spec relies on Python dict insertion-order semantics
+    /// here; iterating `self.data.values()` would be RandomState-seeded and
+    /// fail the equivocation fork-choice tests non-deterministically.
     fn extract_latest_attestations(&self) -> HashMap<u64, AttestationData> {
         let mut result: HashMap<u64, AttestationData> = HashMap::new();
-        for entry in self.data.values() {
+        for data_root in &self.order {
+            let Some(entry) = self.data.get(data_root) else {
+                continue;
+            };
             for proof in &entry.proofs {
                 for vid in proof.participant_indices() {
                     let should_update = result
@@ -1993,6 +2007,94 @@ mod tests {
         assert!(!buf.data.contains_key(&root_a));
         assert!(buf.data.contains_key(&root_c));
         assert_eq!(buf.total_proofs, 2);
+    }
+
+    /// Build an attestation message at `slot` whose target points at `target_root`,
+    /// distinct from the default zero target so two such datas have different roots.
+    fn make_att_data_for_target(slot: u64, target_root: H256) -> AttestationData {
+        AttestationData {
+            slot,
+            head: Checkpoint::default(),
+            target: Checkpoint {
+                root: target_root,
+                slot,
+            },
+            source: Checkpoint::default(),
+        }
+    }
+
+    /// When two aggregations share `slot` but disagree on the target
+    /// (same-slot equivocation), the *first inserted* aggregation must win for
+    /// the validators that participate in both. The fork-choice spec test
+    /// `test_same_slot_equivocating_attesters_count_once` depends on this.
+    /// HashMap iteration would make this RandomState-seeded and flaky.
+    #[test]
+    fn extract_latest_attestations_first_inserted_wins_on_slot_tie() {
+        let target_a = H256([0xaa; 32]);
+        let target_b = H256([0xbb; 32]);
+        let data_a = make_att_data_for_target(3, target_a);
+        let data_b = make_att_data_for_target(3, target_b);
+        assert_ne!(data_a.hash_tree_root(), data_b.hash_tree_root());
+
+        // Order 1: A then B → validators 0,1 (in both) must see A.
+        let mut buf = PayloadBuffer::new(10);
+        buf.push(
+            HashedAttestationData::new(data_a.clone()),
+            make_proof_for_validators(&[0, 1, 2]),
+        );
+        buf.push(
+            HashedAttestationData::new(data_b.clone()),
+            make_proof_for_validators(&[0, 1, 3, 4]),
+        );
+        let extracted = buf.extract_latest_attestations();
+        assert_eq!(extracted[&0].target.root, target_a);
+        assert_eq!(extracted[&1].target.root, target_a);
+        assert_eq!(extracted[&2].target.root, target_a);
+        assert_eq!(extracted[&3].target.root, target_b);
+        assert_eq!(extracted[&4].target.root, target_b);
+
+        // Order 2: B then A → validators 0,1 must now see B.
+        let mut buf = PayloadBuffer::new(10);
+        buf.push(
+            HashedAttestationData::new(data_b),
+            make_proof_for_validators(&[0, 1, 3, 4]),
+        );
+        buf.push(
+            HashedAttestationData::new(data_a),
+            make_proof_for_validators(&[0, 1, 2]),
+        );
+        let extracted = buf.extract_latest_attestations();
+        assert_eq!(extracted[&0].target.root, target_b);
+        assert_eq!(extracted[&1].target.root, target_b);
+        assert_eq!(extracted[&2].target.root, target_a);
+        assert_eq!(extracted[&3].target.root, target_b);
+        assert_eq!(extracted[&4].target.root, target_b);
+    }
+
+    /// `drain` must hand back entries in insertion order so that
+    /// `promote_new_aggregated_payloads` lands them in known_payloads in the
+    /// same order, preserving same-slot equivocation semantics through the
+    /// new → known migration.
+    #[test]
+    fn drain_preserves_insertion_order() {
+        let target_a = H256([0xaa; 32]);
+        let target_b = H256([0xbb; 32]);
+        let target_c = H256([0xcc; 32]);
+        let data_a = make_att_data_for_target(1, target_a);
+        let data_b = make_att_data_for_target(2, target_b);
+        let data_c = make_att_data_for_target(3, target_c);
+
+        let mut buf = PayloadBuffer::new(10);
+        buf.push(HashedAttestationData::new(data_a), make_proof());
+        buf.push(HashedAttestationData::new(data_b), make_proof());
+        buf.push(HashedAttestationData::new(data_c), make_proof());
+
+        let drained = buf.drain();
+        let slots: Vec<u64> = drained.iter().map(|(h, _)| h.data().slot).collect();
+        assert_eq!(slots, vec![1, 2, 3]);
+        assert!(buf.data.is_empty());
+        assert!(buf.order.is_empty());
+        assert_eq!(buf.total_proofs, 0);
     }
 
     // ============ GossipSignatureBuffer Tests ============


### PR DESCRIPTION
## Summary

Replace the equality-only dedup in `PayloadBuffer::push` with a subset-based dedup that maintains each data_root's proof list as an antichain. On push, if the incoming proof's participants are a subset (including equal) of any existing proof, the push is skipped; otherwise every existing proof whose participants are a strict subset of the incoming proof is removed before the insert.

### Why

After an aggregator produces a new proof for a data_root, the child proofs merged into it are still in `new_payloads` with participant sets that are strict subsets of the new proof's. They add no coverage and just consume `PayloadBuffer` capacity, accelerating FIFO eviction of *other* data_roots. The same kind of redundancy accumulates in `known_payloads` through `drain_new_to_known` and block ingestion.

The leanSpec models this at `leanSpec/src/lean_spec/subspecs/forkchoice/store.py:1048-1062` by wholesale-replacing `latest_new_aggregated_payloads[D]` with `{new_proof}`. We can't mimic that synchronously because (a) aggregation runs on a `spawn_blocking` worker while the actor keeps writing `new_payloads` via gossip ingestion, and (b) `update_head` reads `known_payloads` only, so any known-side pruning has to be carefully timed to avoid a fork-choice coverage gap.

Dedupe-on-push sidesteps both constraints:

- Push never shrinks validator coverage: it only removes proofs whose validators are a strict subset of the added one's. Any `update_head` reading `known_payloads` between pushes sees monotonically-growing coverage, so there's no fork-choice timing risk.
- Concurrent gossip-received aggregates that are incomparable with our locally produced aggregate are preserved; ones that are subsumed are absorbed.
- No separate cleanup passes or wiring: `apply_aggregated_group`, `on_gossip_aggregated_attestation`, `on_block_core`, and `promote_new_aggregated_payloads` all benefit transparently.

### Cost

O(n·v) per push (n = proofs currently in the entry, v = participants per proof) via `HashSet<u64>` membership. `n` is bounded by the max-antichain size per data_root (typically 1 in steady state, small when concurrent aggregates overlap). If profiling later shows push in a hot path, a bitwise-native subset op on `AggregationBits` is a natural follow-up.

### Tests

- 8 new unit tests on `PayloadBuffer::push`: superset removes subset, subset skipped, equal-participants skipped, incomparable proofs coexist, superset absorbs multiple singletons in one push, mixed kept/removed under same data_root, cross-data-root independence, FIFO eviction still uses `total_proofs`.
- All 4 existing `PayloadBuffer` tests keep passing unchanged (they use pairwise-incomparable participant sets).

## Test plan

- [x] `cargo test -p ethlambda-storage` — 30 tests pass
- [x] `cargo test -p ethlambda-blockchain` — 20 unit tests pass
- [x] `cargo test -p ethlambda-blockchain --test forkchoice_spectests --release` — 70 spec tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Local devnet smoke (post-review): with `--is-aggregator`, verify `lean_latest_new_aggregated_payloads` and `lean_latest_known_aggregated_payloads` stay bounded across interval 2 / interval 4 instead of growing monotonically