### PR TITLE
fix(forkchoice): use only "new" pool for safe target (leanSpec #680)

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -101,6 +101,16 @@ fn update_head(store: &mut Store, log_tree: bool) {
 }
 
 /// Update the safe target for attestation.
+///
+/// Safe target is an *availability* signal, not a durable-knowledge signal:
+/// only the "new" pool is considered. Migration from "new" to "known" runs at
+/// interval 4, strictly after this computation at interval 3. 3sf-mini chose
+/// that ordering deliberately so safe target sees only freshly received votes
+/// from the current slot and ignores what was carried over from earlier slots
+/// (block-included attestations, previously migrated gossip, self-attestations).
+/// Counting "known" would let a node keep advancing its safe target on stale
+/// evidence even when live participation has collapsed: exactly the failure
+/// mode safe target is supposed to prevent. See leanSpec PR #680.
 fn update_safe_target(store: &mut Store) {
     let head_state = store.get_state(&store.head()).expect("head state exists");
     let num_validators = head_state.validators.len() as u64;
@@ -108,10 +118,7 @@ fn update_safe_target(store: &mut Store) {
     let min_target_score = (num_validators * 2).div_ceil(3);
 
     let blocks = store.get_live_chain();
-    // Merge both attestation pools (known + new).
-    // At interval 3 the promotion (interval 4) hasn't run yet, so we must
-    // merge both pools to get a complete view for safe target computation.
-    let attestations = store.extract_latest_all_attestations();
+    let attestations = store.extract_latest_new_attestations();
     let (safe_target, _weights) = ethlambda_fork_choice::compute_lmd_ghost_head(
         store.latest_justified().root,
         &blocks,

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -992,29 +992,6 @@ impl Store {
             .extract_latest_attestations()
     }
 
-    /// Extract per-validator latest attestations from both known and new payloads.
-    pub fn extract_latest_all_attestations(&self) -> HashMap<u64, AttestationData> {
-        let mut result = self
-            .known_payloads
-            .lock()
-            .unwrap()
-            .extract_latest_attestations();
-        for (vid, data) in self
-            .new_payloads
-            .lock()
-            .unwrap()
-            .extract_latest_attestations()
-        {
-            let should_update = result
-                .get(&vid)
-                .is_none_or(|existing| existing.slot < data.slot);
-            if should_update {
-                result.insert(vid, data);
-            }
-        }
-        result
-    }
-
     // ============ Known Aggregated Payloads ============
     //
     // "Known" aggregated payloads are active in fork choice weight calculations.


### PR DESCRIPTION
## Summary

Ports [leanSpec PR #680](https://github.com/leanEthereum/leanSpec/pull/680) into ethlambda. `update_safe_target` now reads only `latest_new_attestations` instead of merging the `new` and `known` pools.

## Rationale

Safe target is an **availability** signal, not a durable-knowledge signal. The `new -> known` migration step runs at interval 4, strictly *after* safe-target computation at interval 3, and 3sf-mini chose that ordering deliberately:

- At interval 3, votes still in `new` represent the current slot's online view.
- Anything already in `known` is historical: block-included attestations, gossip migrated in earlier slots, self-attestations stored locally without traversing gossipsub.
- Counting `known` would let a node keep advancing its safe target on stale evidence even when live participation has collapsed, which is exactly the failure mode safe target is supposed to prevent.

Aligns with zeam (PR #779) and the Ream reference implementation.

## Changes

- `crates/blockchain/src/store.rs` (`update_safe_target`): swap `extract_latest_all_attestations()` for `extract_latest_new_attestations()`. Docstring rewritten around the interval-3 / interval-4 ordering and the availability framing.
- `crates/storage/src/store.rs`: drop the now-unused `extract_latest_all_attestations` helper.

## Notes

- Marked draft because the upstream spec PR is still draft awaiting confirmation from Yaan on the availability framing. Once leanSpec #680 lands and `LEAN_SPEC_COMMIT_HASH` is bumped, the regenerated `test_safe_target_*` fixtures should validate the new behavior end-to-end. (Today the fixture's `safeTargetSlot` / `safeTargetRootLabel` checks are silently ignored by our spec-test runner because those fields are not yet wired into `StoreChecks`.)

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --release` -- 323 passed, 6 ignored
- [x] `cargo test -p ethlambda-blockchain --release --test forkchoice_spectests` -- 70 passed