### PR TITLE
fix: stop genservers gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "vergen-git2",
@@ -2165,6 +2166,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hex = "0.4"
 spawned-concurrency = "0.5.0"
 spawned-rt = "0.5.0"
 tokio = "1.0"
+tokio-util = "0.7"
 
 prometheus = "0.14"
 

--- a/bin/ethlambda/Cargo.toml
+++ b/bin/ethlambda/Cargo.toml
@@ -17,6 +17,7 @@ libssz.workspace = true
 libssz-types.workspace = true
 
 tokio.workspace = true
+tokio-util.workspace = true
 
 tracing.workspace = true
 tracing-subscriber = "0.3"

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -15,6 +15,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
+    sync::atomic::{AtomicU32, Ordering},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -30,7 +31,7 @@ use ethlambda_types::{
     state::{State, ValidatorPubkeyBytes},
 };
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt};
 
 use ethlambda_blockchain::BlockChain;
@@ -222,8 +223,32 @@ async fn main() -> eyre::Result<()> {
 
     info!("Node initialized");
 
-    tokio::signal::ctrl_c().await.ok();
-    info!("Shutdown signal received, stopping actors and servers...");
+    let signal_count = Arc::new(AtomicU32::new(0));
+    let signal_count_clone = signal_count.clone();
+
+    // Handle multiple Ctrl+C signals:
+    // 1st Ctrl+C: graceful shutdown
+    // 2nd Ctrl+C: force exit immediately
+    tokio::spawn(async move {
+        loop {
+            tokio::signal::ctrl_c().await.ok();
+            let count = signal_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+            if count == 1 {
+                info!("Shutdown signal received, stopping actors and servers...");
+            } else {
+                warn!("Force shutdown requested, exiting immediately");
+                std::process::exit(1);
+            }
+        }
+    });
+
+    // Wait for first signal
+    loop {
+        if signal_count.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
 
     let blockchain_ref = blockchain.actor_ref().clone();
     let p2p_ref = p2p.actor_ref().clone();

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -15,7 +15,6 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
-    sync::atomic::{AtomicU32, Ordering},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -223,32 +222,21 @@ async fn main() -> eyre::Result<()> {
 
     info!("Node initialized");
 
-    let signal_count = Arc::new(AtomicU32::new(0));
-    let signal_count_clone = signal_count.clone();
+    // 1st ctrl+c: start graceful shutdown
+    tokio::signal::ctrl_c().await.ok();
 
-    // Handle multiple Ctrl+C signals:
-    // 1st Ctrl+C: graceful shutdown
-    // 2nd Ctrl+C: force exit immediately
+    info!("Shutdown signal received, stopping actors and servers...");
+
     tokio::spawn(async move {
-        loop {
-            tokio::signal::ctrl_c().await.ok();
-            let count = signal_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
-            if count == 1 {
-                info!("Shutdown signal received, stopping actors and servers...");
-            } else {
-                warn!("Force shutdown requested, exiting immediately");
-                std::process::exit(1);
-            }
-        }
+        // This can be turned into a loop
+        tokio::signal::ctrl_c().await.ok();
+        warn!("Graceful shutdown in progress. Press ctrl+C 2 more times to force ungraceful shutdown");
+        tokio::signal::ctrl_c().await.ok();
+        warn!("Graceful shutdown in progress. Press ctrl+C 1 more times to force ungraceful shutdown");
+        tokio::signal::ctrl_c().await.ok();
+        info!("Forced ungraceful shutdown...");
+        std::process::exit(1);
     });
-
-    // Wait for first signal
-    loop {
-        if signal_count.load(Ordering::SeqCst) > 0 {
-            break;
-        }
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-    }
 
     let blockchain_ref = blockchain.actor_ref().clone();
     let p2p_ref = p2p.actor_ref().clone();

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -16,7 +16,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 
 use clap::Parser;
 use ethlambda_blockchain::key_manager::ValidatorKeyPair;
@@ -205,23 +205,17 @@ async fn main() -> eyre::Result<()> {
         })
         .inspect_err(|err| error!(%err, "Failed to send InitBlockChain — actors not wired"))?;
 
-    let shutdown_notify = Arc::new(Notify::new());
-    let metrics_shutdown = shutdown_notify.clone();
-    let api_shutdown = shutdown_notify.clone();
+    let shutdown_token = CancellationToken::new();
+    let metrics_shutdown = shutdown_token.clone();
+    let api_shutdown = shutdown_token.clone();
 
     let metrics_handle = tokio::spawn(async move {
-        let shutdown_future = async move {
-            metrics_shutdown.notified().await;
-        };
-        let _ = ethlambda_rpc::start_metrics_server(metrics_socket, shutdown_future)
+        let _ = ethlambda_rpc::start_metrics_server(metrics_socket, metrics_shutdown)
             .await
             .inspect_err(|err| error!(%err, "Metrics server failed"));
     });
     let api_handle = tokio::spawn(async move {
-        let shutdown_future = async move {
-            api_shutdown.notified().await;
-        };
-        let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator, shutdown_future)
+        let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator, api_shutdown)
             .await
             .inspect_err(|err| error!(%err, "API server failed"));
     });
@@ -235,7 +229,7 @@ async fn main() -> eyre::Result<()> {
     let p2p_ref = p2p.actor_ref().clone();
     blockchain_ref.context().stop();
     p2p_ref.context().stop();
-    shutdown_notify.notify_waiters();
+    shutdown_token.cancel();
 
     blockchain_ref.join().await;
     p2p_ref.join().await;

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use tokio::sync::Notify;
 
 use clap::Parser;
 use ethlambda_blockchain::key_manager::ValidatorKeyPair;
@@ -204,13 +205,23 @@ async fn main() -> eyre::Result<()> {
         })
         .inspect_err(|err| error!(%err, "Failed to send InitBlockChain — actors not wired"))?;
 
-    tokio::spawn(async move {
-        let _ = ethlambda_rpc::start_metrics_server(metrics_socket)
+    let shutdown_notify = Arc::new(Notify::new());
+    let metrics_shutdown = shutdown_notify.clone();
+    let api_shutdown = shutdown_notify.clone();
+
+    let metrics_handle = tokio::spawn(async move {
+        let shutdown_future = async move {
+            metrics_shutdown.notified().await;
+        };
+        let _ = ethlambda_rpc::start_metrics_server(metrics_socket, shutdown_future)
             .await
             .inspect_err(|err| error!(%err, "Metrics server failed"));
     });
-    tokio::spawn(async move {
-        let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator)
+    let api_handle = tokio::spawn(async move {
+        let shutdown_future = async move {
+            api_shutdown.notified().await;
+        };
+        let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator, shutdown_future)
             .await
             .inspect_err(|err| error!(%err, "API server failed"));
     });
@@ -218,7 +229,20 @@ async fn main() -> eyre::Result<()> {
     info!("Node initialized");
 
     tokio::signal::ctrl_c().await.ok();
-    println!("Shutting down...");
+    info!("Shutdown signal received, stopping actors and servers...");
+
+    let blockchain_ref = blockchain.actor_ref().clone();
+    let p2p_ref = p2p.actor_ref().clone();
+    blockchain_ref.context().stop();
+    p2p_ref.context().stop();
+    shutdown_notify.notify_waiters();
+
+    blockchain_ref.join().await;
+    p2p_ref.join().await;
+    let _ = api_handle.await;
+    let _ = metrics_handle.await;
+
+    info!("Shutdown complete");
 
     Ok(())
 }

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -230,9 +230,13 @@ async fn main() -> eyre::Result<()> {
     tokio::spawn(async move {
         // This can be turned into a loop
         tokio::signal::ctrl_c().await.ok();
-        warn!("Graceful shutdown in progress. Press ctrl+C 2 more times to force ungraceful shutdown");
+        warn!(
+            "Graceful shutdown in progress. Press ctrl+C 2 more times to force ungraceful shutdown"
+        );
         tokio::signal::ctrl_c().await.ok();
-        warn!("Graceful shutdown in progress. Press ctrl+C 1 more times to force ungraceful shutdown");
+        warn!(
+            "Graceful shutdown in progress. Press ctrl+C 1 more times to force ungraceful shutdown"
+        );
         tokio::signal::ctrl_c().await.ok();
         info!("Forced ungraceful shutdown...");
         std::process::exit(1);

--- a/crates/net/rpc/Cargo.toml
+++ b/crates/net/rpc/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [dependencies]
 axum = "0.8.1"
 tokio.workspace = true
+tokio-util.workspace = true
 ethlambda-fork-choice.workspace = true
 ethlambda-metrics.workspace = true
 tracing.workspace = true

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -20,23 +20,31 @@ pub async fn start_api_server(
     address: SocketAddr,
     store: Store,
     aggregator: AggregatorController,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> Result<(), std::io::Error> {
     let api_router = build_api_router(store).layer(Extension(aggregator));
 
     let listener = tokio::net::TcpListener::bind(address).await?;
-    axum::serve(listener, api_router).await?;
+    axum::serve(listener, api_router)
+        .with_graceful_shutdown(shutdown)
+        .await?;
 
     Ok(())
 }
 
-pub async fn start_metrics_server(address: SocketAddr) -> Result<(), std::io::Error> {
+pub async fn start_metrics_server(
+    address: SocketAddr,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), std::io::Error> {
     let metrics_router = metrics::start_prometheus_metrics_api();
     let debug_router = build_debug_router();
 
     let app = Router::new().merge(metrics_router).merge(debug_router);
 
     let listener = tokio::net::TcpListener::bind(address).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await?;
 
     Ok(())
 }

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -20,13 +20,15 @@ pub async fn start_api_server(
     address: SocketAddr,
     store: Store,
     aggregator: AggregatorController,
-    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+    shutdown: tokio_util::sync::CancellationToken,
 ) -> Result<(), std::io::Error> {
     let api_router = build_api_router(store).layer(Extension(aggregator));
 
     let listener = tokio::net::TcpListener::bind(address).await?;
     axum::serve(listener, api_router)
-        .with_graceful_shutdown(shutdown)
+        .with_graceful_shutdown(async move {
+            shutdown.cancelled().await;
+        })
         .await?;
 
     Ok(())
@@ -34,7 +36,7 @@ pub async fn start_api_server(
 
 pub async fn start_metrics_server(
     address: SocketAddr,
-    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+    shutdown: tokio_util::sync::CancellationToken,
 ) -> Result<(), std::io::Error> {
     let metrics_router = metrics::start_prometheus_metrics_api();
     let debug_router = build_debug_router();
@@ -43,7 +45,9 @@ pub async fn start_metrics_server(
 
     let listener = tokio::net::TcpListener::bind(address).await?;
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown)
+        .with_graceful_shutdown(async move {
+            shutdown.cancelled().await;
+        })
         .await?;
 
     Ok(())

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -7,6 +7,7 @@ use ethlambda_storage::Store;
 use ethlambda_types::aggregator::AggregatorController;
 use ethlambda_types::primitives::H256;
 use libssz::SszEncode;
+use tokio_util::sync::CancellationToken;
 
 pub(crate) const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
 pub(crate) const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
@@ -20,7 +21,7 @@ pub async fn start_api_server(
     address: SocketAddr,
     store: Store,
     aggregator: AggregatorController,
-    shutdown: tokio_util::sync::CancellationToken,
+    shutdown: CancellationToken,
 ) -> Result<(), std::io::Error> {
     let api_router = build_api_router(store).layer(Extension(aggregator));
 
@@ -36,7 +37,7 @@ pub async fn start_api_server(
 
 pub async fn start_metrics_server(
     address: SocketAddr,
-    shutdown: tokio_util::sync::CancellationToken,
+    shutdown: CancellationToken,
 ) -> Result<(), std::io::Error> {
     let metrics_router = metrics::start_prometheus_metrics_api();
     let debug_router = build_debug_router();


### PR DESCRIPTION
## 🗒️ Description

This PR implements graceful shutdown for the ethlambda node's actors and HTTP servers. Previously, the node would abruptly terminate on Ctrl+C without waiting for in-flight operations to complete.

Now, on shutdown signal:

- The BlockChain and P2P actors are stopped cleanly via their context's [`stop()`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method
- The API and metrics HTTP servers are shut down gracefully using Axum's `with_graceful_shutdown()`
- The main thread waits for all actors and server tasks to finish before exiting

These changes ensure that:
- Aggregation workers complete their current jobs  
- Database writes are flushed  
- Network connections are closed properly  

This prevents data corruption and improves reliability.

🔗 Related Issues or PRs

Closes #195