### PR TITLE
feat!: align flag names with lean-quickstart spec

### DIFF
--- a/.claude/skills/devnet-runner/references/long-lived-devnet.md
+++ b/.claude/skills/devnet-runner/references/long-lived-devnet.md
@@ -53,7 +53,11 @@ done
 docker run -d --restart unless-stopped --name ethlambda_0 --network host \
   -v $GENESIS:/config -v $DATA/ethlambda_0:/data \
   $IMAGE \
-  --custom-network-config-dir /config \
+  --genesis /config/config.yaml \
+  --validators /config/annotated_validators.yaml \
+  --bootnodes /config/nodes.yaml \
+  --validator-config /config/validator-config.yaml \
+  --hash-sig-keys-dir /config/hash-sig-keys \
   --gossipsub-port 9001 --node-id ethlambda_0 \
   --node-key /config/ethlambda_0.key \
   --http-address 0.0.0.0 --api-port 5052 --metrics-port 8081
@@ -61,7 +65,11 @@ docker run -d --restart unless-stopped --name ethlambda_0 --network host \
 docker run -d --restart unless-stopped --name ethlambda_1 --network host \
   -v $GENESIS:/config -v $DATA/ethlambda_1:/data \
   $IMAGE \
-  --custom-network-config-dir /config \
+  --genesis /config/config.yaml \
+  --validators /config/annotated_validators.yaml \
+  --bootnodes /config/nodes.yaml \
+  --validator-config /config/validator-config.yaml \
+  --hash-sig-keys-dir /config/hash-sig-keys \
   --gossipsub-port 9002 --node-id ethlambda_1 \
   --node-key /config/ethlambda_1.key \
   --http-address 0.0.0.0 --api-port 5053 --metrics-port 8082
@@ -69,7 +77,11 @@ docker run -d --restart unless-stopped --name ethlambda_1 --network host \
 docker run -d --restart unless-stopped --name ethlambda_2 --network host \
   -v $GENESIS:/config -v $DATA/ethlambda_2:/data \
   $IMAGE \
-  --custom-network-config-dir /config \
+  --genesis /config/config.yaml \
+  --validators /config/annotated_validators.yaml \
+  --bootnodes /config/nodes.yaml \
+  --validator-config /config/validator-config.yaml \
+  --hash-sig-keys-dir /config/hash-sig-keys \
   --gossipsub-port 9003 --node-id ethlambda_2 \
   --node-key /config/ethlambda_2.key \
   --http-address 0.0.0.0 --api-port 5054 --metrics-port 8083
@@ -77,7 +89,11 @@ docker run -d --restart unless-stopped --name ethlambda_2 --network host \
 docker run -d --restart unless-stopped --name ethlambda_3 --network host \
   -v $GENESIS:/config -v $DATA/ethlambda_3:/data \
   $IMAGE \
-  --custom-network-config-dir /config \
+  --genesis /config/config.yaml \
+  --validators /config/annotated_validators.yaml \
+  --bootnodes /config/nodes.yaml \
+  --validator-config /config/validator-config.yaml \
+  --hash-sig-keys-dir /config/hash-sig-keys \
   --gossipsub-port 9004 --node-id ethlambda_3 \
   --node-key /config/ethlambda_3.key \
   --is-aggregator \
@@ -141,7 +157,11 @@ sleep 60
 docker run -d --restart unless-stopped --name ethlambda_0 --network host \
   -v $GENESIS:/config -v $DATA/ethlambda_0:/data \
   $NEW_IMAGE \
-  --custom-network-config-dir /config \
+  --genesis /config/config.yaml \
+  --validators /config/annotated_validators.yaml \
+  --bootnodes /config/nodes.yaml \
+  --validator-config /config/validator-config.yaml \
+  --hash-sig-keys-dir /config/hash-sig-keys \
   --gossipsub-port 9001 --node-id ethlambda_0 \
   --node-key /config/ethlambda_0.key \
   --http-address 0.0.0.0 --api-port 5052 --metrics-port 8081 \

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -46,19 +46,19 @@ const ASCII_ART: &str = r#"
 #[derive(Debug, clap::Parser)]
 #[command(name = "ethlambda", author = "LambdaClass", version = version::CLIENT_VERSION, about = "ethlambda consensus client")]
 struct CliOptions {
-    /// Path to the chain genesis config (config.yaml).
+    /// Path to the chain genesis config (e.g., config.yaml).
     #[arg(long)]
     genesis: PathBuf,
-    /// Path to the validator registry (annotated_validators.yaml).
+    /// Path to the validator registry (e.g., annotated_validators.yaml).
     #[arg(long)]
     validators: PathBuf,
-    /// Path to the bootnode list (nodes.yaml).
+    /// Path to the bootnode list (e.g., nodes.yaml).
     #[arg(long)]
     bootnodes: PathBuf,
     /// Path to validator-config.yaml (validator name registry for metrics labels).
     #[arg(long)]
     validator_config: PathBuf,
-    /// Directory containing per-validator XMSS keys (hash-sig-keys/).
+    /// Directory containing per-validator XMSS keys (e.g., hash-sig-keys/).
     #[arg(long)]
     hash_sig_keys_dir: PathBuf,
     #[arg(long, default_value = "9000")]

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -46,14 +46,19 @@ const ASCII_ART: &str = r#"
 #[derive(Debug, clap::Parser)]
 #[command(name = "ethlambda", author = "LambdaClass", version = version::CLIENT_VERSION, about = "ethlambda consensus client")]
 struct CliOptions {
+    /// Path to the chain genesis config (config.yaml).
     #[arg(long)]
     genesis: PathBuf,
+    /// Path to the validator registry (annotated_validators.yaml).
     #[arg(long)]
     validators: PathBuf,
+    /// Path to the bootnode list (nodes.yaml).
     #[arg(long)]
     bootnodes: PathBuf,
+    /// Path to validator-config.yaml (validator name registry for metrics labels).
     #[arg(long)]
     validator_config: PathBuf,
+    /// Directory containing per-validator XMSS keys (hash-sig-keys/).
     #[arg(long)]
     hash_sig_keys_dir: PathBuf,
     #[arg(long, default_value = "9000")]

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -47,7 +47,15 @@ const ASCII_ART: &str = r#"
 #[command(name = "ethlambda", author = "LambdaClass", version = version::CLIENT_VERSION, about = "ethlambda consensus client")]
 struct CliOptions {
     #[arg(long)]
-    custom_network_config_dir: PathBuf,
+    genesis: PathBuf,
+    #[arg(long)]
+    validators: PathBuf,
+    #[arg(long)]
+    bootnodes: PathBuf,
+    #[arg(long)]
+    validator_config: PathBuf,
+    #[arg(long)]
+    hash_sig_keys_dir: PathBuf,
     #[arg(long, default_value = "9000")]
     gossipsub_port: u16,
     #[arg(long, default_value = "127.0.0.1")]
@@ -121,15 +129,11 @@ async fn main() -> eyre::Result<()> {
 
     info!(node_key=?options.node_key, "got node key");
 
-    let config_path = options.custom_network_config_dir.join("config.yaml");
-    let bootnodes_path = options.custom_network_config_dir.join("nodes.yaml");
-    let validators_path = options
-        .custom_network_config_dir
-        .join("annotated_validators.yaml");
-    let validator_config = options
-        .custom_network_config_dir
-        .join("validator-config.yaml");
-    let validator_keys_dir = options.custom_network_config_dir.join("hash-sig-keys");
+    let config_path = options.genesis;
+    let bootnodes_path = options.bootnodes;
+    let validators_path = options.validators;
+    let validator_config = options.validator_config;
+    let validator_keys_dir = options.hash_sig_keys_dir;
 
     let config_yaml = std::fs::read_to_string(&config_path).expect("Failed to read config.yaml");
     let genesis_config: GenesisConfig =

--- a/docs/checkpoint_sync.md
+++ b/docs/checkpoint_sync.md
@@ -6,14 +6,18 @@ Checkpoint sync allows a new consensus node to skip replaying the entire chain f
 
 ## Usage
 
-Checkpoint sync still requires a full network config directory (`--custom-network-config-dir`). The genesis config is needed to verify the downloaded state: checkpoint sync only replaces the starting state, not node configuration.
+Checkpoint sync still requires the network config files (genesis, validators, bootnodes, etc.). The genesis config is needed to verify the downloaded state: checkpoint sync only replaces the starting state, not node configuration.
 
 Pass the `--checkpoint-sync-url` flag when starting ethlambda:
 
 ```bash
 ethlambda \
   --checkpoint-sync-url <URL> \
-  --custom-network-config-dir ./network-config \
+  --genesis ./network-config/config.yaml \
+  --validators ./network-config/annotated_validators.yaml \
+  --bootnodes ./network-config/nodes.yaml \
+  --validator-config ./network-config/validator-config.yaml \
+  --hash-sig-keys-dir ./network-config/hash-sig-keys \
   --node-key ./node.key \
   --node-id ethlambda_0
 ```

--- a/docs/fork_choice_visualization.md
+++ b/docs/fork_choice_visualization.md
@@ -29,7 +29,11 @@ The local devnet runs 3 ethlambda nodes with metrics ports 8085, 8086, and 8087.
 
 ```bash
 cargo run --release -- \
-  --custom-network-config-dir ./config \
+  --genesis ./config/config.yaml \
+  --validators ./config/annotated_validators.yaml \
+  --bootnodes ./config/nodes.yaml \
+  --validator-config ./config/validator-config.yaml \
+  --hash-sig-keys-dir ./config/hash-sig-keys \
   --node-key ./keys/node.key \
   --node-id 0 \
   --api-port 5052

--- a/preview-config.nix
+++ b/preview-config.nix
@@ -90,7 +90,11 @@ let
         WorkingDirectory = "${dataDir}/${name}";
         ExecStart = builtins.concatStringsSep " " ([
           binaryPath
-          "--custom-network-config-dir" genesisDir
+          "--genesis" "${genesisDir}/config.yaml"
+          "--validators" "${genesisDir}/annotated_validators.yaml"
+          "--bootnodes" "${genesisDir}/nodes.yaml"
+          "--validator-config" "${genesisDir}/validator-config.yaml"
+          "--hash-sig-keys-dir" "${genesisDir}/hash-sig-keys"
           "--gossipsub-port" (toString gossipPort)
           "--node-id" name
           "--node-key" "${genesisDir}/${name}.key"


### PR DESCRIPTION
## Summary

Closes #287. Aligns CLI flags with the  [lean-quickstart spec](https://github.com/blockblaz/lean-quickstart/blob/main/docs/adding-a-new-client.md#required-cli-flags-your-client-must-support).
  
**Removed:**
  - `--custom-network-config-dir`

 **Added:**

  | Flag | Maps to |
  |---|---|
  | `--genesis` | `config.yaml` |
  | `--validators` | `annotated_validators.yaml` |
  | `--bootnodes` | `nodes.yaml` |
  | `--validator-config` | `validator-config.yaml` |
  | `--hash-sig-keys-dir` | `hash-sig-keys/` |

  `--genesis`, `--validators`, and `--bootnodes` are mandated by the spec.
  `--validator-config` and `--hash-sig-keys-dir` cover ethlambda-internal paths that the spec doesn't standardize.
  
## Coordination

Coordinated lean-quickstart PR: https://github.com/lambdaclass/ethlambda/pull/321.

## Testing

To verify the new flags locally:
  1. Build the binary from this branch:
     ```bash
     cargo build --release
     ```

  2. Inspect --help and confirm the new flags appear:
  ```bash
  ./target/release/ethlambda --help
  ```
  
- Flags that should be listed as part of the change:  `--genesis`, `--validators`, `--bootnodes`, `--validator-config`, and `--hash-sig-keys-dir`
-  `--custom-network-config-dir` should no longer be present

---

To boot the binary from the `lean-quickstart` repository:
1. Checkout the [ethlambda-update-cmd-flags](https://github.com/conache/lean-quickstart/tree/ethlambda-update-cmd-flags) branch associated with [the lean-quickstart PR](https://github.com/lambdaclass/ethlambda/pull/321).
2. Run `NETWORK_DIR=local-devnet ./spin-node.sh --node ethlambda_0 --generateGenesis`

The binary parses succesfully parses all five flags.

#### Important note:
> Unrelated to this PR; worth flagging as a separate issue if not already tracked.

Local-devnet boot panics after parsing the CLI flags with the following error (confirmed it reproduces identically on `main`):

```bash
thread 'main' (13480983) panicked at bin/ethlambda/src/main.rs:136:47:
Failed to parse config.yaml: Error("GENESIS_VALIDATORS[0]: invalid type: string \"...", expected struct GenesisValidatorEntry", line: 12, column: 7)
```
