### PR TITLE
feat(p2p): log received messages with peer count

### DIFF
--- a/crates/net/p2p/src/gossipsub/handler.rs
+++ b/crates/net/p2p/src/gossipsub/handler.rs
@@ -26,9 +26,11 @@ pub async fn handle_gossipsub_message(server: &mut P2PServer, event: Event) {
     else {
         unreachable!("we already matched on Message variant in handle_swarm_event");
     };
+    let peer_count = server.connected_peers.len();
     let topic_kind = message.topic.as_str().split("/").nth(3);
     match topic_kind {
         Some(BLOCK_TOPIC_KIND) => {
+            info!(kind = "block", peer_count, "P2P message received");
             let Ok(uncompressed_data) = decompress_message(&message.data)
                 .inspect_err(|err| error!(%err, "Failed to decompress gossipped block"))
             else {
@@ -61,6 +63,7 @@ pub async fn handle_gossipsub_message(server: &mut P2PServer, event: Event) {
             }
         }
         Some(AGGREGATION_TOPIC_KIND) => {
+            info!(kind = "aggregation", peer_count, "P2P message received");
             let Ok(uncompressed_data) = decompress_message(&message.data)
                 .inspect_err(|err| error!(%err, "Failed to decompress gossipped aggregation"))
             else {
@@ -91,6 +94,7 @@ pub async fn handle_gossipsub_message(server: &mut P2PServer, event: Event) {
             }
         }
         Some(kind) if kind.starts_with(ATTESTATION_SUBNET_TOPIC_PREFIX) => {
+            info!(kind = "attestation", peer_count, "P2P message received");
             let Ok(uncompressed_data) = decompress_message(&message.data)
                 .inspect_err(|err| error!(%err, "Failed to decompress gossipped attestation"))
             else {

--- a/crates/net/p2p/src/req_resp/handlers.rs
+++ b/crates/net/p2p/src/req_resp/handlers.rs
@@ -28,31 +28,48 @@ pub async fn handle_req_resp_message(
         request_response::Event::Message { peer, message, .. } => match message {
             request_response::Message::Request {
                 request, channel, ..
-            } => match request {
-                Request::Status(status) => {
-                    handle_status_request(server, status, channel, peer).await;
+            } => {
+                let peer_count = server.connected_peers.len();
+                match request {
+                    Request::Status(status) => {
+                        info!(kind = "status_request", peer_count, "P2P message received");
+                        handle_status_request(server, status, channel, peer).await;
+                    }
+                    Request::BlocksByRoot(request) => {
+                        info!(
+                            kind = "blocks_by_root_request",
+                            peer_count, "P2P message received"
+                        );
+                        handle_blocks_by_root_request(server, request, channel, peer).await;
+                    }
                 }
-                Request::BlocksByRoot(request) => {
-                    handle_blocks_by_root_request(server, request, channel, peer).await;
-                }
-            },
+            }
             request_response::Message::Response {
                 request_id,
                 response,
-            } => match response {
-                Response::Success { payload } => match payload {
-                    ResponsePayload::Status(status) => {
-                        handle_status_response(status, peer).await;
+            } => {
+                let peer_count = server.connected_peers.len();
+                match response {
+                    Response::Success { payload } => match payload {
+                        ResponsePayload::Status(status) => {
+                            info!(kind = "status_response", peer_count, "P2P message received");
+                            handle_status_response(status, peer).await;
+                        }
+                        ResponsePayload::BlocksByRoot(blocks) => {
+                            info!(
+                                kind = "blocks_by_root_response",
+                                peer_count, "P2P message received"
+                            );
+                            handle_blocks_by_root_response(server, blocks, peer, request_id, ctx)
+                                .await;
+                        }
+                    },
+                    Response::Error { code, message } => {
+                        let error_str = String::from_utf8_lossy(&message);
+                        warn!(%peer, ?code, %error_str, "Received error response");
                     }
-                    ResponsePayload::BlocksByRoot(blocks) => {
-                        handle_blocks_by_root_response(server, blocks, peer, request_id, ctx).await;
-                    }
-                },
-                Response::Error { code, message } => {
-                    let error_str = String::from_utf8_lossy(&message);
-                    warn!(%peer, ?code, %error_str, "Received error response");
                 }
-            },
+            }
         },
         request_response::Event::OutboundFailure {
             peer,


### PR DESCRIPTION
## Motivation

Today, when an ethlambda node receives a p2p message we log per-message-type
lines (`Received block from gossip`, `Received attestation from gossip`,
`Received BlocksByRoot request`, etc.) but none of them carry the **count of
currently connected peers**. Operators reading logs cannot easily tell, at a
glance, whether ongoing gossip activity is being amplified by a healthy mesh
or coming from just a couple of peers — they have to cross-reference the
last `Peer connected` / `Peer disconnected` event, which can be far up the
log.

This PR adds a single, dedicated log line emitted on every inbound p2p
message that includes the peer count, giving operators a continuously
updated network-health signal aligned with traffic.

The log level matches existing chain/fork events (`Fork choice reorg
detected`, `Block imported`, `Peer connected`) — `info!`.

## Description

### What is logged

A new `info!` log line per inbound p2p message:

```
INFO ethlambda_p2p::...: P2P message received kind="block" peer_count=4
```

`kind` is a stable snake_case identifier; `peer_count` is the size of
`P2PServer::connected_peers` at the moment of reception.

### Logged kinds

| `kind`                     | Source protocol | Triggering event |
|----------------------------|-----------------|------------------|
| `block`                    | gossipsub       | block topic message |
| `aggregation`              | gossipsub       | aggregation topic message |
| `attestation`              | gossipsub       | any `attestation_<subnet_id>` topic message |
| `status_request`           | req/resp        | inbound `Status` request |
| `status_response`          | req/resp        | inbound `Status` response |
| `blocks_by_root_request`   | req/resp        | inbound `BlocksByRoot` request |
| `blocks_by_root_response`  | req/resp        | inbound `BlocksByRoot` response |

### Deliberate exclusions

- **Unknown gossip topics** stay at `trace!` (existing behavior, unchanged).
  They mostly come from cross-version peers and would otherwise add `info!`
  noise on every misrouted message. This is the one knowing exception to
  "every received message".
- **`OutboundFailure` / `InboundFailure` / `ResponseSent`** in the req/resp
  protocol are not "received messages" in the user-visible sense and remain
  unchanged.
- **Connection lifecycle events** (`Peer connected`, `Peer disconnected`)
  already include `peer_count` — untouched.
- **Outbound publish logs** (`Published block to gossipsub`, etc.) — out of
  scope; this PR is about inbound traffic only.

### Implementation

Two emit sites — one per protocol entry point — to minimize duplication
and keep the new log close to the earliest knowable point:

1. **`crates/net/p2p/src/gossipsub/handler.rs`**
   - `peer_count` captured once at the top of `handle_gossipsub_message`
     into a local variable. The read is immutable and does not conflict
     with the later mutable use of `server` inside each match arm.
   - `info!(kind = …, peer_count, "P2P message received")` is placed at
     the **head of each known-topic match arm**, so the log fires before
     decompression / decoding work — i.e. it captures the message even if
     decoding subsequently fails.

2. **`crates/net/p2p/src/req_resp/handlers.rs`**
   - In `handle_req_resp_message`, `peer_count` is captured once per
     `Message::Request` / `Message::Response` branch.
   - The new `info!` is emitted inside the inner request/response variant
     match, so `kind` is precise (`status_request` vs `blocks_by_root_request`,
     etc.).

No new helpers, no new types, no signature changes to the existing
`handle_status_request` / `handle_blocks_by_root_request` etc. functions —
they already had `&mut P2PServer` access. The `kind` strings are short
literals inlined at each call site (≤ 7 sites across 2 files); abstracting
them into a helper or enum would have been over-engineering.

### Why a dedicated log line, and not just a new `peer_count` field on the existing `Received …` logs?

Two reasonable designs were considered:

- **Option A** — augment each existing `Received …` log with a
  `peer_count` field (no new log lines, ~7 sites touched).
- **Option B** *(this PR)* — one dedicated `P2P message received` log per
  reception (one new log line per inbound message).

We chose Option B as a first iteration to evaluate whether the new
correlation is useful in practice without altering the existing per-type
logs that operators already grep for. If the new line proves redundant
with the existing ones, collapsing into Option A is a small follow-up.
Notes are in `docs/plans/p2p-received-peer-count-log.md` (local plan
doc, not committed) for the rationale.

### Field ordering

Follows the project logging convention from `CLAUDE.md`
(temporal → identity → identifiers → context → metadata): `kind` is the
identity-ish field, `peer_count` is metadata, both come before the message
string.

## How to Test

1. `make fmt` — passes.
2. `make lint` (clippy `-D warnings`) — passes.
3. `make test` — passes (full workspace test suite green; no test changes
   needed since this is logging-only).
4. **Manual smoke test against a local devnet:**
   ```bash
   make run-devnet
   # In another shell:
   docker logs -f <ethlambda-container> 2>&1 | grep "P2P message received"
   ```
   You should see lines like:
   ```
   INFO ethlambda_p2p::gossipsub::handler: P2P message received kind="block" peer_count=4
   INFO ethlambda_p2p::gossipsub::handler: P2P message received kind="attestation" peer_count=4
   INFO ethlambda_p2p::req_resp::handlers: P2P message received kind="status_request" peer_count=4
   ```
   Verify that:
   - `peer_count` matches the value last reported by `Peer connected` /
     `Peer disconnected` events.
   - All expected `kind` values appear during normal operation
     (`block` and `attestation` every slot; `aggregation` once
     aggregations occur; `status_*` shortly after each new connection;
     `blocks_by_root_*` when a peer is missing blocks and re-syncs).
   - No `P2P message received` line appears for messages on unknown
     topics (those stay at `trace!`).

## Risk / open questions

- **Log volume.** This adds one `info!` line per inbound message. With
  N validators, that is roughly N attestations + 1 block per slot per
  node, plus any aggregations and req/resp traffic — acceptable on the
  current devnets. If volume becomes a concern in production, the clear
  follow-up is to collapse `peer_count` into the existing per-type logs
  (Option A above) and remove this dedicated line.
- **Operational follow-up.** No metric is added in this PR. If we later
  want a counterpart `lean_p2p_messages_received_total{kind=…}` counter,
  that can be a separate change.

## Files changed

- `crates/net/p2p/src/gossipsub/handler.rs` — 3 new `info!` calls + 1
  local `peer_count` capture.
- `crates/net/p2p/src/req_resp/handlers.rs` — 4 new `info!` calls + 2
  local `peer_count` captures; restructure of the match to scope
  `peer_count` to the request/response branches.

No new files. No public API changes. No dependency changes.