### PR TITLE
fix(blockchain): reject blocks too far in future before pending storage

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -420,6 +420,27 @@ impl BlockChainServer {
             return;
         }
 
+        // Reject blocks whose slot has not started locally, mirroring the
+        // attestation time check in `validate_attestation_data`. The disparity
+        // bound is in intervals, not slots: a whole-slot margin would let an
+        // adversary pre-publish next-slot blocks ahead of any honest proposer.
+        // Catching this early also avoids persisting bogus future blocks to
+        // RocksDB and triggering BlocksByRoot fan-out for fabricated parents.
+        let block_start_interval = slot.saturating_mul(INTERVALS_PER_SLOT);
+        let store_time = self.store.time();
+        if block_start_interval > store_time + GOSSIP_DISPARITY_INTERVALS {
+            warn!(
+                %slot,
+                store_time,
+                proposer,
+                block_root = %ShortRoot(&block_root.0),
+                parent_root = %ShortRoot(&parent_root.0),
+                "Rejecting block: slot is too far in future"
+            );
+            self.discard_pending_subtree(block_root);
+            return;
+        }
+
         // Check if parent state exists before attempting to process
         if !self.store.has_state(&parent_root) {
             info!(%slot, %parent_root, %block_root, "Block parent missing, storing as pending");


### PR DESCRIPTION
## Summary

Adds a parent-independent future-slot check in `BlockChainServer::process_or_pend_block` so blocks whose start interval is more than `GOSSIP_DISPARITY_INTERVALS` ahead of local time are dropped before the parent-state lookup.

Mirrors the bound used by `validate_attestation_data` (leanSpec PR #682): an interval-based margin (not a whole-slot one), since a slot-wide tolerance would let an adversary pre-publish next-slot blocks ahead of any honest proposer.

## Motivation

Today, the only slot-based gate on incoming blocks is `slot <= finalized_slot`. There is no upper bound, so a peer can flood blocks at arbitrary future slots and force us to:

- Persist them to RocksDB via `insert_pending_block` (since the fabricated parent state will be missing).
- Issue `BlocksByRoot` requests for the fabricated parent roots, fanning out to peers.

The new check rejects these at the orchestration layer (`BlockChainServer`) before any disk write or network request. `on_block_core` is intentionally untouched: spec tests drive `store::on_block_*` directly with arbitrary `on_tick` advancements, and we don't want a wall-clock gate at that layer.

## Behavior

```
process_or_pend_block:
  slot ≤ finalized                                  → discard subtree, drop  (existing)
  block_start_interval > store.time() + DISPARITY   → discard subtree, drop  (NEW)
  parent state missing                              → persist as pending     (existing)
  otherwise                                         → process_block          (existing)
```

`block_start_interval = slot * INTERVALS_PER_SLOT` is the interval at which the block's slot begins. Tolerance is `GOSSIP_DISPARITY_INTERVALS = 1` (~800 ms), matching the attestation bound.

## Test plan

- [x] `make fmt` clean
- [x] `make lint` clean (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] No regressions in `cargo test --workspace --release` from this change (the 8 fixture failures in `forkchoice_spectests` pre-exist on `main` after #317 and are unrelated).
- [ ] Devnet smoke: bring up local devnet, confirm normal block flow is unaffected and a manually crafted future-slot block is rejected with the expected `warn!`.