### PR TITLE
docs: render documentation site with mdbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ CLAUDE.local.md
 
 # Log output by make run-devnet
 devnet.log
+
+# mdbook build output
+book/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint docker-build run-devnet test
+.PHONY: help fmt lint docker-build run-devnet test docs docs-deps docs-serve
 
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -48,3 +48,12 @@ run-devnet: docker-build lean-quickstart ## 🚀 Run a local devnet using lean-q
 	@echo "Starting local devnet. Press Ctrl+C to stop all nodes."
 	@cd lean-quickstart \
 		&& NETWORK_DIR=local-devnet ./spin-node.sh --node all --generateGenesis --metrics > ../devnet.log 2>&1
+
+docs-deps: ## 📦 Install dependencies for generating the documentation
+	cargo install --version 0.4.51 mdbook
+
+docs: ## 📚 Generate the documentation site under ./book
+	mdbook build
+
+docs-serve: ## 📖 Serve the documentation locally with live reload
+	mdbook serve --open

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ run-devnet: docker-build lean-quickstart ## 🚀 Run a local devnet using lean-q
 		&& NETWORK_DIR=local-devnet ./spin-node.sh --node all --generateGenesis --metrics > ../devnet.log 2>&1
 
 docs-deps: ## 📦 Install dependencies for generating the documentation
-	cargo install --version 0.4.51 mdbook
+	cargo install --version 0.5.2 mdbook
+	cargo install --version 0.12.0 mdbook-linkcheck2
 
 docs: ## 📚 Generate the documentation site under ./book
 	mdbook build

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,15 @@
+[book]
+authors = ["lambdaclass"]
+language = "en"
+src = "docs"
+title = "ethlambda"
+description = "Minimalist, fast and modular implementation of the Lean Ethereum client written in Rust"
+
+[rust]
+edition = "2024"
+
+[output.html]
+git-repository-url = "https://github.com/lambdaclass/ethlambda"
+edit-url-template = "https://github.com/lambdaclass/ethlambda/edit/main/{path}"
+# Make sections collapsible, starting fully expanded
+fold = { enable = true, level = 1 }

--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,9 @@ git-repository-url = "https://github.com/lambdaclass/ethlambda"
 edit-url-template = "https://github.com/lambdaclass/ethlambda/edit/main/{path}"
 # Make sections collapsible, starting fully expanded
 fold = { enable = true, level = 1 }
+
+# Broken-link checker
+# https://github.com/marxin/mdbook-linkcheck2
+# Needs to be installed with `cargo install mdbook-linkcheck2`
+[output.linkcheck2]
+optional = true

--- a/docs/3sf_mini.md
+++ b/docs/3sf_mini.md
@@ -312,7 +312,7 @@ When finalization advances, the following cleanup occurs:
 
 ## End-to-End: From Head Selection to Finalization
 
-This section connects [LMD-GHOST fork choice](ghost-fork-choice.md) with 3SF-mini.
+This section connects [LMD-GHOST fork choice](lmd_ghost.md) with 3SF-mini.
 The [quick example above](#quick-example-three-slots-to-finality) showed the happy
 path; here we focus on what happens when things go wrong.
 
@@ -340,7 +340,7 @@ The **safe target** is computed by running LMD-GHOST with a two-thirds vote thre
 Only blocks backed by a supermajority qualify, so the safe target is always at or
 behind the head. The attestation **target** is derived by walking back from the head
 toward the safe target (max 3 steps), then to the nearest justifiable slot. See
-[Safe Target Selection](ghost-fork-choice.md#safe-target-selection) for details.
+[Safe Target Selection](lmd_ghost.md#safe-target-selection) for details.
 
 > **In ethlambda:** `get_attestation_target()` in `crates/blockchain/src/store.rs`
 > implements this walk-back. `JUSTIFICATION_LOOKBACK_SLOTS = 3` provides a liveness

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,14 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# Consensus
+
+- [3SF-mini: Justification & Finalization](./3sf_mini.md)
+- [LMD-GHOST Fork Choice](./lmd_ghost.md)
+
+# Operations
+
+- [Metrics](./metrics.md)
+- [Checkpoint Sync](./checkpoint_sync.md)
+- [Fork Choice Visualization](./fork_choice_visualization.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,42 @@
+# Introduction
+
+**ethlambda** is a minimalist, fast and modular implementation of the Lean Ethereum
+consensus client, written in Rust.
+
+This book collects the design notes and operator-facing references for ethlambda.
+It is split into two parts:
+
+- **Consensus** explains the algorithms ethlambda implements: the
+  [3SF-mini](./3sf_mini.md) justification and finalization rules, and the
+  [LMD-GHOST](./lmd_ghost.md) fork choice algorithm. Both documents are
+  implementation-agnostic; ethlambda-specific behaviour is called out in
+  blockquotes.
+- **Operations** documents observable surfaces of a running node:
+  [Prometheus metrics](./metrics.md), [checkpoint sync](./checkpoint_sync.md),
+  and the [fork choice visualization](./fork_choice_visualization.md) served
+  by the API.
+
+For build and contribution instructions, see the
+[`README`](https://github.com/lambdaclass/ethlambda/blob/main/README.md) and
+[`CONTRIBUTING.md`](https://github.com/lambdaclass/ethlambda/blob/main/CONTRIBUTING.md)
+in the repository.
+
+## Visual references
+
+Two standalone HTML infographics ship alongside this book and are copied verbatim
+into the rendered output:
+
+- [3SF-mini infographic](./infographics/3sf-mini-infographic.html)
+- [ethlambda architecture infographic](./infographics/ethlambda_architecture.html)
+
+## Related projects
+
+ethlambda is one of several Lean Ethereum consensus clients under active development.
+For comparison and cross-client testing:
+
+- [zeam](https://github.com/blockblaz/zeam) (Zig)
+- [ream](https://github.com/ReamLabs/ream) (Rust)
+- [qlean](https://github.com/qdrvm/qlean-mini) (C++)
+- [grandine](https://github.com/grandinetech/lean/tree/main/lean_client) (Rust)
+- [gean](https://github.com/devlongs/gean) (Go)
+- [Lantern](https://github.com/Pier-Two/lantern) (C)


### PR DESCRIPTION
## Summary

Closes #122. Wires up [mdbook](https://rust-lang.github.io/mdBook/) so the existing `docs/` markdown can be rendered as a browsable site.

## Changes

- `book.toml`: mdbook config pointing `src` at `docs/`, with `git-repository-url` and an `edit-url-template` so each page links back to its source on `main`.
- `docs/SUMMARY.md`: required mdbook table of contents. Groups pages into two parts — **Consensus** (3SF-mini, LMD-GHOST) and **Operations** (Metrics, Checkpoint Sync, Fork Choice Visualization).
- `docs/introduction.md`: landing page that orients the reader and links to the existing `docs/infographics/*.html` (mdbook copies the HTML files into the rendered site as-is).
- `Makefile`: `docs-deps` (installs mdbook 0.4.51 via cargo), `docs` (one-shot build into `./book`), `docs-serve` (live-reload preview).
- `.gitignore`: excludes the `book/` build output.

No mdbook plugins are pulled in — none of the current docs use mermaid / katex / GFM alerts, so the bare renderer is enough. Plugins can be added later if/when content needs them, following the [ethrex setup](https://github.com/lambdaclass/ethrex/blob/728dc7ded560c665ab1ff2cf7f3eeb197b5bc40f/Makefile#L201) referenced in the issue.

## Test plan

- [x] `make docs-deps` installs mdbook (already cached locally; target verified)
- [x] `make docs` builds successfully and produces a complete `book/` site
- [x] `make docs-serve` renders Introduction + Consensus + Operations sections in the sidebar with correct ordering
- [x] Both infographics under `docs/infographics/` are reachable from the introduction page
- [ ] CI workflow for building / publishing the docs left as a follow-up