### PR TITLE
chore: parallelize fixture generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Generate test fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'
         working-directory: leanSpec
-        run: uv run fill --fork=Devnet --scheme prod -o fixtures -n 2
+        run: uv run fill --fork=Devnet --scheme prod -o fixtures -n auto
 
       # Save fixtures even if a later step fails, so a re-run does not
       # have to regenerate them. See: https://github.com/actions/cache/tree/main/save#always-save-cache

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ leanSpec:
 	cd leanSpec && git checkout $(LEAN_SPEC_COMMIT_HASH)
 
 leanSpec/fixtures: leanSpec
-	cd leanSpec && uv run fill --fork devnet --scheme=prod -o fixtures
+	cd leanSpec && uv run fill --fork devnet -n auto --scheme=prod -o fixtures
 
 lean-quickstart:
 	git clone https://github.com/blockblaz/lean-quickstart.git --depth 1 --single-branch


### PR DESCRIPTION
## 🗒️ Description / Motivation

This PR enables parallel fixture generation in the Makefile, and changes the CI to use auto-parallelization instead of a fixed 2.