### PR TITLE
feat(cli): default --attestation-committee-count from validator-config.yaml

### DIFF
--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -146,10 +146,16 @@ async fn main() -> eyre::Result<()> {
     populate_name_registry(&validator_config_file);
 
     // Resolve attestation_committee_count: CLI flag > validator-config.yaml > 1.
+    // The CLI path is bounded by clap's `range(1..)`; enforce the same lower
+    // bound here so a YAML value of 0 cannot bypass it.
     let attestation_committee_count = options
         .attestation_committee_count
         .or(validator_config_file.config.attestation_committee_count)
         .unwrap_or(1);
+    eyre::ensure!(
+        attestation_committee_count >= 1,
+        "attestation_committee_count must be >= 1 (got {attestation_committee_count})"
+    );
     info!(
         attestation_committee_count,
         "Loaded attestation committee count"

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -518,3 +518,96 @@ async fn fetch_initial_state(
     // Store the anchor state and header, without body
     Ok(Store::from_anchor_state(backend, state))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Validator-config snippet matching `lean-quickstart`'s ansible-devnet
+    /// (devnet-4) where networks share a non-default committee count.
+    const VC_WITH_COMMITTEE_COUNT: &str = r#"
+shuffle: roundrobin
+deployment_mode: ansible
+config:
+  activeEpoch: 18
+  keyType: "hash-sig"
+  attestation_committee_count: 2
+validators:
+  - name: "ethlambda_0"
+    privkey: "299550529a79bc2dce003747c52fb0639465c893e00b0440ac66144d625e066a"
+    enrFields:
+      ip: "127.0.0.1"
+      quic: 9001
+    metricsPort: 9095
+    apiPort: 5055
+    subnet: 0
+    isAggregator: false
+    count: 1
+"#;
+
+    /// Local-devnet snippet without the optional field — committee count is
+    /// expected to fall back to the binary default.
+    const VC_WITHOUT_COMMITTEE_COUNT: &str = r#"
+shuffle: roundrobin
+deployment_mode: local
+config:
+  activeEpoch: 18
+  keyType: "hash-sig"
+validators:
+  - name: "ethlambda_0"
+    privkey: "299550529a79bc2dce003747c52fb0639465c893e00b0440ac66144d625e066a"
+    enrFields:
+      ip: "127.0.0.1"
+      quic: 9001
+    metricsPort: 8087
+    apiPort: 5055
+    isAggregator: false
+    count: 1
+"#;
+
+    #[test]
+    fn parses_committee_count_when_present() {
+        let file: ValidatorConfigFile = serde_yaml_ng::from_str(VC_WITH_COMMITTEE_COUNT).unwrap();
+        assert_eq!(file.config.attestation_committee_count, Some(2));
+        assert_eq!(file.validators.len(), 1);
+        assert_eq!(file.validators[0].name, "ethlambda_0");
+    }
+
+    #[test]
+    fn defaults_to_none_when_field_absent() {
+        let file: ValidatorConfigFile =
+            serde_yaml_ng::from_str(VC_WITHOUT_COMMITTEE_COUNT).unwrap();
+        assert_eq!(file.config.attestation_committee_count, None);
+    }
+
+    #[test]
+    fn cli_overrides_file_value() {
+        let file: ValidatorConfigFile = serde_yaml_ng::from_str(VC_WITH_COMMITTEE_COUNT).unwrap();
+        let cli_override: Option<u64> = Some(5);
+        let resolved = cli_override
+            .or(file.config.attestation_committee_count)
+            .unwrap_or(1);
+        assert_eq!(resolved, 5);
+    }
+
+    #[test]
+    fn falls_back_to_file_when_cli_absent() {
+        let file: ValidatorConfigFile = serde_yaml_ng::from_str(VC_WITH_COMMITTEE_COUNT).unwrap();
+        let cli_override: Option<u64> = None;
+        let resolved = cli_override
+            .or(file.config.attestation_committee_count)
+            .unwrap_or(1);
+        assert_eq!(resolved, 2);
+    }
+
+    #[test]
+    fn falls_back_to_default_when_neither_set() {
+        let file: ValidatorConfigFile =
+            serde_yaml_ng::from_str(VC_WITHOUT_COMMITTEE_COUNT).unwrap();
+        let cli_override: Option<u64> = None;
+        let resolved = cli_override
+            .or(file.config.attestation_committee_count)
+            .unwrap_or(1);
+        assert_eq!(resolved, 1);
+    }
+}

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -76,9 +76,13 @@ struct CliOptions {
     /// use the admin endpoint to rotate duties (hot-standby model).
     #[arg(long, default_value = "false")]
     is_aggregator: bool,
-    /// Number of attestation committees (subnets) per slot
-    #[arg(long, default_value = "1", value_parser = clap::value_parser!(u64).range(1..))]
-    attestation_committee_count: u64,
+    /// Number of attestation committees (subnets) per slot.
+    ///
+    /// If unset, falls back to `config.attestation_committee_count` from
+    /// `validator-config.yaml` in the network config dir, or `1` if that
+    /// field is also absent.
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    attestation_committee_count: Option<u64>,
     /// Subnet IDs this aggregator should subscribe to (comma-separated).
     /// Requires --is-aggregator. Defaults to the subnets of the node's validators.
     #[arg(long, value_delimiter = ',', requires = "is_aggregator")]
@@ -102,9 +106,6 @@ async fn main() -> eyre::Result<()> {
     ethlambda_blockchain::metrics::init();
     ethlambda_blockchain::metrics::set_node_info("ethlambda", version::CLIENT_VERSION);
     ethlambda_blockchain::metrics::set_node_start_time();
-    ethlambda_blockchain::metrics::set_attestation_committee_count(
-        options.attestation_committee_count,
-    );
 
     let api_socket = SocketAddr::new(options.http_address, options.api_port);
     let metrics_socket = SocketAddr::new(options.http_address, options.metrics_port);
@@ -141,7 +142,31 @@ async fn main() -> eyre::Result<()> {
         "Loaded genesis configuration"
     );
 
-    populate_name_registry(&validator_config);
+    let validator_config_file = read_validator_config_file(&validator_config);
+    populate_name_registry(&validator_config_file);
+
+    // Resolve attestation_committee_count: CLI flag > validator-config.yaml > 1.
+    let attestation_committee_count = options
+        .attestation_committee_count
+        .or(validator_config_file.config.attestation_committee_count)
+        .unwrap_or(1);
+    info!(
+        attestation_committee_count,
+        source = if options.attestation_committee_count.is_some() {
+            "cli"
+        } else if validator_config_file
+            .config
+            .attestation_committee_count
+            .is_some()
+        {
+            "validator-config.yaml"
+        } else {
+            "default"
+        },
+        "Resolved attestation committee count"
+    );
+    ethlambda_blockchain::metrics::set_attestation_committee_count(attestation_committee_count);
+
     let bootnodes = read_bootnodes(&bootnodes_path);
 
     let validator_keys =
@@ -181,7 +206,7 @@ async fn main() -> eyre::Result<()> {
         bootnodes,
         listening_socket: p2p_socket,
         validator_ids,
-        attestation_committee_count: options.attestation_committee_count,
+        attestation_committee_count,
         is_aggregator: options.is_aggregator,
         aggregate_subnet_ids: options.aggregate_subnet_ids,
     })
@@ -223,25 +248,40 @@ async fn main() -> eyre::Result<()> {
     Ok(())
 }
 
-fn populate_name_registry(validator_config: impl AsRef<Path>) {
-    #[derive(Deserialize)]
-    struct Validator {
-        name: String,
-        privkey: H256,
-    }
-    #[derive(Deserialize)]
-    struct Config {
-        validators: Vec<Validator>,
-    }
-    let config_yaml =
-        std::fs::read_to_string(&validator_config).expect("Failed to read validator config file");
-    let config: Config =
-        serde_yaml_ng::from_str(&config_yaml).expect("Failed to parse validator config file");
+/// Subset of `validator-config.yaml` consumed by ethlambda.
+///
+/// The `config` block is a network-wide settings bag shared across clients;
+/// only fields ethlambda actually reads are deserialized. The `validators`
+/// list feeds the metrics name registry.
+#[derive(Debug, Deserialize)]
+struct ValidatorConfigFile {
+    #[serde(default)]
+    config: ValidatorConfigBlock,
+    validators: Vec<ValidatorConfigEntry>,
+}
 
-    let names_and_privkeys = config
+#[derive(Debug, Default, Deserialize)]
+struct ValidatorConfigBlock {
+    #[serde(default)]
+    attestation_committee_count: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValidatorConfigEntry {
+    name: String,
+    privkey: H256,
+}
+
+fn read_validator_config_file(path: impl AsRef<Path>) -> ValidatorConfigFile {
+    let yaml = std::fs::read_to_string(&path).expect("Failed to read validator config file");
+    serde_yaml_ng::from_str(&yaml).expect("Failed to parse validator config file")
+}
+
+fn populate_name_registry(file: &ValidatorConfigFile) {
+    let names_and_privkeys = file
         .validators
-        .into_iter()
-        .map(|v| (v.name, v.privkey))
+        .iter()
+        .map(|v| (v.name.clone(), v.privkey))
         .collect();
 
     // Populates a dictionary used for labeling metrics with node names

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -150,7 +150,10 @@ async fn main() -> eyre::Result<()> {
         .attestation_committee_count
         .or(validator_config_file.config.attestation_committee_count)
         .unwrap_or(1);
-    info!(attestation_committee_count, "Loaded attestation committee count");
+    info!(
+        attestation_committee_count,
+        "Loaded attestation committee count"
+    );
     ethlambda_blockchain::metrics::set_attestation_committee_count(attestation_committee_count);
 
     let bootnodes = read_bootnodes(&bootnodes_path);

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -150,21 +150,7 @@ async fn main() -> eyre::Result<()> {
         .attestation_committee_count
         .or(validator_config_file.config.attestation_committee_count)
         .unwrap_or(1);
-    info!(
-        attestation_committee_count,
-        source = if options.attestation_committee_count.is_some() {
-            "cli"
-        } else if validator_config_file
-            .config
-            .attestation_committee_count
-            .is_some()
-        {
-            "validator-config.yaml"
-        } else {
-            "default"
-        },
-        "Resolved attestation committee count"
-    );
+    info!(attestation_committee_count, "Loaded attestation committee count");
     ethlambda_blockchain::metrics::set_attestation_committee_count(attestation_committee_count);
 
     let bootnodes = read_bootnodes(&bootnodes_path);


### PR DESCRIPTION
## 🗒️ Description / Motivation
Make `--attestation-committee-count` optional and let it default to the
`config.attestation_committee_count` field already defined in
`validator-config.yaml` (the shared genesis bundle every Lean client
reads). Falls back to `1` when the field is also absent.

This lets multi-subnet networks like lean-quickstart's ansible-devnet
(which sets `attestation_committee_count: 2` in the bundle) drop the
per-client wrapper flag and rely on a single source of truth.

## What Changed
- `bin/ethlambda/src/main.rs`
  - `--attestation-committee-count` is now `Option<u64>` with no default.
  - New `ValidatorConfigFile` / `ValidatorConfigBlock` structs read the
    optional `config.attestation_committee_count` while parsing the file
    we already read for the metrics name registry.
  - Resolution order: **CLI flag > validator-config.yaml > 1**.
  - Logs the resolved value at startup.
  - 5 unit tests covering precedence and YAML shapes (with and without
    the field).

## Correctness / Behavior Guarantees
- Pre-existing CLI behavior preserved when `--attestation-committee-count`
  is supplied: same value, same metric, same swarm config.
- Lower bound (`1`) still enforced via clap's value parser.
- No change to the `SwarmConfig` API or downstream callers; only the
  binding site in `main` switches from a CLI default to the resolved
  value.

## Tests Added / Run
- `cargo test -p ethlambda --release` — 23 pass, including 5 new
  `tests::*` covering: file parses the field, defaults to `None` when
  absent, CLI overrides file, file fallback when CLI absent, default
  fallback when neither is set.
- `cargo clippy -p ethlambda --tests -- -D warnings` — clean.
- `cargo fmt --all` — clean.
- **Live runtime verification** with the branch's docker image, all
  three resolution paths fired and logged correctly:
  | Scenario | CLI flag | YAML field | Resolved |
  |---|---|---|---|
  | File path | (omitted) | `2` | **2** |
  | Default path | (omitted) | (absent) | **1** |
  | CLI override | `7` | `2` | **7** |
- **End-to-end devnet run** on `lean-quickstart` `devnet4` branch with
  the branch's image: 8/10 multi-client nodes up, ethlambda elected as
  subnet-0 aggregator, blocks produced/imported, `justified_slot=12
  vote_count=7 threshold=7`.

## Related Issues / PRs
- Mirrors the existing `attestationCommitteeCount` env wiring in
  `lean-quickstart/client-cmds/ethlambda-cmd.sh`; once this lands, the
  flag forwarding there can be retired in a follow-up.