### PR TITLE
feat(metrics): add lean_gossip_mesh_peers gauge

### DIFF
--- a/crates/common/metrics/src/lib.rs
+++ b/crates/common/metrics/src/lib.rs
@@ -6,8 +6,8 @@ pub mod timing;
 // Re-export prometheus types and macros we use
 pub use prometheus::{
     Encoder, Error as PrometheusError, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
-    TextEncoder, gather, register_histogram, register_int_counter, register_int_counter_vec,
-    register_int_gauge, register_int_gauge_vec,
+    TextEncoder, core::Collector, gather, register_histogram, register_int_counter,
+    register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
 };
 
 // Re-export commonly used items

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -198,6 +198,8 @@ pub fn update_gossip_mesh_peers<'a>(peers: impl Iterator<Item = &'a PeerId>) {
         }
     }
     for (name, count) in counts {
-        LEAN_GOSSIP_MESH_PEERS.with_label_values(&[&name]).set(count);
+        LEAN_GOSSIP_MESH_PEERS
+            .with_label_values(&[&name])
+            .set(count);
     }
 }

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -8,8 +8,8 @@ use std::{
 use ethlambda_metrics::*;
 use ethlambda_types::primitives::H256;
 use libp2p::{
-    identity::{secp256k1, Keypair},
     PeerId,
+    identity::{Keypair, secp256k1},
 };
 
 static NODE_NAME_REGISTRY: LazyLock<RwLock<HashMap<PeerId, &'static str>>> =

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -180,27 +180,24 @@ pub fn notify_peer_disconnected(peer_id: &Option<PeerId>, direction: &str, reaso
 
 /// Refresh the gossipsub mesh peers gauge from the current mesh peer set.
 pub fn update_gossip_mesh_peers<'a>(peers: impl Iterator<Item = &'a PeerId>) {
-    let mut counts: HashMap<&'static str, i64> = HashMap::new();
+    let mut counts: HashMap<String, i64> = HashMap::new();
     {
         let registry = NODE_NAME_REGISTRY.read().unwrap();
         for peer_id in peers {
             let name = registry.get(peer_id).copied().unwrap_or("unknown");
-            *counts.entry(name).or_default() += 1;
+            *counts.entry(name.to_string()).or_default() += 1;
         }
     }
-    // Zero out client labels that were published before but aren't in the
-    // current mesh, by enumerating the gauge's existing children.
+    // Seed previously-published labels with 0 so departed clients fall to
+    // zero in the single set() pass below.
     for family in LEAN_GOSSIP_MESH_PEERS.collect() {
         for metric in family.get_metric() {
             for label in metric.get_label() {
-                let value = label.value();
-                if !counts.contains_key(value) {
-                    LEAN_GOSSIP_MESH_PEERS.with_label_values(&[value]).set(0);
-                }
+                counts.entry(label.value().to_string()).or_insert(0);
             }
         }
     }
     for (name, count) in counts {
-        LEAN_GOSSIP_MESH_PEERS.with_label_values(&[name]).set(count);
+        LEAN_GOSSIP_MESH_PEERS.with_label_values(&[&name]).set(count);
     }
 }

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -8,8 +8,8 @@ use std::{
 use ethlambda_metrics::*;
 use ethlambda_types::primitives::H256;
 use libp2p::{
+    identity::{secp256k1, Keypair},
     PeerId,
-    identity::{Keypair, secp256k1},
 };
 
 static NODE_NAME_REGISTRY: LazyLock<RwLock<HashMap<PeerId, &'static str>>> =
@@ -50,6 +50,15 @@ static LEAN_CONNECTED_PEERS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+static LEAN_GOSSIP_MESH_PEERS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "lean_gossip_mesh_peers",
+        "Number of peers in the gossipsub mesh",
+        &["client"]
+    )
+    .unwrap()
+});
+
 static LEAN_PEER_CONNECTION_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         "lean_peer_connection_events_total",
@@ -64,15 +73,6 @@ static LEAN_PEER_DISCONNECTION_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock:
         "lean_peer_disconnection_events_total",
         "Total number of peer disconnection events",
         &["direction", "reason"]
-    )
-    .unwrap()
-});
-
-static LEAN_GOSSIP_MESH_PEERS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    register_int_gauge_vec!(
-        "lean_gossip_mesh_peers",
-        "Number of peers in the gossipsub mesh",
-        &["client"]
     )
     .unwrap()
 });
@@ -179,17 +179,27 @@ pub fn notify_peer_disconnected(peer_id: &Option<PeerId>, direction: &str, reaso
 }
 
 /// Refresh the gossipsub mesh peers gauge from the current mesh peer set.
-///
-/// Called periodically by the swarm adapter. The gauge is reset before
-/// re-population so client labels for peers no longer in the mesh drop
-/// off rather than retaining stale counts.
 pub fn update_gossip_mesh_peers<'a>(peers: impl Iterator<Item = &'a PeerId>) {
     let mut counts: HashMap<&'static str, i64> = HashMap::new();
-    for peer_id in peers {
-        let name = resolve(&Some(*peer_id));
-        *counts.entry(name).or_insert(0) += 1;
+    {
+        let registry = NODE_NAME_REGISTRY.read().unwrap();
+        for peer_id in peers {
+            let name = registry.get(peer_id).copied().unwrap_or("unknown");
+            *counts.entry(name).or_default() += 1;
+        }
     }
-    LEAN_GOSSIP_MESH_PEERS.reset();
+    // Zero out client labels that were published before but aren't in the
+    // current mesh, by enumerating the gauge's existing children.
+    for family in LEAN_GOSSIP_MESH_PEERS.collect() {
+        for metric in family.get_metric() {
+            for label in metric.get_label() {
+                let value = label.value();
+                if !counts.contains_key(value) {
+                    LEAN_GOSSIP_MESH_PEERS.with_label_values(&[value]).set(0);
+                }
+            }
+        }
+    }
     for (name, count) in counts {
         LEAN_GOSSIP_MESH_PEERS.with_label_values(&[name]).set(count);
     }

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -68,6 +68,15 @@ static LEAN_PEER_DISCONNECTION_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock:
     .unwrap()
 });
 
+static LEAN_GOSSIP_MESH_PEERS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "lean_gossip_mesh_peers",
+        "Number of peers in the gossipsub mesh",
+        &["client"]
+    )
+    .unwrap()
+});
+
 // --- Gossip Message Size Histograms ---
 
 static LEAN_GOSSIP_BLOCK_SIZE_BYTES: LazyLock<Histogram> = LazyLock::new(|| {
@@ -167,4 +176,21 @@ pub fn notify_peer_disconnected(peer_id: &Option<PeerId>, direction: &str, reaso
 
     let name = resolve(peer_id);
     LEAN_CONNECTED_PEERS.with_label_values(&[name]).dec();
+}
+
+/// Refresh the gossipsub mesh peers gauge from the current mesh peer set.
+///
+/// Called periodically by the swarm adapter. The gauge is reset before
+/// re-population so client labels for peers no longer in the mesh drop
+/// off rather than retaining stale counts.
+pub fn update_gossip_mesh_peers<'a>(peers: impl Iterator<Item = &'a PeerId>) {
+    let mut counts: HashMap<&'static str, i64> = HashMap::new();
+    for peer_id in peers {
+        let name = resolve(&Some(*peer_id));
+        *counts.entry(name).or_insert(0) += 1;
+    }
+    LEAN_GOSSIP_MESH_PEERS.reset();
+    for (name, count) in counts {
+        LEAN_GOSSIP_MESH_PEERS.with_label_values(&[name]).set(count);
+    }
 }

--- a/crates/net/p2p/src/swarm_adapter.rs
+++ b/crates/net/p2p/src/swarm_adapter.rs
@@ -12,10 +12,7 @@ use tracing::{error, warn};
 use crate::{Behaviour, BehaviourEvent, metrics, req_resp::Request, req_resp::Response};
 
 /// Interval between gossipsub mesh peer metric refreshes.
-///
-/// Slightly slower than the gossipsub heartbeat (700ms) so the gauge
-/// reflects post-heartbeat mesh state with minimal polling overhead.
-const MESH_METRIC_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const MESH_METRIC_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 
 pub enum SwarmCommand {
     Publish {

--- a/crates/net/p2p/src/swarm_adapter.rs
+++ b/crates/net/p2p/src/swarm_adapter.rs
@@ -1,13 +1,21 @@
+use std::time::Duration;
+
 use libp2p::{
     Multiaddr, PeerId, StreamProtocol,
     futures::StreamExt,
     request_response::{self, OutboundRequestId},
     swarm::SwarmEvent,
 };
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::MissedTickBehavior};
 use tracing::{error, warn};
 
-use crate::{Behaviour, BehaviourEvent, req_resp::Request, req_resp::Response};
+use crate::{Behaviour, BehaviourEvent, metrics, req_resp::Request, req_resp::Response};
+
+/// Interval between gossipsub mesh peer metric refreshes.
+///
+/// Slightly slower than the gossipsub heartbeat (700ms) so the gauge
+/// reflects post-heartbeat mesh state with minimal polling overhead.
+const MESH_METRIC_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 pub enum SwarmCommand {
     Publish {
@@ -106,6 +114,8 @@ async fn swarm_loop(
     event_tx: mpsc::UnboundedSender<SwarmEvent<BehaviourEvent>>,
     mut cmd_rx: mpsc::UnboundedReceiver<SwarmCommand>,
 ) {
+    let mut mesh_metric_tick = tokio::time::interval(MESH_METRIC_REFRESH_INTERVAL);
+    mesh_metric_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
         tokio::select! {
             event = swarm.next() => {
@@ -115,6 +125,11 @@ async fn swarm_loop(
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else { break };
                 execute_command(&mut swarm, cmd);
+            }
+            _ = mesh_metric_tick.tick() => {
+                metrics::update_gossip_mesh_peers(
+                    swarm.behaviour().gossipsub.all_mesh_peers(),
+                );
             }
         }
     }


### PR DESCRIPTION
## 🗒️ Description / Motivation

Implements the `lean_gossip_mesh_peers` metric introduced in [leanMetrics PR #35](https://github.com/leanEthereum/leanMetrics/pull/35).

This is a `Gauge` that exposes the number of peers currently in our gossipsub mesh, broken down by `client` label. It complements the existing `lean_connected_peers` gauge: connected peers are nodes we have an active libp2p connection to, while mesh peers are the smaller subset gossipsub has selected as full-message neighbours.

The `client` label uses the same `<name>_<N>|unknown` resolution as `lean_connected_peers` (handled by the existing `resolve()` helper in `crates/net/p2p/src/metrics.rs`), so PR #35's label-format clarification needed no code changes — only the new gauge.

## What Changed

- `crates/net/p2p/src/metrics.rs`
  - Register `LEAN_GOSSIP_MESH_PEERS: IntGaugeVec` with the `client` label.
  - Add `update_gossip_mesh_peers(peers)`: groups peers by resolved client name (acquiring the `NODE_NAME_REGISTRY` read lock once for the batch). To avoid the scrape-window gap that an `IntGaugeVec::reset()` + repopulate would leave between writes, the function instead enumerates currently-registered children via `Collector::collect()` and `set(0)` for any client labels no longer in the mesh, then writes the new counts. Each `set()` is a single registry write, so a concurrent Prometheus scrape always observes a coherent label set.
- `crates/common/metrics/src/lib.rs`
  - Re-export `prometheus::core::Collector` so consumers can enumerate existing label children.
- `crates/net/p2p/src/swarm_adapter.rs`
  - Add a `tokio::time::interval` (10 s, `MissedTickBehavior::Skip`) arm to the `swarm_loop` `tokio::select!`. On each tick it reads `swarm.behaviour().gossipsub.all_mesh_peers()` and pushes counts into the gauge.

## Correctness / Behavior Guarantees

- **No state changes on the network/consensus path.** The new code only reads `gossipsub.all_mesh_peers()` (a `BTreeSet` iteration) and writes to a Prometheus registry; it cannot affect block propagation, fork choice, or attestation handling.
- **Scrape-stable updates.** Departed client labels are written as `set(0)` rather than removed via `reset()`, so a Prometheus scrape between writes always sees a complete (non-empty) label set. Alerting rules like `lean_gossip_mesh_peers > 0` see continuous time series instead of vanishing labels.
- **No starvation of swarm/cmd events.** The new arm shares the `tokio::select!` with the swarm event and command receiver, with `MissedTickBehavior::Skip` to avoid backlogging metric refreshes if the swarm loop is busy. Polling cost is one short iterator pass per 10 s over the mesh peer set (typically <50 peers).
- **Polling rationale.** Mesh membership changes inside gossipsub heartbeats (700 ms) and is not surfaced as a `BehaviourEvent`, so an event-driven update is not possible without forking the gossipsub behaviour. 10 s polling bounds scrape staleness while keeping overhead negligible.

## Tests Added / Run

The change is operational (Prometheus gauge update): no new unit tests were added because there's no observable behaviour outside the metrics endpoint and the gauge update is exercised by every devnet run.

Verification commands:

- `cargo check -p ethlambda-p2p` — clean
- `make fmt` — clean
- `make lint` (clippy with `-D warnings`) — clean
- `cargo test --workspace --release` — all passing

Devnet verification (4 ethlambda nodes, local image):

- All 4 nodes published `lean_gossip_mesh_peers{client="ethlambda_N"} = 1` for each peer once mesh formed.
- After `docker stop ethlambda_3`, surviving nodes' `lean_gossip_mesh_peers{client="ethlambda_3"}` dropped to `0` within ~6 s instead of disappearing — confirming scrape-stable behavior.

## Related Issues / PRs

- Implements the `lean_gossip_mesh_peers` metric from leanEthereum/leanMetrics#35