### PR TITLE
handle same port values for API and metrics endpoints

### DIFF
--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -108,8 +108,6 @@ async fn main() -> eyre::Result<()> {
         options.attestation_committee_count,
     );
 
-    // let api_socket = SocketAddr::new(options.http_address, options.api_port);
-    // let metrics_socket = SocketAddr::new(options.http_address, options.metrics_port);
     let node_p2p_key = read_hex_file_bytes(&options.node_key);
     let p2p_socket = SocketAddr::new(IpAddr::from([0, 0, 0, 0]), options.gossipsub_port);
     let rpc_config = RpcConfig {

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -35,6 +35,7 @@ use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt};
 
 use ethlambda_blockchain::BlockChain;
 use ethlambda_storage::{StorageBackend, Store, backend::RocksDBBackend};
+use ethlambda_rpc::{RpcConfig};
 
 const ASCII_ART: &str = r#"
       _   _     _                 _         _
@@ -107,10 +108,15 @@ async fn main() -> eyre::Result<()> {
         options.attestation_committee_count,
     );
 
-    let api_socket = SocketAddr::new(options.http_address, options.api_port);
-    let metrics_socket = SocketAddr::new(options.http_address, options.metrics_port);
+    // let api_socket = SocketAddr::new(options.http_address, options.api_port);
+    // let metrics_socket = SocketAddr::new(options.http_address, options.metrics_port);
     let node_p2p_key = read_hex_file_bytes(&options.node_key);
     let p2p_socket = SocketAddr::new(IpAddr::from([0, 0, 0, 0]), options.gossipsub_port);
+    let rpc_config = RpcConfig {
+      http_address: options.http_address,
+      api_port: options.api_port,
+      metrics_port: options.metrics_port,
+  };
 
     println!("{ASCII_ART}");
 
@@ -205,6 +211,7 @@ async fn main() -> eyre::Result<()> {
         })
         .inspect_err(|err| error!(%err, "Failed to send InitBlockChain — actors not wired"))?;
 
+<<<<<<< Updated upstream
     let shutdown_token = CancellationToken::new();
     let metrics_shutdown = shutdown_token.clone();
     let api_shutdown = shutdown_token.clone();
@@ -218,6 +225,23 @@ async fn main() -> eyre::Result<()> {
         let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator, api_shutdown)
             .await
             .inspect_err(|err| error!(%err, "API server failed"));
+=======
+    // tokio::spawn(async move {
+    //     let _ = ethlambda_rpc::start_metrics_server(metrics_socket)
+    //         .await
+    //         .inspect_err(|err| error!(%err, "Metrics server failed"));
+    // });
+    // tokio::spawn(async move {
+    //     let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator)
+    //         .await
+    //         .inspect_err(|err| error!(%err, "API server failed"));
+    // });
+
+    tokio::spawn(async move {
+        let _ = ethlambda_rpc::start_rpc_server(rpc_config, store, aggregator)
+            .await
+            .inspect_err(|err| error!(%err, "rpc server failed"));
+>>>>>>> Stashed changes
     });
 
     info!("Node initialized");

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -35,7 +35,7 @@ use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt};
 
 use ethlambda_blockchain::BlockChain;
 use ethlambda_storage::{StorageBackend, Store, backend::RocksDBBackend};
-use ethlambda_rpc::{RpcConfig};
+use ethlambda_rpc::RpcConfig;
 
 const ASCII_ART: &str = r#"
       _   _     _                 _         _

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -113,10 +113,10 @@ async fn main() -> eyre::Result<()> {
     let node_p2p_key = read_hex_file_bytes(&options.node_key);
     let p2p_socket = SocketAddr::new(IpAddr::from([0, 0, 0, 0]), options.gossipsub_port);
     let rpc_config = RpcConfig {
-      http_address: options.http_address,
-      api_port: options.api_port,
-      metrics_port: options.metrics_port,
-  };
+        http_address: options.http_address,
+        api_port: options.api_port,
+        metrics_port: options.metrics_port,
+    };
 
     println!("{ASCII_ART}");
 
@@ -211,37 +211,13 @@ async fn main() -> eyre::Result<()> {
         })
         .inspect_err(|err| error!(%err, "Failed to send InitBlockChain — actors not wired"))?;
 
-<<<<<<< Updated upstream
     let shutdown_token = CancellationToken::new();
-    let metrics_shutdown = shutdown_token.clone();
-    let api_shutdown = shutdown_token.clone();
+    let rpc_shutdown = shutdown_token.clone();
 
-    let metrics_handle = tokio::spawn(async move {
-        let _ = ethlambda_rpc::start_metrics_server(metrics_socket, metrics_shutdown)
+    let rpc_handle = tokio::spawn(async move {
+        let _ = ethlambda_rpc::start_rpc_server(rpc_config, store, aggregator, rpc_shutdown)
             .await
-            .inspect_err(|err| error!(%err, "Metrics server failed"));
-    });
-    let api_handle = tokio::spawn(async move {
-        let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator, api_shutdown)
-            .await
-            .inspect_err(|err| error!(%err, "API server failed"));
-=======
-    // tokio::spawn(async move {
-    //     let _ = ethlambda_rpc::start_metrics_server(metrics_socket)
-    //         .await
-    //         .inspect_err(|err| error!(%err, "Metrics server failed"));
-    // });
-    // tokio::spawn(async move {
-    //     let _ = ethlambda_rpc::start_api_server(api_socket, store, aggregator)
-    //         .await
-    //         .inspect_err(|err| error!(%err, "API server failed"));
-    // });
-
-    tokio::spawn(async move {
-        let _ = ethlambda_rpc::start_rpc_server(rpc_config, store, aggregator)
-            .await
-            .inspect_err(|err| error!(%err, "rpc server failed"));
->>>>>>> Stashed changes
+            .inspect_err(|err| error!(%err, "RPC server failed"));
     });
 
     info!("Node initialized");
@@ -274,8 +250,7 @@ async fn main() -> eyre::Result<()> {
 
     blockchain_ref.join().await;
     p2p_ref.join().await;
-    let _ = api_handle.await;
-    let _ = metrics_handle.await;
+    let _ = rpc_handle.await;
 
     info!("Shutdown complete");
 

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -34,8 +34,8 @@ use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, Layer, Registry, layer::SubscriberExt};
 
 use ethlambda_blockchain::BlockChain;
-use ethlambda_storage::{StorageBackend, Store, backend::RocksDBBackend};
 use ethlambda_rpc::RpcConfig;
+use ethlambda_storage::{StorageBackend, Store, backend::RocksDBBackend};
 
 const ASCII_ART: &str = r#"
       _   _     _                 _         _

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use axum::{
     Extension, Json, Router, http::HeaderValue, http::header, response::IntoResponse, routing::get,
@@ -17,6 +17,7 @@ mod fork_choice;
 mod heap_profiling;
 pub mod metrics;
 
+<<<<<<< Updated upstream
 pub async fn start_api_server(
     address: SocketAddr,
     store: Store,
@@ -50,6 +51,35 @@ pub async fn start_metrics_server(
             shutdown.cancelled().await;
         })
         .await?;
+=======
+pub struct RpcConfig {
+    pub http_address: IpAddr,
+    pub api_port: u16,
+    pub metrics_port: u16,
+}
+
+pub async fn start_rpc_server(config: RpcConfig, store: Store, aggregator: AggregatorController) -> Result<(), std::io::Error> {
+    let api_router = build_api_router(store).layer(Extension(aggregator));
+    let metrics_router = metrics::start_prometheus_metrics_api();
+    let debug_router = build_debug_router();
+
+    if config.api_port == config.metrics_port {
+        let app = Router::new().merge(api_router).merge(metrics_router).merge(debug_router);
+        let addr = SocketAddr::new(config.http_address, config.api_port);
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, app).await?;
+    } else {
+        let api_addr = SocketAddr::new(config.http_address, config.api_port);
+        let metrics_addr = SocketAddr::new(config.http_address, config.metrics_port);
+        let api_listener = tokio::net::TcpListener::bind(api_addr).await?;
+        let metrics_listener = tokio::net::TcpListener::bind(metrics_addr).await?;
+        let metrics_app = Router::new().merge(metrics_router).merge(debug_router);
+        tokio::try_join!(
+            axum::serve(api_listener, api_router),
+            axum::serve(metrics_listener, metrics_app),
+        )?;
+    }
+>>>>>>> Stashed changes
 
     Ok(())
 }

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -17,48 +17,18 @@ mod fork_choice;
 mod heap_profiling;
 pub mod metrics;
 
-<<<<<<< Updated upstream
-pub async fn start_api_server(
-    address: SocketAddr,
-    store: Store,
-    aggregator: AggregatorController,
-    shutdown: CancellationToken,
-) -> Result<(), std::io::Error> {
-    let api_router = build_api_router(store).layer(Extension(aggregator));
-
-    let listener = tokio::net::TcpListener::bind(address).await?;
-    axum::serve(listener, api_router)
-        .with_graceful_shutdown(async move {
-            shutdown.cancelled().await;
-        })
-        .await?;
-
-    Ok(())
-}
-
-pub async fn start_metrics_server(
-    address: SocketAddr,
-    shutdown: CancellationToken,
-) -> Result<(), std::io::Error> {
-    let metrics_router = metrics::start_prometheus_metrics_api();
-    let debug_router = build_debug_router();
-
-    let app = Router::new().merge(metrics_router).merge(debug_router);
-
-    let listener = tokio::net::TcpListener::bind(address).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            shutdown.cancelled().await;
-        })
-        .await?;
-=======
 pub struct RpcConfig {
     pub http_address: IpAddr,
     pub api_port: u16,
     pub metrics_port: u16,
 }
 
-pub async fn start_rpc_server(config: RpcConfig, store: Store, aggregator: AggregatorController) -> Result<(), std::io::Error> {
+pub async fn start_rpc_server(
+    config: RpcConfig,
+    store: Store,
+    aggregator: AggregatorController,
+    shutdown: CancellationToken,
+) -> Result<(), std::io::Error> {
     let api_router = build_api_router(store).layer(Extension(aggregator));
     let metrics_router = metrics::start_prometheus_metrics_api();
     let debug_router = build_debug_router();
@@ -67,19 +37,27 @@ pub async fn start_rpc_server(config: RpcConfig, store: Store, aggregator: Aggre
         let app = Router::new().merge(api_router).merge(metrics_router).merge(debug_router);
         let addr = SocketAddr::new(config.http_address, config.api_port);
         let listener = tokio::net::TcpListener::bind(addr).await?;
-        axum::serve(listener, app).await?;
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown.cancelled().await;
+            })
+            .await?;
     } else {
         let api_addr = SocketAddr::new(config.http_address, config.api_port);
         let metrics_addr = SocketAddr::new(config.http_address, config.metrics_port);
         let api_listener = tokio::net::TcpListener::bind(api_addr).await?;
         let metrics_listener = tokio::net::TcpListener::bind(metrics_addr).await?;
         let metrics_app = Router::new().merge(metrics_router).merge(debug_router);
+        let metrics_shutdown = shutdown.clone();
         tokio::try_join!(
-            axum::serve(api_listener, api_router),
-            axum::serve(metrics_listener, metrics_app),
+            axum::serve(api_listener, api_router).with_graceful_shutdown(async move {
+                shutdown.cancelled().await;
+            }),
+            axum::serve(metrics_listener, metrics_app).with_graceful_shutdown(async move {
+                metrics_shutdown.cancelled().await;
+            }),
         )?;
     }
->>>>>>> Stashed changes
 
     Ok(())
 }

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -17,6 +17,7 @@ mod fork_choice;
 mod heap_profiling;
 pub mod metrics;
 
+#[derive(Debug, Clone)]
 pub struct RpcConfig {
     pub http_address: IpAddr,
     pub api_port: u16,
@@ -34,7 +35,10 @@ pub async fn start_rpc_server(
     let debug_router = build_debug_router();
 
     if config.api_port == config.metrics_port {
-        let app = Router::new().merge(api_router).merge(metrics_router).merge(debug_router);
+        let app = Router::new()
+            .merge(api_router)
+            .merge(metrics_router)
+            .merge(debug_router);
         let addr = SocketAddr::new(config.http_address, config.api_port);
         let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(listener, app)
@@ -65,7 +69,7 @@ pub async fn start_rpc_server(
 /// Build the API router with the given store.
 ///
 /// The aggregator controller is threaded in via `Extension` by the caller
-/// (see `start_api_server`) so existing store-backed handlers don't need to
+/// (see `start_rpc_server`) so existing store-backed handlers don't need to
 /// know about it and admin handlers extract it independently.
 fn build_api_router(store: Store) -> Router {
     Router::new()


### PR DESCRIPTION
## 🗒️ Description

merged both `start_metrics_server` and `start_api_server` functions into one `start_rpc_server` receiving `RpcConfig` struct:

```
pub struct RpcConfig {
    pub http_address: IpAddr,
    pub api_port: u16,
    pub metrics_port: u16,
}
```
while in that single function, handling whether to merge both API and metrics routers into a single endpoint if specified ports (API and metrics) are the same, or just start two separate servers as before if different ports were chosen.

## What Changed
- `crates/net/rpc/src/lib.rs`: new struct `RpcConfig`, `start_metrics_server` and `start_api_server` replaced with a single `start_rpc_server`.
- `bin/ethlambda/src/main.rs`: import `RpcConfig` and update callers.

## Related Issues / PRs
- Closes #329 
