### PR TITLE
fix(p2p): remove legacy step field from BlocksByRange request

### DIFF
--- a/crates/net/p2p/src/req_resp/handlers.rs
+++ b/crates/net/p2p/src/req_resp/handlers.rs
@@ -156,11 +156,10 @@ async fn handle_blocks_by_range_request(
         %peer,
         start_slot = request.start_slot,
         count = request.count,
-        step = request.step,
         "Received BlocksByRange request"
     );
 
-    if request.step == 0 || request.count == 0 || request.count > MAX_REQUEST_BLOCKS {
+    if request.count == 0 || request.count > MAX_REQUEST_BLOCKS {
         let response = Response::error(
             ResponseCode::INVALID_REQUEST,
             error_message("invalid BlocksByRange request"),
@@ -169,18 +168,12 @@ async fn handle_blocks_by_range_request(
         return;
     }
 
-    let blocks = canonical_blocks_by_range(
-        &server.store,
-        request.start_slot,
-        request.count,
-        request.step,
-    );
+    let blocks = canonical_blocks_by_range(&server.store, request.start_slot, request.count);
 
     info!(
         %peer,
         start_slot = request.start_slot,
         count = request.count,
-        step = request.step,
         found = blocks.len(),
         "Responding to BlocksByRange request"
     );
@@ -189,19 +182,13 @@ async fn handle_blocks_by_range_request(
     server.swarm_handle.send_response(channel, response);
 }
 
-fn canonical_blocks_by_range(
-    store: &Store,
-    start_slot: u64,
-    count: u64,
-    step: u64,
-) -> Vec<SignedBlock> {
+fn canonical_blocks_by_range(store: &Store, start_slot: u64, count: u64) -> Vec<SignedBlock> {
     if count == 0 {
         return Vec::new();
     }
 
     let Some(end_slot) = count
         .checked_sub(1)
-        .and_then(|value| value.checked_mul(step))
         .and_then(|last_offset| start_slot.checked_add(last_offset))
     else {
         return Vec::new();
@@ -219,16 +206,15 @@ fn canonical_blocks_by_range(
             break;
         }
 
-        if header.slot <= end_slot && (header.slot - start_slot).is_multiple_of(step) {
+        if header.slot <= end_slot {
             roots_by_slot.insert(header.slot, current_root);
         }
 
         current_root = header.parent_root;
     }
 
-    (0..count)
-        .filter_map(|index| {
-            let slot = start_slot.checked_add(index.checked_mul(step)?)?;
+    (start_slot..=end_slot)
+        .filter_map(|slot| {
             let root = roots_by_slot.get(&slot)?;
             store.get_signed_block(root)
         })
@@ -460,7 +446,7 @@ mod tests {
         store.insert_signed_block(root_4, block_4);
         store.update_checkpoints(ForkCheckpoints::head_only(root_4));
 
-        let blocks = canonical_blocks_by_range(&store, 1, 4, 1);
+        let blocks = canonical_blocks_by_range(&store, 1, 4);
         let slots: Vec<_> = blocks.iter().map(|block| block.message.slot).collect();
         let roots: Vec<_> = blocks
             .iter()

--- a/crates/net/p2p/src/req_resp/messages.rs
+++ b/crates/net/p2p/src/req_resp/messages.rs
@@ -136,5 +136,4 @@ pub struct BlocksByRootRequest {
 pub struct BlocksByRangeRequest {
     pub start_slot: u64,
     pub count: u64,
-    pub step: u64,
 }


### PR DESCRIPTION
## Summary

- Drop the legacy phase-0 `step: u64` field from `BlocksByRangeRequest`. The leanSpec container has only `(start_slot, count)`; `step` was deprecated in Altair and explicitly omitted from the lean spec.
- Without this fix, SSZ decode requires 24 bytes while peers (and the ethereum/hive lean simulator) send the spec-compliant 16-byte encoding, so every inbound BlocksByRange request fails to decode before reaching the handler.
- Remove the now-dead `step == 0` validation and simplify `canonical_blocks_by_range` to walk contiguous slots; update the existing unit test to the new signature.

## Test plan

- [x] `cargo test -p ethlambda-p2p`
- [x] Verified against hive's `reqresp/blocks_by_range` suite: all 4 tests pass (previously hung at fixture timeout because the SSZ decode error prevented any response).