### PR TITLE
fix(blockchain): allow older-but-justified sources in `build_block`

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1055,17 +1055,6 @@ fn build_block(
         let mut current_finalized_slot = head_state.latest_finalized.slot;
         let mut current_justified_slots = head_state.justified_slots.clone();
 
-        // Chain view that `process_block_header` would produce on the candidate
-        // block: covering [0, slot - 1] with parent_root at parent.slot and
-        // ZERO_HASH for empty slots in between. Lets us validate source/target
-        // roots without waiting for the STF to drop mismatches.
-        let parent_slot = head_state.latest_block_header.slot;
-        let num_empty_slots = slot.saturating_sub(parent_slot).saturating_sub(1) as usize;
-        let mut extended_historical_block_hashes: Vec<H256> =
-            head_state.historical_block_hashes.iter().copied().collect();
-        extended_historical_block_hashes.push(parent_root);
-        extended_historical_block_hashes.extend(std::iter::repeat_n(H256::ZERO, num_empty_slots));
-
         let mut processed_data_roots: HashSet<H256> = HashSet::new();
 
         // Sort by target.slot to match the spec's processing order.
@@ -1094,7 +1083,11 @@ fn build_block(
                     continue;
                 }
 
-                if !attestation_data_matches_chain(&extended_historical_block_hashes, att_data) {
+                if !attestation_data_matches_chain(
+                    &head_state.historical_block_hashes,
+                    Some(parent_root),
+                    att_data,
+                ) {
                     continue;
                 }
 

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1055,6 +1055,17 @@ fn build_block(
         let mut current_finalized_slot = head_state.latest_finalized.slot;
         let mut current_justified_slots = head_state.justified_slots.clone();
 
+        // Chain view that `process_block_header` would produce on the candidate
+        // block: covering [0, slot - 1] with parent_root at parent.slot and
+        // ZERO_HASH for empty slots in between. Lets us validate source/target
+        // roots without waiting for the STF to drop mismatches.
+        let parent_slot = head_state.latest_block_header.slot;
+        let num_empty_slots = slot.saturating_sub(parent_slot).saturating_sub(1) as usize;
+        let mut extended_historical_block_hashes: Vec<H256> =
+            head_state.historical_block_hashes.iter().copied().collect();
+        extended_historical_block_hashes.push(parent_root);
+        extended_historical_block_hashes.extend(std::iter::repeat_n(H256::ZERO, num_empty_slots));
+
         let mut processed_data_roots: HashSet<H256> = HashSet::new();
 
         // Sort by target.slot to match the spec's processing order.
@@ -1083,11 +1094,7 @@ fn build_block(
                     continue;
                 }
 
-                if !attestation_data_matches_chain(
-                    &head_state.historical_block_hashes,
-                    Some(parent_root),
-                    att_data,
-                ) {
+                if !attestation_data_matches_chain(&extended_historical_block_hashes, att_data) {
                     continue;
                 }
 

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1060,7 +1060,7 @@ fn build_block(
         // ZERO_HASH for empty slots in between. Lets us validate source/target
         // roots without waiting for the STF to drop mismatches.
         let parent_slot = head_state.latest_block_header.slot;
-        let num_empty_slots = (slot - parent_slot - 1) as usize;
+        let num_empty_slots = slot.saturating_sub(parent_slot).saturating_sub(1) as usize;
         let mut extended_historical_block_hashes: Vec<H256> =
             head_state.historical_block_hashes.iter().copied().collect();
         extended_historical_block_hashes.push(parent_root);
@@ -1086,11 +1086,11 @@ fn build_block(
                 if !known_block_roots.contains(&att_data.head.root) {
                     continue;
                 }
-                // Relaxed source check (leanSpec #716): accept any source whose
-                // slot is at or before the head chain's latest justified slot,
-                // not just an exact-match checkpoint. Lets us absorb gap-closing
-                // attestations from sibling forks that justified earlier slots.
-                if att_data.source.slot > current_justified.slot {
+                if !justified_slots_ops::is_slot_justified(
+                    &current_justified_slots,
+                    current_finalized_slot,
+                    att_data.source.slot,
+                ) {
                     continue;
                 }
 

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -2,7 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use ethlambda_crypto::aggregate_proofs;
 use ethlambda_state_transition::{
-    is_proposer, process_block, process_slots, slot_is_justifiable_after,
+    attestation_data_matches_chain, is_proposer, justified_slots_ops, process_block, process_slots,
+    slot_is_justifiable_after,
 };
 use ethlambda_storage::{ForkCheckpoints, Store};
 use ethlambda_types::{
@@ -1050,17 +1051,20 @@ fn build_block(
     let mut selected: Vec<(AggregatedAttestation, AggregatedSignatureProof)> = Vec::new();
 
     if !aggregated_payloads.is_empty() {
-        // Genesis edge case: when building on genesis (slot 0),
-        // process_block_header will set latest_justified.root = parent_root.
-        // Derive this upfront so attestation filtering matches.
-        let mut current_justified = if head_state.latest_block_header.slot == 0 {
-            Checkpoint {
-                root: parent_root,
-                slot: head_state.latest_justified.slot,
-            }
-        } else {
-            head_state.latest_justified
-        };
+        let mut current_justified = head_state.latest_justified;
+        let mut current_finalized_slot = head_state.latest_finalized.slot;
+        let mut current_justified_slots = head_state.justified_slots.clone();
+
+        // Chain view that `process_block_header` would produce on the candidate
+        // block: covering [0, slot - 1] with parent_root at parent.slot and
+        // ZERO_HASH for empty slots in between. Lets us validate source/target
+        // roots without waiting for the STF to drop mismatches.
+        let parent_slot = head_state.latest_block_header.slot;
+        let num_empty_slots = (slot - parent_slot - 1) as usize;
+        let mut extended_historical_block_hashes: Vec<H256> =
+            head_state.historical_block_hashes.iter().copied().collect();
+        extended_historical_block_hashes.push(parent_root);
+        extended_historical_block_hashes.extend(std::iter::repeat_n(H256::ZERO, num_empty_slots));
 
         let mut processed_data_roots: HashSet<H256> = HashSet::new();
 
@@ -1082,7 +1086,30 @@ fn build_block(
                 if !known_block_roots.contains(&att_data.head.root) {
                     continue;
                 }
-                if att_data.source != current_justified {
+                // Relaxed source check (leanSpec #716): accept any source whose
+                // slot is at or before the head chain's latest justified slot,
+                // not just an exact-match checkpoint. Lets us absorb gap-closing
+                // attestations from sibling forks that justified earlier slots.
+                if att_data.source.slot > current_justified.slot {
+                    continue;
+                }
+
+                if !attestation_data_matches_chain(&extended_historical_block_hashes, att_data) {
+                    continue;
+                }
+
+                // Skip attestations whose target slot is already justified on
+                // this chain (they wouldn't change post-state). Allow the
+                // genesis self-vote (source=target=0) for fork-choice
+                // bootstrapping.
+                let is_genesis_self_vote = att_data.source.slot == 0 && att_data.target.slot == 0;
+                if !is_genesis_self_vote
+                    && justified_slots_ops::is_slot_justified(
+                        &current_justified_slots,
+                        current_finalized_slot,
+                        att_data.target.slot,
+                    )
+                {
                     continue;
                 }
 
@@ -1096,7 +1123,7 @@ fn build_block(
                 break;
             }
 
-            // Check if justification advanced
+            // Check if justification or finalization advanced
             let attestations: AggregatedAttestations = selected
                 .iter()
                 .map(|(att, _)| att.clone())
@@ -1114,8 +1141,12 @@ fn build_block(
             process_slots(&mut post_state, slot)?;
             process_block(&mut post_state, &candidate)?;
 
-            if post_state.latest_justified != current_justified {
+            if post_state.latest_justified != current_justified
+                || post_state.latest_finalized.slot != current_finalized_slot
+            {
                 current_justified = post_state.latest_justified;
+                current_justified_slots = post_state.justified_slots.clone();
+                current_finalized_slot = post_state.latest_finalized.slot;
                 // Continue: new checkpoint may unlock more attestation data
             } else {
                 break;
@@ -1396,6 +1427,10 @@ mod tests {
     /// at MAX_ATTESTATIONS_DATA (16) and stays under the gossip size limit.
     #[test]
     fn build_block_caps_attestation_data_entries() {
+        use ethlambda_types::{
+            block::BlockHeader,
+            state::{ChainConfig, JustificationValidators, JustifiedSlots},
+        };
         use libssz::SszEncode;
         use libssz_types::SszList;
 
@@ -1404,7 +1439,9 @@ mod tests {
         const NUM_VALIDATORS: usize = 50;
         const NUM_PAYLOAD_ENTRIES: usize = 50;
 
-        // Create genesis state with NUM_VALIDATORS validators.
+        const HEAD_SLOT: u64 = 51;
+        const TARGET_SLOT: u64 = 5;
+
         let validators: Vec<_> = (0..NUM_VALIDATORS)
             .map(|i| ethlambda_types::state::Validator {
                 attestation_pubkey: [i as u8; 52],
@@ -1412,47 +1449,75 @@ mod tests {
                 index: i as u64,
             })
             .collect();
-        let head_state = State::from_genesis(1000, validators);
 
-        // process_slots fills in the genesis header's state_root before
+        // Build a head state at slot HEAD_SLOT with valid historical_block_hashes
+        // so attestations referencing in-range slots match the chain (the
+        // chain-match check in build_block now rejects mismatches).
+        let hashes: Vec<H256> = (0..HEAD_SLOT).map(|i| H256([(i + 1) as u8; 32])).collect();
+        let historical_block_hashes = SszList::try_from(hashes.clone()).unwrap();
+
+        let head_header = BlockHeader {
+            slot: HEAD_SLOT,
+            proposer_index: 0,
+            parent_root: H256::ZERO,
+            state_root: H256::ZERO,
+            body_root: BlockBody::default().hash_tree_root(),
+        };
+
+        let head_state = State {
+            config: ChainConfig { genesis_time: 1000 },
+            slot: HEAD_SLOT,
+            latest_block_header: head_header,
+            latest_justified: Checkpoint::default(),
+            latest_finalized: Checkpoint::default(),
+            historical_block_hashes,
+            justified_slots: JustifiedSlots::new(),
+            validators: SszList::try_from(validators).unwrap(),
+            justifications_roots: Default::default(),
+            justifications_validators: JustificationValidators::new(),
+        };
+
+        // process_slots fills in the parent header's state_root before
         // process_block_header computes the parent hash. Simulate that here.
         let mut header_for_root = head_state.latest_block_header.clone();
         header_for_root.state_root = head_state.hash_tree_root();
         let parent_root = header_for_root.hash_tree_root();
 
-        // Proposer for slot 1 with NUM_VALIDATORS validators: 1 % 50 = 1
-        let proposer_index = 1u64;
-        let slot = 1u64;
+        let slot = HEAD_SLOT + 1;
+        let proposer_index = slot % NUM_VALIDATORS as u64;
 
-        // The genesis edge case in build_block sets current_justified to:
-        //   Checkpoint { root: parent_root, slot: 0 }
+        // Common source / target / head referencing valid chain entries so the
+        // chain-match check passes for every payload. We vary AttestationData.slot
+        // alone to produce 50 distinct data_roots.
         let source = Checkpoint {
-            root: parent_root,
+            root: hashes[0],
+            slot: 0,
+        };
+        let target = Checkpoint {
+            root: hashes[TARGET_SLOT as usize],
+            slot: TARGET_SLOT,
+        };
+        let head = Checkpoint {
+            root: hashes[0],
             slot: 0,
         };
 
         let mut known_block_roots = HashSet::new();
         known_block_roots.insert(parent_root);
+        known_block_roots.insert(hashes[0]);
 
         // Simulate a stall: populate the payload pool with many distinct entries.
-        // Each has a unique target (different slot) and a large proof payload.
+        // Each has a unique attestation slot and a large proof payload.
         let mut aggregated_payloads: HashMap<
             H256,
             (AttestationData, Vec<AggregatedSignatureProof>),
         > = HashMap::new();
 
         for i in 0..NUM_PAYLOAD_ENTRIES {
-            let target_slot = (i + 1) as u64;
             let att_data = AttestationData {
-                slot: target_slot,
-                head: Checkpoint {
-                    root: parent_root,
-                    slot: 0,
-                },
-                target: Checkpoint {
-                    root: H256([target_slot as u8; 32]),
-                    slot: target_slot,
-                },
+                slot: (i + 1) as u64,
+                head,
+                target,
                 source,
             };
 

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1578,6 +1578,134 @@ mod tests {
         );
     }
 
+    /// Regression test for leanSpec PR #716: build_block must absorb
+    /// gap-closing attestations whose source is justified on the head
+    /// chain but older than `latest_justified` (e.g., a sibling fork
+    /// advanced the store's justified past what the canonical head has
+    /// proven). Without the relaxed `is_slot_justified(source.slot)`
+    /// filter, the exact-equality check would drop the attestation and
+    /// justification would never converge on this chain.
+    #[test]
+    fn build_block_absorbs_older_but_justified_source() {
+        use ethlambda_state_transition::justified_slots_ops;
+        use ethlambda_types::{
+            block::BlockHeader,
+            state::{ChainConfig, JustificationValidators, JustifiedSlots},
+        };
+        use libssz_types::SszList;
+
+        const NUM_VALIDATORS: usize = 50;
+        const SUPERMAJORITY: usize = 34; // ceil(2 * 50 / 3)
+        const HEAD_SLOT: u64 = 5;
+        const JUSTIFIED_SLOT: u64 = 1;
+        const GAP_TARGET_SLOT: u64 = 2;
+
+        let validators: Vec<_> = (0..NUM_VALIDATORS)
+            .map(|i| ethlambda_types::state::Validator {
+                attestation_pubkey: [i as u8; 52],
+                proposal_pubkey: [i as u8; 52],
+                index: i as u64,
+            })
+            .collect();
+
+        let hashes: Vec<H256> = (0..HEAD_SLOT).map(|i| H256([(i + 1) as u8; 32])).collect();
+
+        let mut justified_slots = JustifiedSlots::new();
+        justified_slots_ops::extend_to_slot(&mut justified_slots, 0, JUSTIFIED_SLOT);
+        justified_slots_ops::set_justified(&mut justified_slots, 0, JUSTIFIED_SLOT);
+
+        let head_header = BlockHeader {
+            slot: HEAD_SLOT,
+            proposer_index: 0,
+            parent_root: H256::ZERO,
+            state_root: H256::ZERO,
+            body_root: BlockBody::default().hash_tree_root(),
+        };
+
+        let head_state = State {
+            config: ChainConfig { genesis_time: 1000 },
+            slot: HEAD_SLOT,
+            latest_block_header: head_header,
+            latest_justified: Checkpoint {
+                root: hashes[JUSTIFIED_SLOT as usize],
+                slot: JUSTIFIED_SLOT,
+            },
+            latest_finalized: Checkpoint::default(),
+            historical_block_hashes: SszList::try_from(hashes.clone()).unwrap(),
+            justified_slots,
+            validators: SszList::try_from(validators).unwrap(),
+            justifications_roots: Default::default(),
+            justifications_validators: JustificationValidators::new(),
+        };
+
+        let mut header_for_root = head_state.latest_block_header.clone();
+        header_for_root.state_root = head_state.hash_tree_root();
+        let parent_root = header_for_root.hash_tree_root();
+
+        let slot = HEAD_SLOT + 1;
+        let proposer_index = slot % NUM_VALIDATORS as u64;
+
+        // source = genesis (slot 0): older than head.latest_justified at
+        // slot 1. Pre-PR exact-equality filter would drop this; post-PR
+        // it's absorbed and the candidate justifies GAP_TARGET_SLOT.
+        let att_data = AttestationData {
+            slot,
+            head: Checkpoint {
+                root: hashes[0],
+                slot: 0,
+            },
+            target: Checkpoint {
+                root: hashes[GAP_TARGET_SLOT as usize],
+                slot: GAP_TARGET_SLOT,
+            },
+            source: Checkpoint {
+                root: hashes[0],
+                slot: 0,
+            },
+        };
+        let data_root = att_data.hash_tree_root();
+
+        let mut bits = AggregationBits::with_length(NUM_VALIDATORS).unwrap();
+        for i in 0..SUPERMAJORITY {
+            bits.set(i, true).unwrap();
+        }
+        let proof = AggregatedSignatureProof::new(bits, SszList::try_from(vec![0xAB; 64]).unwrap());
+
+        let mut aggregated_payloads = HashMap::new();
+        aggregated_payloads.insert(data_root, (att_data.clone(), vec![proof]));
+
+        let mut known_block_roots = HashSet::new();
+        known_block_roots.insert(parent_root);
+        known_block_roots.insert(hashes[0]);
+
+        let (block, _signatures, post_checkpoints) = build_block(
+            &head_state,
+            slot,
+            proposer_index,
+            parent_root,
+            &known_block_roots,
+            &aggregated_payloads,
+        )
+        .expect("build_block should succeed");
+
+        let targets: Vec<_> = block
+            .body
+            .attestations
+            .iter()
+            .map(|att| att.data.target)
+            .collect();
+        assert!(
+            targets.contains(&att_data.target),
+            "produced block missing gap-closing attestation: {targets:?}"
+        );
+
+        assert_eq!(post_checkpoints.justified.slot, GAP_TARGET_SLOT);
+        assert_eq!(
+            post_checkpoints.justified.root,
+            hashes[GAP_TARGET_SLOT as usize]
+        );
+    }
+
     fn make_att_data(slot: u64) -> AttestationData {
         AttestationData {
             slot,

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -367,7 +367,7 @@ fn is_valid_vote(state: &State, data: &AttestationData) -> bool {
 
     // Ensure the vote refers to blocks that actually exist on our chain;
     // also rejects zero-hash source or target inline.
-    if !attestation_data_matches_chain(&state.historical_block_hashes, data) {
+    if !attestation_data_matches_chain(&state.historical_block_hashes, None, data) {
         return false;
     }
 
@@ -476,25 +476,32 @@ fn serialize_justifications(
 /// Whether both source and target checkpoints in `data` match the chain at
 /// their slots.
 ///
-/// Callers pass a chain view as it would appear after `process_block_header`
-/// on the consuming block: covering `[0, block.slot - 1]` with `parent_root`
-/// at the parent slot and `H256::ZERO` for empty slots between parent and the
-/// candidate.
+/// `parent_root` lets callers extend `historical_block_hashes` by one virtual
+/// entry at index `historical_block_hashes.len()` without allocating an
+/// extended slice. `build_block` uses it to represent the candidate block's
+/// parent (whose root is not yet in the post-state's `historical_block_hashes`);
+/// `process_attestations` passes `None` since by then the state already
+/// contains all relevant entries.
 pub fn attestation_data_matches_chain(
     historical_block_hashes: &[H256],
+    parent_root: Option<H256>,
     data: &AttestationData,
 ) -> bool {
     if data.source.root == H256::ZERO || data.target.root == H256::ZERO {
         return false;
     }
-    let source_slot = data.source.slot as usize;
-    let target_slot = data.target.slot as usize;
-    if source_slot >= historical_block_hashes.len() || target_slot >= historical_block_hashes.len()
-    {
-        return false;
-    }
-    historical_block_hashes[source_slot] == data.source.root
-        && historical_block_hashes[target_slot] == data.target.root
+    let root_at = |slot: u64| -> Option<H256> {
+        let idx = slot as usize;
+        if idx < historical_block_hashes.len() {
+            Some(historical_block_hashes[idx])
+        } else if idx == historical_block_hashes.len() {
+            parent_root
+        } else {
+            None
+        }
+    };
+    root_at(data.source.slot) == Some(data.source.root)
+        && root_at(data.target.slot) == Some(data.target.root)
 }
 
 /// Checks if the slot is a valid candidate for justification after a given finalized slot.

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -499,8 +499,12 @@ pub fn attestation_data_matches_chain(
     {
         return false;
     }
-    historical_block_hashes[source_slot] == data.source.root
-        && historical_block_hashes[target_slot] == data.target.root
+    let source_root = historical_block_hashes[source_slot];
+    let target_root = historical_block_hashes[target_slot];
+    if source_root == H256::ZERO || target_root == H256::ZERO {
+        return false;
+    }
+    source_root == data.source.root && target_root == data.target.root
 }
 
 /// Checks if the slot is a valid candidate for justification after a given finalized slot.

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -272,7 +272,7 @@ fn process_attestations(
         let source = attestation_data.source;
         let target = attestation_data.target;
 
-        if !is_valid_vote(state, source, target) {
+        if !is_valid_vote(state, attestation_data) {
             continue;
         }
 
@@ -338,11 +338,14 @@ fn process_attestations(
 /// Checks (all must pass):
 /// 1. Source is already justified
 /// 2. Target is not yet justified
-/// 3. Neither root is zero hash
-/// 4. Both checkpoints exist in historical_block_hashes
-/// 5. Target slot > source slot
-/// 6. Target slot is justifiable after the finalized slot
-fn is_valid_vote(state: &State, source: Checkpoint, target: Checkpoint) -> bool {
+/// 3. Both checkpoints match the canonical chain at their slots (which also
+///    rejects zero-hash source or target roots)
+/// 4. Target slot > source slot
+/// 5. Target slot is justifiable after the finalized slot
+fn is_valid_vote(state: &State, data: &AttestationData) -> bool {
+    let source = data.source;
+    let target = data.target;
+
     // Check that the source is already justified
     if !justified_slots_ops::is_slot_justified(
         &state.justified_slots,
@@ -362,13 +365,9 @@ fn is_valid_vote(state: &State, source: Checkpoint, target: Checkpoint) -> bool 
         return false;
     }
 
-    // Ignore votes that reference zero-hash slots.
-    if source.root == H256::ZERO || target.root == H256::ZERO {
-        return false;
-    }
-
-    // Ensure the vote refers to blocks that actually exist on our chain
-    if !checkpoint_exists(state, source) || !checkpoint_exists(state, target) {
+    // Ensure the vote refers to blocks that actually exist on our chain;
+    // also rejects zero-hash source or target inline.
+    if !attestation_data_matches_chain(&state.historical_block_hashes, data) {
         return false;
     }
 
@@ -474,14 +473,6 @@ fn serialize_justifications(
     state.justifications_validators = justifications_validators;
 }
 
-fn checkpoint_exists(state: &State, checkpoint: Checkpoint) -> bool {
-    state
-        .historical_block_hashes
-        .get(checkpoint.slot as usize)
-        .map(|root| root == &checkpoint.root)
-        .unwrap_or(false)
-}
-
 /// Whether both source and target checkpoints in `data` match the chain at
 /// their slots.
 ///
@@ -493,18 +484,17 @@ pub fn attestation_data_matches_chain(
     historical_block_hashes: &[H256],
     data: &AttestationData,
 ) -> bool {
+    if data.source.root == H256::ZERO || data.target.root == H256::ZERO {
+        return false;
+    }
     let source_slot = data.source.slot as usize;
     let target_slot = data.target.slot as usize;
     if source_slot >= historical_block_hashes.len() || target_slot >= historical_block_hashes.len()
     {
         return false;
     }
-    let source_root = historical_block_hashes[source_slot];
-    let target_root = historical_block_hashes[target_slot];
-    if source_root == H256::ZERO || target_root == H256::ZERO {
-        return false;
-    }
-    source_root == data.source.root && target_root == data.target.root
+    historical_block_hashes[source_slot] == data.source.root
+        && historical_block_hashes[target_slot] == data.target.root
 }
 
 /// Checks if the slot is a valid candidate for justification after a given finalized slot.

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use ethlambda_types::{
     ShortRoot,
+    attestation::AttestationData,
     block::{AggregatedAttestations, Block, BlockHeader},
     checkpoint::Checkpoint,
     primitives::{H256, HashTreeRoot as _},
@@ -9,7 +10,7 @@ use ethlambda_types::{
 };
 use tracing::{info, warn};
 
-mod justified_slots_ops;
+pub mod justified_slots_ops;
 pub mod metrics;
 
 #[derive(Debug, thiserror::Error)]
@@ -479,6 +480,27 @@ fn checkpoint_exists(state: &State, checkpoint: Checkpoint) -> bool {
         .get(checkpoint.slot as usize)
         .map(|root| root == &checkpoint.root)
         .unwrap_or(false)
+}
+
+/// Whether both source and target checkpoints in `data` match the chain at
+/// their slots.
+///
+/// Callers pass a chain view as it would appear after `process_block_header`
+/// on the consuming block: covering `[0, block.slot - 1]` with `parent_root`
+/// at the parent slot and `H256::ZERO` for empty slots between parent and the
+/// candidate.
+pub fn attestation_data_matches_chain(
+    historical_block_hashes: &[H256],
+    data: &AttestationData,
+) -> bool {
+    let source_slot = data.source.slot as usize;
+    let target_slot = data.target.slot as usize;
+    if source_slot >= historical_block_hashes.len() || target_slot >= historical_block_hashes.len()
+    {
+        return false;
+    }
+    historical_block_hashes[source_slot] == data.source.root
+        && historical_block_hashes[target_slot] == data.target.root
 }
 
 /// Checks if the slot is a valid candidate for justification after a given finalized slot.

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -367,7 +367,7 @@ fn is_valid_vote(state: &State, data: &AttestationData) -> bool {
 
     // Ensure the vote refers to blocks that actually exist on our chain;
     // also rejects zero-hash source or target inline.
-    if !attestation_data_matches_chain(&state.historical_block_hashes, None, data) {
+    if !attestation_data_matches_chain(&state.historical_block_hashes, data) {
         return false;
     }
 
@@ -476,32 +476,25 @@ fn serialize_justifications(
 /// Whether both source and target checkpoints in `data` match the chain at
 /// their slots.
 ///
-/// `parent_root` lets callers extend `historical_block_hashes` by one virtual
-/// entry at index `historical_block_hashes.len()` without allocating an
-/// extended slice. `build_block` uses it to represent the candidate block's
-/// parent (whose root is not yet in the post-state's `historical_block_hashes`);
-/// `process_attestations` passes `None` since by then the state already
-/// contains all relevant entries.
+/// Callers pass a chain view as it would appear after `process_block_header`
+/// on the consuming block: covering `[0, block.slot - 1]` with `parent_root`
+/// at the parent slot and `H256::ZERO` for empty slots between parent and the
+/// candidate.
 pub fn attestation_data_matches_chain(
     historical_block_hashes: &[H256],
-    parent_root: Option<H256>,
     data: &AttestationData,
 ) -> bool {
     if data.source.root == H256::ZERO || data.target.root == H256::ZERO {
         return false;
     }
-    let root_at = |slot: u64| -> Option<H256> {
-        let idx = slot as usize;
-        if idx < historical_block_hashes.len() {
-            Some(historical_block_hashes[idx])
-        } else if idx == historical_block_hashes.len() {
-            parent_root
-        } else {
-            None
-        }
-    };
-    root_at(data.source.slot) == Some(data.source.root)
-        && root_at(data.target.slot) == Some(data.target.root)
+    let source_slot = data.source.slot as usize;
+    let target_slot = data.target.slot as usize;
+    if source_slot >= historical_block_hashes.len() || target_slot >= historical_block_hashes.len()
+    {
+        return false;
+    }
+    historical_block_hashes[source_slot] == data.source.root
+        && historical_block_hashes[target_slot] == data.target.root
 }
 
 /// Checks if the slot is a valid candidate for justification after a given finalized slot.


### PR DESCRIPTION
## Summary

Mirrors [leanSpec#716](https://github.com/leanEthereum/leanSpec/pull/716). The fixed-point attestation loop in `build_block` required `att.source` to equal `current_justified` exactly. When the store's justified checkpoint has advanced via a sibling fork while the canonical head's chain has only proven an earlier slot, the head chain's pool holds a gap-closing attestation whose source differs from the head's `latest_justified` checkpoint. The exact-match filter dropped it and block production aborted with `JustifiedDivergenceNotClosed` ("Fixed-point attestation loop did not converge").

### Scenario (from the spec PR)

```
                       block_4(4) -- block_5(5)  <-- head
                      /
genesis -- 1 -- 2 -- 3
                      \
                       block_6(6)
```

- `block_4`: 6/8 attest `target=block_1` (justifies slot 1).
- `block_5`: 2/8 attest `target=block_4` (fork-choice weight only).
- `block_6` (sibling of block_4): 6/8 attest `target=block_2` (justifies slot 2 on the store).

Fork choice picks `block_5` as head; the store's `latest_justified` is `block_2`, but `block_5`'s post-state still sits at `block_1`. The proposer at slot 7 builds on `block_5` and must absorb `block_6`'s attestation from the gossip pool to close the gap.

## Changes

In `build_block` (`crates/blockchain/src/store.rs`):

- Relax the source filter from `att.source != current_justified` to `att.source.slot > current_justified.slot`, so older-but-already-justified sources can flow through.
- Build a chain view that `process_block_header` would produce on the candidate block (the head's `historical_block_hashes` plus `parent_root` at the parent slot plus `H256::ZERO` for each empty slot between parent and the candidate) and reject attestations whose `source.root` or `target.root` do not match it. Prevents pulling in attestations about other forks now that the exact source check is gone.
- Skip attestations whose target slot is already justified on the chain, with a genesis self-vote (`source.slot == 0 && target.slot == 0`) exception for fork-choice bootstrapping.
- Track `current_finalized_slot` and `current_justified_slots` alongside `current_justified`, refreshing them from `post_state` whenever the STF iteration advances either checkpoint.

In `state_transition`:

- Add a public `attestation_data_matches_chain(&[H256], &AttestationData) -> bool` helper.
- Make the `justified_slots_ops` module `pub` so `is_slot_justified` can be reused from `build_block` without duplicating the relative-index logic.

The existing process_attestations path already factored the source/target chain match into `checkpoint_exists` and is left unchanged.

### Test update

`build_block_caps_attestation_data_entries` previously used fake target roots that don't appear in the chain. Restructured the setup to build a head state at slot 51 with populated `historical_block_hashes` and vary `AttestationData.slot` (rather than the target root) to produce distinct entries. Still verifies the `MAX_ATTESTATIONS_DATA` cap and gossip-size bound.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --release` (including `forkchoice_spectests`, `stf_spectests`, `signature_spectests` against the pinned leanSpec fixtures)
- [ ] Multi-client devnet run to confirm no regression in steady-state finalization

> Note: the leanSpec spec test for this scenario (`test_block_production_justification_gap.py`) is not yet in the pinned `LEAN_SPEC_COMMIT_HASH`. A follow-up commit hash bump in `Makefile` will pick it up automatically.