### PR TITLE
docs: surface community channels on README and docs landing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,9 +144,11 @@ If you discover a security vulnerability, **do not open a public issue**. Instea
 
 ## Communication
 
-- **Telegram**: [ethlambda group](https://t.me/ethlambda_client) — questions, discussion, coordination
-- **X (Twitter)**: Follow [@ethlambda_lean](https://twitter.com/ethlambda_lean) for updates
-- **GitHub Issues**: Bugs, feature requests, and technical discussion
+- **Telegram**: [ethlambda group](https://t.me/ethlambda_client), where we post daily updates; drop by to ask questions or chat about anything Lean-related.
+- **X (Twitter)**: [@ethlambda_lean](https://twitter.com/ethlambda_lean) for occasional updates.
+- **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
+- **GitHub Issues**: bugs, feature requests, and technical discussion.
+- **Ecosystem coordination**: the [open PQ Interop calls](https://github.com/ethereum/pm/issues/2055) cover cross-client Lean Ethereum work.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ If you discover a security vulnerability, **do not open a public issue**. Instea
 - **X (Twitter)**: [@ethlambda_lean](https://twitter.com/ethlambda_lean) for occasional updates.
 - **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
 - **GitHub Issues**: bugs, feature requests, and technical discussion.
-- **Ecosystem coordination**: the [open PQ Interop calls](https://github.com/ethereum/pm/issues/2055) cover cross-client Lean Ethereum work.
+- **Ecosystem coordination**: the [PQ Interop calls](https://github.com/ethereum/pm/issues?q=is%3Aissue+%22PQ+Interop%22+in%3Atitle) on `ethereum/pm` cover cross-client Lean Ethereum work and related updates; the meeting links are posted on each issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We welcome contributions! Please read our [CONTRIBUTING.md](./CONTRIBUTING.md) f
 - **Telegram**: [ethlambda group](https://t.me/ethlambda_client), where we post daily updates; drop by to ask questions or chat about anything Lean-related.
 - **X (Twitter)**: [@ethlambda_lean](https://twitter.com/ethlambda_lean) for occasional updates.
 - **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
-- **Ecosystem coordination**: the [open PQ Interop calls](https://github.com/ethereum/pm/issues/2055) cover cross-client Lean Ethereum work.
+- **Ecosystem coordination**: the [PQ Interop calls](https://github.com/ethereum/pm/issues?q=is%3Aissue+%22PQ+Interop%22+in%3Atitle) on `ethereum/pm` cover cross-client Lean Ethereum work and related updates; the meeting links are posted on each issue.
 
 ## Philosophy
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ For custom devnet configurations, go to `lean-quickstart/local-devnet/genesis/va
 
 We welcome contributions! Please read our [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to get involved.
 
+## Community
+
+- **Telegram**: [ethlambda group](https://t.me/ethlambda_client), where we post daily updates; drop by to ask questions or chat about anything Lean-related.
+- **X (Twitter)**: [@ethlambda_lean](https://twitter.com/ethlambda_lean) for occasional updates.
+- **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
+- **Ecosystem coordination**: the [open PQ Interop calls](https://github.com/ethereum/pm/issues/2055) cover cross-client Lean Ethereum work.
+
 ## Philosophy
 
 Many long-established clients accumulate bloat over time. This often occurs due to the need to support legacy features for existing users or through attempts to implement overly ambitious software. The result is often complex, difficult-to-maintain, and error-prone systems.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -34,7 +34,7 @@ into the rendered output:
 - **Telegram**: [ethlambda group](https://t.me/ethlambda_client), where we post daily updates; drop by to ask questions or chat about anything Lean-related.
 - **X (Twitter)**: [@ethlambda_lean](https://twitter.com/ethlambda_lean) for occasional updates.
 - **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
-- **Ecosystem coordination**: the [open PQ Interop calls](https://github.com/ethereum/pm/issues/2055) cover cross-client Lean Ethereum work.
+- **Ecosystem coordination**: the [PQ Interop calls](https://github.com/ethereum/pm/issues?q=is%3Aissue+%22PQ+Interop%22+in%3Atitle) on `ethereum/pm` cover cross-client Lean Ethereum work and related updates; the meeting links are posted on each issue.
 
 ## Related projects
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -29,6 +29,13 @@ into the rendered output:
 - [3SF-mini infographic](./infographics/3sf-mini-infographic.html)
 - [ethlambda architecture infographic](./infographics/ethlambda_architecture.html)
 
+## Community
+
+- **Telegram**: [ethlambda group](https://t.me/ethlambda_client), where we post daily updates; drop by to ask questions or chat about anything Lean-related.
+- **X (Twitter)**: [@ethlambda_lean](https://twitter.com/ethlambda_lean) for occasional updates.
+- **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
+- **Ecosystem coordination**: the [open PQ Interop calls](https://github.com/ethereum/pm/issues/2055) cover cross-client Lean Ethereum work.
+
 ## Related projects
 
 ethlambda is one of several Lean Ethereum consensus clients under active development.


### PR DESCRIPTION
## Summary

- Add a **Community** section to the README and `docs/introduction.md` so newcomers find the Telegram group, the weekly Friday community call, and the PQ Interop calls without digging into `CONTRIBUTING.md`.
- Refresh the existing **Communication** section in `CONTRIBUTING.md` to match (adds the weekly call and PQ Interop pointers, tightens the Telegram description).

Triggered by the follow-up in https://github.com/lambdaclass/ethlambda/pull/368#issuecomment-4452169978.

## Test plan

- [x] `README.md` renders the new Community section between Contributing and Philosophy.
- [x] `docs/introduction.md` renders the new Community section before Related projects (will show up in the mdBook).
- [x] `CONTRIBUTING.md` Communication block stays consistent with the other two.