### PR TITLE
fix: serve genesis block on BlocksByRoot with structurally-valid blank XMSS signature

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -1356,13 +1356,14 @@ fn reorg_depth(old_head: H256, new_head: H256, store: &Store) -> Option<u64> {
 mod tests {
     use super::*;
     use ethlambda_types::{
-        attestation::{AggregatedAttestation, AggregationBits, AttestationData, XmssSignature},
+        attestation::{
+            AggregatedAttestation, AggregationBits, AttestationData, blank_xmss_signature,
+        },
         block::{
             AggregatedSignatureProof, AttestationSignatures, BlockBody, BlockSignatures,
             SignedBlock,
         },
         checkpoint::Checkpoint,
-        signature::SIGNATURE_SIZE,
         state::State,
     };
 
@@ -1407,7 +1408,7 @@ mod tests {
             },
             signature: BlockSignatures {
                 attestation_signatures,
-                proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE]).unwrap(),
+                proposer_signature: blank_xmss_signature(),
             },
         };
 
@@ -1561,7 +1562,7 @@ mod tests {
             message: block,
             signature: BlockSignatures {
                 attestation_signatures: AttestationSignatures::try_from(attestation_sigs).unwrap(),
-                proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE]).unwrap(),
+                proposer_signature: blank_xmss_signature(),
             },
         };
 
@@ -1858,7 +1859,7 @@ mod tests {
             },
             signature: BlockSignatures {
                 attestation_signatures,
-                proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE]).unwrap(),
+                proposer_signature: blank_xmss_signature(),
             },
         };
 

--- a/crates/common/test-fixtures/src/fork_choice.rs
+++ b/crates/common/test-fixtures/src/fork_choice.rs
@@ -7,12 +7,11 @@ use crate::{
     AggregationBits, AttestationData, Block, BlockBody, Checkpoint, TestInfo, TestState,
     deser_xmss_hex,
 };
-use ethlambda_types::attestation::XmssSignature;
+use ethlambda_types::attestation::{XmssSignature, blank_xmss_signature};
 use ethlambda_types::block::{
     AggregatedSignatureProof, AttestationSignatures, BlockSignatures, SignedBlock,
 };
 use ethlambda_types::primitives::H256;
-use ethlambda_types::signature::SIGNATURE_SIZE;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::path::Path;
@@ -171,8 +170,7 @@ impl BlockStepData {
         SignedBlock {
             message: block,
             signature: BlockSignatures {
-                proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE])
-                    .expect("zero-filled signature has the correct length"),
+                proposer_signature: blank_xmss_signature(),
                 attestation_signatures: AttestationSignatures::try_from(proofs)
                     .expect("attestation proofs within limit"),
             },

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -55,8 +55,39 @@ pub struct SignedAttestation {
     pub signature: XmssSignature,
 }
 
-/// XMSS signature as a fixed-length byte vector (3112 bytes).
+/// XMSS signature as a fixed-length byte vector (`SIGNATURE_SIZE` bytes).
 pub type XmssSignature = SszVector<u8, SIGNATURE_SIZE>;
+
+/// SSZ offset (in bytes) of the `path` body inside an XMSS `Signature` container.
+///
+/// Layout: 4-byte path offset + 28-byte rho + 4-byte hashes offset = 36.
+const SIGNATURE_PATH_OFFSET: u32 = 36;
+
+/// SSZ offset (in bytes) of the `hashes` body inside an XMSS `Signature`.
+///
+/// `path` body is 4-byte siblings offset + LOG_LIFETIME (32) siblings × 32-byte
+/// digest = 1028, starting at byte 36, so hashes start at 36 + 1028 = 1064.
+const SIGNATURE_HASHES_OFFSET: u32 = 1064;
+
+/// SSZ offset (in bytes) of the `siblings` list inside the `path` container.
+const SIGNATURE_PATH_SIBLINGS_OFFSET: u32 = 4;
+
+/// Build a placeholder XMSS signature that decodes as a structurally valid
+/// leanSpec `Signature` container of all-zero hashes.
+///
+/// Used for genesis-style anchor blocks that were never proposed and therefore
+/// have no real signature. Parent containers inline this as an opaque
+/// `SIGNATURE_SIZE`-byte blob; consumers that decode the inner `Signature`
+/// container see `path = HashTreeOpening { siblings = [0; 32] }`, `rho = 0`,
+/// `hashes = [0; 46]`. Matches ream's `Signature::blank()` so the wire format
+/// is byte-identical across clients.
+pub fn blank_xmss_signature() -> XmssSignature {
+    let mut bytes = vec![0u8; SIGNATURE_SIZE];
+    bytes[..4].copy_from_slice(&SIGNATURE_PATH_OFFSET.to_le_bytes());
+    bytes[32..36].copy_from_slice(&SIGNATURE_HASHES_OFFSET.to_le_bytes());
+    bytes[36..40].copy_from_slice(&SIGNATURE_PATH_SIBLINGS_OFFSET.to_le_bytes());
+    XmssSignature::try_from(bytes).expect("size matches SIGNATURE_SIZE")
+}
 
 /// Aggregated attestation consisting of participation bits and message.
 #[derive(Debug, Clone, Serialize, SszEncode, SszDecode, HashTreeRoot)]

--- a/crates/common/types/src/attestation.rs
+++ b/crates/common/types/src/attestation.rs
@@ -306,4 +306,36 @@ mod tests {
         let b = bits(24, &[0, 1, 16]);
         assert!(!bits_is_subset(&a, &b));
     }
+
+    /// Guard the three SSZ offsets at fixed byte positions so a one-off in any
+    /// constant doesn't silently produce a blob that still has the right outer
+    /// length but decodes incorrectly at the inner `Signature` container level.
+    #[test]
+    fn blank_xmss_signature_has_expected_ssz_offsets() {
+        let sig = blank_xmss_signature();
+        let bytes: Vec<u8> = sig.into_iter().collect();
+
+        assert_eq!(bytes.len(), SIGNATURE_SIZE);
+        assert_eq!(
+            u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+            SIGNATURE_PATH_OFFSET,
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[32..36].try_into().unwrap()),
+            SIGNATURE_HASHES_OFFSET,
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[36..40].try_into().unwrap()),
+            SIGNATURE_PATH_SIBLINGS_OFFSET,
+        );
+
+        // Everything outside the three offset slots must be zero — the
+        // placeholder is "all-zero hashes" once the offsets locate them.
+        for (i, b) in bytes.iter().enumerate() {
+            let in_offset_slot = matches!(i, 0..4 | 32..36 | 36..40);
+            if !in_offset_slot {
+                assert_eq!(*b, 0, "non-offset byte at index {i} should be zero");
+            }
+        }
+    }
 }

--- a/crates/net/p2p/src/req_resp/handlers.rs
+++ b/crates/net/p2p/src/req_resp/handlers.rs
@@ -400,9 +400,8 @@ mod tests {
     use super::*;
     use ethlambda_storage::{ForkCheckpoints, backend::InMemoryBackend};
     use ethlambda_types::{
-        attestation::XmssSignature,
+        attestation::blank_xmss_signature,
         block::{Block, BlockBody, BlockSignatures},
-        signature::SIGNATURE_SIZE,
         state::State,
     };
     use libssz_types::SszList;
@@ -419,7 +418,7 @@ mod tests {
             },
             signature: BlockSignatures {
                 attestation_signatures: SszList::new(),
-                proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE]).unwrap(),
+                proposer_signature: blank_xmss_signature(),
             },
         }
     }

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -494,11 +494,10 @@ mod tests {
     #[tokio::test]
     async fn test_get_latest_finalized_block() {
         use ethlambda_types::{
-            attestation::XmssSignature,
+            attestation::blank_xmss_signature,
             block::{Block, BlockBody, BlockSignatures, SignedBlock},
             checkpoint::Checkpoint,
             primitives::{H256, HashTreeRoot as _},
-            signature::SIGNATURE_SIZE,
         };
         use libssz::SszEncode;
 
@@ -519,7 +518,7 @@ mod tests {
             message: block,
             signature: BlockSignatures {
                 attestation_signatures: Default::default(),
-                proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE]).unwrap(),
+                proposer_signature: blank_xmss_signature(),
             },
         };
 
@@ -559,10 +558,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_latest_finalized_block_returns_404_when_absent() {
-        // Genesis-anchored store: init_store writes header + state but no
-        // BlockSignatures entry, so get_signed_block(genesis_root) returns None
-        // and the endpoint must report 404 rather than panic.
+    async fn test_get_latest_finalized_block_serves_genesis_with_placeholder_signature() {
+        // Genesis-anchored store: `init_store` writes the header + state but no
+        // `BlockSignatures` row. `get_signed_block` synthesizes an empty
+        // `BlockSignatures` so peers can still receive the genesis block on
+        // BlocksByRoot; the HTTP endpoint stays consistent and returns 200
+        // rather than 404.
         let state = create_test_state();
         let backend = Arc::new(InMemoryBackend::new());
         let store = Store::from_anchor_state(backend, state);
@@ -579,6 +580,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -559,6 +559,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_latest_finalized_block_serves_genesis_with_placeholder_signature() {
+        use ethlambda_types::{
+            attestation::blank_xmss_signature,
+            block::{BlockSignatures, SignedBlock},
+        };
+        use libssz::SszEncode;
+
         // Genesis-anchored store: `init_store` writes the header + state but no
         // `BlockSignatures` row. `get_signed_block` synthesizes an empty
         // `BlockSignatures` so peers can still receive the genesis block on
@@ -567,6 +573,21 @@ mod tests {
         let state = create_test_state();
         let backend = Arc::new(InMemoryBackend::new());
         let store = Store::from_anchor_state(backend, state);
+
+        // The body the endpoint serves must round-trip to a `SignedBlock`
+        // matching the genesis header paired with the synthetic blank
+        // signatures — same shape `get_signed_block` builds in storage.
+        let genesis_block = store
+            .get_signed_block(&store.latest_finalized().root)
+            .expect("genesis served via get_signed_block");
+        let expected = SignedBlock {
+            message: genesis_block.message.clone(),
+            signature: BlockSignatures {
+                attestation_signatures: Default::default(),
+                proposer_signature: blank_xmss_signature(),
+            },
+        };
+        let expected_ssz = expected.to_ssz();
 
         let app = build_api_router(store);
 
@@ -581,5 +602,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            SSZ_CONTENT_TYPE
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.as_ref(), expected_ssz.as_slice());
     }
 }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -7,16 +7,30 @@ use std::sync::{Arc, LazyLock, Mutex};
 /// allowing us to skip storing empty bodies and reconstruct them on read.
 static EMPTY_BODY_ROOT: LazyLock<H256> = LazyLock::new(|| BlockBody::default().hash_tree_root());
 
+/// Build a placeholder `BlockSignatures` for blocks that were never signed.
+///
+/// Genesis-style anchor blocks have no proposer signature and no per-attestation
+/// proofs (no attestations exist). `get_signed_block` returns this so peers can
+/// still receive the block in BlocksByRoot responses.
+fn empty_block_signatures() -> BlockSignatures {
+    BlockSignatures {
+        attestation_signatures: AttestationSignatures::default(),
+        proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE])
+            .expect("zero-filled signature fits"),
+    }
+}
+
 use crate::api::{StorageBackend, StorageWriteBatch, Table};
 
 use ethlambda_types::{
-    attestation::{AttestationData, HashedAttestationData, bits_is_subset},
+    attestation::{AttestationData, HashedAttestationData, XmssSignature, bits_is_subset},
     block::{
-        AggregatedSignatureProof, Block, BlockBody, BlockHeader, BlockSignatures, SignedBlock,
+        AggregatedSignatureProof, AttestationSignatures, Block, BlockBody, BlockHeader,
+        BlockSignatures, SignedBlock,
     },
     checkpoint::Checkpoint,
     primitives::{H256, HashTreeRoot as _},
-    signature::ValidatorSignature,
+    signature::{SIGNATURE_SIZE, ValidatorSignature},
     state::{ChainConfig, State, anchor_pair_is_consistent},
 };
 use libssz::{SszDecode, SszEncode};
@@ -990,15 +1004,17 @@ impl Store {
 
     /// Get a signed block by combining header, body, and signatures.
     ///
-    /// Returns None if any of the components are not found.
-    /// Note: Genesis block has no entry in BlockSignatures table.
+    /// Returns None if the header or body (for non-empty bodies) is missing.
+    ///
+    /// Signatures are absent for genesis-style anchor blocks (no proposer ever
+    /// signed them). To keep BlocksByRoot symmetric with the fork-choice view
+    /// for peers, synthesize empty `BlockSignatures` when the header exists
+    /// but no signature row was written.
     pub fn get_signed_block(&self, root: &H256) -> Option<SignedBlock> {
         let view = self.backend.begin_read().expect("read view");
         let key = root.to_ssz();
 
         let header_bytes = view.get(Table::BlockHeaders, &key).expect("get")?;
-        let sig_bytes = view.get(Table::BlockSignatures, &key).expect("get")?;
-
         let header = BlockHeader::from_ssz_bytes(&header_bytes).expect("valid header");
 
         // Use empty body if header indicates empty, otherwise fetch from DB
@@ -1009,8 +1025,14 @@ impl Store {
             BlockBody::from_ssz_bytes(&body_bytes).expect("valid body")
         };
 
+        let signature = match view.get(Table::BlockSignatures, &key).expect("get") {
+            Some(sig_bytes) => {
+                BlockSignatures::from_ssz_bytes(&sig_bytes).expect("valid signatures")
+            }
+            None => empty_block_signatures(),
+        };
+
         let block = Block::from_header_and_body(header, body);
-        let signature = BlockSignatures::from_ssz_bytes(&sig_bytes).expect("valid signatures");
 
         Some(SignedBlock {
             message: block,

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -1,24 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::{Arc, LazyLock, Mutex};
 
-/// The tree hash root of an empty block body.
-///
-/// Used to detect genesis/anchor blocks that have no attestations,
-/// allowing us to skip storing empty bodies and reconstruct them on read.
-static EMPTY_BODY_ROOT: LazyLock<H256> = LazyLock::new(|| BlockBody::default().hash_tree_root());
-
-/// Build a placeholder `BlockSignatures` for blocks that were never signed.
-///
-/// Genesis-style anchor blocks have no proposer signature and no per-attestation
-/// proofs (no attestations exist). `get_signed_block` returns this so peers can
-/// still receive the block in BlocksByRoot responses.
-fn empty_block_signatures() -> BlockSignatures {
-    BlockSignatures {
-        attestation_signatures: AttestationSignatures::default(),
-        proposer_signature: blank_xmss_signature(),
-    }
-}
-
 use crate::api::{StorageBackend, StorageWriteBatch, Table};
 
 use ethlambda_types::{
@@ -47,6 +29,24 @@ pub enum GetForkchoiceStoreError {
         anchor_state: Box<State>,
         anchor_block: Box<Block>,
     },
+}
+
+/// The tree hash root of an empty block body.
+///
+/// Used to detect genesis/anchor blocks that have no attestations,
+/// allowing us to skip storing empty bodies and reconstruct them on read.
+static EMPTY_BODY_ROOT: LazyLock<H256> = LazyLock::new(|| BlockBody::default().hash_tree_root());
+
+/// Build a placeholder `BlockSignatures` for blocks that were never signed.
+///
+/// Genesis-style anchor blocks have no proposer signature and no per-attestation
+/// proofs (no attestations exist). `get_signed_block` returns this so peers can
+/// still receive the block in BlocksByRoot responses.
+fn empty_block_signatures() -> BlockSignatures {
+    BlockSignatures {
+        attestation_signatures: AttestationSignatures::default(),
+        proposer_signature: blank_xmss_signature(),
+    }
 }
 
 /// Checkpoints to update in the forkchoice store.
@@ -1003,12 +1003,16 @@ impl Store {
 
     /// Get a signed block by combining header, body, and signatures.
     ///
-    /// Returns None if the header or body (for non-empty bodies) is missing.
+    /// Returns None if the header or body (for non-empty bodies) is missing,
+    /// or if the signature row is missing for any block other than the
+    /// slot-0 anchor.
     ///
-    /// Signatures are absent for genesis-style anchor blocks (no proposer ever
-    /// signed them). To keep BlocksByRoot symmetric with the fork-choice view
-    /// for peers, synthesize empty `BlockSignatures` when the header exists
-    /// but no signature row was written.
+    /// Signatures are absent for genesis-style anchor blocks (no proposer
+    /// ever signed them). To keep BlocksByRoot symmetric with the
+    /// fork-choice view for peers, synthesize empty `BlockSignatures` for
+    /// the slot-0 case only; for any other slot the missing-signature
+    /// state is treated as storage corruption and surfaces as `None`
+    /// rather than as a fabricated block.
     pub fn get_signed_block(&self, root: &H256) -> Option<SignedBlock> {
         let view = self.backend.begin_read().expect("read view");
         let key = root.to_ssz();
@@ -1028,7 +1032,12 @@ impl Store {
             Some(sig_bytes) => {
                 BlockSignatures::from_ssz_bytes(&sig_bytes).expect("valid signatures")
             }
-            None => empty_block_signatures(),
+            // Synthesis only covers the genesis-style anchor (slot 0). Any other
+            // missing-signature case is a storage corruption that should surface
+            // as `None` rather than fabricating a block whose `attestation_signatures`
+            // list is empty regardless of what the body actually carries.
+            None if header.slot == 0 => empty_block_signatures(),
+            None => return None,
         };
 
         let block = Block::from_header_and_body(header, body);
@@ -2333,5 +2342,53 @@ mod tests {
         assert!(!buf.data.contains_key(&slot1_root));
         assert_eq!(buf.total_signatures(), 2); // slot 2 (1) + slot 3 (1)
         assert_eq!(buf.len(), 2);
+    }
+
+    /// `Store::from_anchor_state` writes the header but no `BlockSignatures`
+    /// row for the slot-0 anchor. `get_signed_block` must synthesize an empty
+    /// `BlockSignatures` so the genesis block can still be served on
+    /// BlocksByRoot / `/lean/v0/blocks/finalized`.
+    #[test]
+    fn get_signed_block_synthesizes_blank_signatures_for_genesis_anchor() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::new());
+        let store = Store::from_anchor_state(backend, State::from_genesis(0, vec![]));
+
+        let head_root = store.head();
+        let signed = store
+            .get_signed_block(&head_root)
+            .expect("genesis block must be retrievable with synthetic signatures");
+
+        assert_eq!(signed.message.slot, 0);
+        assert_eq!(signed.signature.proposer_signature, blank_xmss_signature());
+        assert_eq!(signed.signature.attestation_signatures.len(), 0);
+    }
+
+    /// The synthesis branch must be confined to the slot-0 anchor: a
+    /// non-genesis block whose `BlockSignatures` row is missing is treated
+    /// as storage corruption and surfaces as `None`, not a fabricated block.
+    #[test]
+    fn get_signed_block_returns_none_for_non_genesis_with_missing_signatures() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::new());
+
+        // Hand-insert a slot-1 header (and empty body, via `EMPTY_BODY_ROOT`)
+        // but skip the `BlockSignatures` row. This mimics the corruption case
+        // the guard is meant to catch, without going through the normal
+        // `insert_signed_block` write path which always writes all three rows.
+        let header = BlockHeader {
+            slot: 1,
+            proposer_index: 0,
+            parent_root: H256::ZERO,
+            state_root: H256::ZERO,
+            body_root: *EMPTY_BODY_ROOT,
+        };
+        let root = header.hash_tree_root();
+        let mut batch = backend.begin_write().expect("write batch");
+        batch
+            .put_batch(Table::BlockHeaders, vec![(root.to_ssz(), header.to_ssz())])
+            .expect("put header");
+        batch.commit().expect("commit");
+
+        let store = Store::from_anchor_state(backend, State::from_genesis(0, vec![]));
+        assert!(store.get_signed_block(&root).is_none());
     }
 }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -15,22 +15,21 @@ static EMPTY_BODY_ROOT: LazyLock<H256> = LazyLock::new(|| BlockBody::default().h
 fn empty_block_signatures() -> BlockSignatures {
     BlockSignatures {
         attestation_signatures: AttestationSignatures::default(),
-        proposer_signature: XmssSignature::try_from(vec![0u8; SIGNATURE_SIZE])
-            .expect("zero-filled signature fits"),
+        proposer_signature: blank_xmss_signature(),
     }
 }
 
 use crate::api::{StorageBackend, StorageWriteBatch, Table};
 
 use ethlambda_types::{
-    attestation::{AttestationData, HashedAttestationData, XmssSignature, bits_is_subset},
+    attestation::{AttestationData, HashedAttestationData, bits_is_subset, blank_xmss_signature},
     block::{
         AggregatedSignatureProof, AttestationSignatures, Block, BlockBody, BlockHeader,
         BlockSignatures, SignedBlock,
     },
     checkpoint::Checkpoint,
     primitives::{H256, HashTreeRoot as _},
-    signature::{SIGNATURE_SIZE, ValidatorSignature},
+    signature::ValidatorSignature,
     state::{ChainConfig, State, anchor_pair_is_consistent},
 };
 use libssz::{SszDecode, SszEncode};


### PR DESCRIPTION
## Summary

Two related fixes that let peers (and our HTTP API) receive the genesis block in response to BlocksByRoot / \`/lean/v0/blocks/finalized\`.

### 1. \`fix(storage): synthesize empty BlockSignatures for genesis on read\`

\`store.get_signed_block(root)\` previously short-circuited to \`None\` when the \`BlockSignatures\` row was missing. That row is intentionally absent for genesis-style anchor blocks (no proposer ever signed them, no attestations exist) — but it also meant we silently dropped the genesis chunk from BlocksByRoot responses. The lean spec response container is \`List[SignedBlock]\` and peers (notably the ethereum/hive lean simulator's \`blocks_by_root/multiple_known_blocks\` test) expect one chunk per requested root.

Synthesize an empty \`BlockSignatures\` when the header exists but no signature row was written, so the fork-choice view and BlocksByRoot agree on what the node will serve. Same shape ream pre-materializes at write time (\`bin/ream/src/main.rs:301-306\`); we synthesize on read because our split storage layout (\`BlockHeaders\` / \`BlockBodies\` / \`BlockSignatures\`) would otherwise pin a 2536-byte zero blob per anchor.

### 2. \`fix(types): use SSZ-structurally-valid blank XMSS signature\`

The placeholder \`proposer_signature\` in (1) — and a handful of test / RPC stubs scattered around the workspace — was built as 2536 raw zero bytes. That works on the wire because parent containers treat \`XmssSignature\` as an opaque fixed-size blob (leanSpec \`xmss/containers.py::Signature.is_fixed_size\` returns \`True\`), but the bytes are not a valid SSZ encoding of the inner \`Signature\` container: all offsets are zero. Any consumer that round-trips the placeholder through the inner-container decoder (e.g. leanSpec API-output validators) would reject it.

Match ream's [\`Signature::blank()\`](https://github.com/ReamLabs/ream/blob/master/crates/crypto/post_quantum/src/leansig/signature.rs#L36-L48) (post devnet4 alignment): write the three SSZ offsets at fixed positions (36, 1064, 4) so the same 2536-byte blob decodes back to:

\`\`\`
Signature {
    path:   HashTreeOpening { siblings = [0; 32] },
    rho:    0,
    hashes: [0; 46],
}
\`\`\`

Centralize the construction in a single \`attestation::blank_xmss_signature()\` helper and point every existing call site at it (storage helper, blockchain/p2p/rpc test stubs, fork-choice spec-test fixture builder). Also:

- fix the stale \`(3112 bytes)\` doc on \`XmssSignature\` (we're 2536 — DIM=46);
- update the HTTP test that asserted 404-on-genesis (\`get_latest_finalized_block\`) to assert 200 instead, so it stays consistent with the BlocksByRoot path.

## Why bundled

(2) depends on (1) — the \`empty_block_signatures()\` helper it touches is introduced by (1). Keeping them in one PR avoids a half-step where genesis is served on the wire with bytes that no one can decode back to a \`Signature\` container.

## Test plan

- [x] \`make fmt\`
- [x] \`make lint\` (\`-D warnings\`)
- [x] \`cargo test --workspace\` — all suites green locally
- [x] hive lean \`reqresp\` suite — 22/22 pass against an image built from this branch (verified previously when only (1) was in place; (2) is a wire-format refinement of the same placeholder)

## Cross-client context

ream pre-materializes the same placeholder at write time when constructing the anchor SignedBlock (\`bin/ream/src/main.rs:283-310\` calls \`Signature::blank()\`). Lighthouse does the equivalent for the beacon chain — see [\`beacon_node/beacon_chain/src/builder.rs::genesis_block\`](https://github.com/sigp/lighthouse/blob/stable/beacon_node/beacon_chain/src/builder.rs) which wraps the genesis block in \`SignedBeaconBlock::from_block(genesis_block, Signature::empty())\` with the inline comment *"Empty signature, which should NEVER be read. This isn't to-spec, but makes the genesis block consistent with every other block."* The Ethereum consensus-specs are silent on what shape this placeholder takes (\`specs/phase0/p2p-interface.md\` \`BeaconBlocksByRoot\` allows peers to silently skip out-of-range roots), so this is by-convention across clients rather than a spec requirement.

## Risk

- Wire format unchanged for already-signed blocks; only the placeholder bytes change.
- Genesis is now served via BlocksByRoot and \`/lean/v0/blocks/finalized\` instead of being silently dropped / 404'd. Any consumer that *required* the 404 to detect "node hasn't progressed past genesis" needs to switch to checking \`latest_finalized.slot == 0\`. I'm not aware of one in this codebase.