### PR TITLE
perf(storage): tune RocksDB options

### DIFF
--- a/crates/storage/src/backend/rocksdb.rs
+++ b/crates/storage/src/backend/rocksdb.rs
@@ -4,7 +4,8 @@ use crate::api::{
     ALL_TABLES, Error, PrefixResult, StorageBackend, StorageReadView, StorageWriteBatch, Table,
 };
 use rocksdb::{
-    ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded, Options, WriteBatch, WriteOptions,
+    BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded, Options,
+    WriteBatch, WriteOptions,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -34,9 +35,29 @@ impl RocksDBBackend {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
+        opts.set_max_open_files(-1);
+        opts.set_max_file_opening_threads(8);
+        opts.set_max_background_jobs(8);
+        opts.set_max_subcompactions(2);
+        opts.set_compaction_readahead_size(4 * 1024 * 1024);
+        opts.set_level_compaction_dynamic_level_bytes(true);
+        opts.set_bytes_per_sync(32 * 1024 * 1024);
+        opts.set_wal_bytes_per_sync(32 * 1024 * 1024);
+        opts.set_max_total_wal_size(256 * 1024 * 1024);
+        opts.set_use_fsync(false);
+        opts.set_enable_pipelined_write(true);
+
+        let block_cache = Cache::new_lru_cache(128 * 1024 * 1024);
+        let mut block_opts = BlockBasedOptions::default();
+        block_opts.set_block_cache(&block_cache);
+
         let cf_descriptors: Vec<_> = ALL_TABLES
             .iter()
-            .map(|t| ColumnFamilyDescriptor::new(cf_name(*t), Options::default()))
+            .map(|t| {
+                let mut cf_opts = Options::default();
+                cf_opts.set_block_based_table_factory(&block_opts);
+                ColumnFamilyDescriptor::new(cf_name(*t), cf_opts)
+            })
             .collect();
 
         let db =


### PR DESCRIPTION
## Summary

Replaces bare `Options::default()` on every column family with a tuned config.

Most options that were no-ops at the RocksDB default were dropped; the meaningful changes are:

| Option | RocksDB default | This PR |
|---|---|---|
| `max_background_jobs` | `2` | `8` |
| `max_subcompactions` | `1` | `2` |
| `compaction_readahead_size` | `2 MB` | `4 MB` |
| `bytes_per_sync` | `0` (disabled) | `32 MB` |
| `wal_bytes_per_sync` | `0` (disabled) | `32 MB` |
| `max_total_wal_size` | `0` (auto: ~5 GB at our buffer sizes) | `256 MB` |
| `enable_pipelined_write` | `false` | `true` |
| Block cache | per-CF 32 MB auto | shared `128 MB` LRU across all CFs |

Reference: [RocksDB Setup & Basic Tuning](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning) and ethrex's [`crates/storage/backend/rocksdb.rs`](https://github.com/lambdaclass/ethrex/blob/main/crates/storage/backend/rocksdb.rs).

## Why

We had some errors due to files being kept open during devnet runs. We think it might be due to compaction being slow. The changes should make compaction faster.

## Test plan

- [x] `cargo build -p ethlambda-storage`
- [x] `cargo test -p ethlambda-storage --release` (35 tests pass)
- [x] `cargo fmt --all`
- [x] `cargo clippy -p ethlambda-storage -- -D warnings`
- [ ] Devnet run to confirm no regression in startup, finality, or memory footprint