### PR TITLE
refactor(blockchain): consolidate XMSS preparation window advance logic

### DIFF
--- a/crates/blockchain/src/key_manager.rs
+++ b/crates/blockchain/src/key_manager.rs
@@ -53,10 +53,10 @@ impl KeyManager {
     pub fn advance_keys_to(&mut self, slot: u32) {
         for (validator_id, key_pair) in self.keys.iter_mut() {
             let _ = advance_key(*validator_id, &mut key_pair.attestation_key, slot).inspect_err(
-                |err| warn!(%err, "Failed to advance attestation key preparation window"),
+                |err| warn!(validator_id, slot, %err, "Failed to advance attestation key preparation window"),
             );
             let _ = advance_key(*validator_id, &mut key_pair.proposal_key, slot).inspect_err(
-                |err| warn!(%err, "Failed to advance proposal key preparation window"),
+                |err| warn!(validator_id, slot, %err, "Failed to advance proposal key preparation window"),
             );
         }
     }

--- a/crates/blockchain/src/key_manager.rs
+++ b/crates/blockchain/src/key_manager.rs
@@ -52,8 +52,12 @@ impl KeyManager {
     /// Advances every validator's XMSS preparation windows to cover slot
     pub fn advance_keys_to(&mut self, slot: u32) {
         for (validator_id, key_pair) in self.keys.iter_mut() {
-            advance_key(*validator_id, &mut key_pair.attestation_key, slot);
-            advance_key(*validator_id, &mut key_pair.proposal_key, slot);
+            let _ = advance_key(*validator_id, &mut key_pair.attestation_key, slot).inspect_err(
+                |err| warn!(%err, "Failed to advance attestation key preparation window"),
+            );
+            let _ = advance_key(*validator_id, &mut key_pair.proposal_key, slot).inspect_err(
+                |err| warn!(%err, "Failed to advance proposal key preparation window"),
+            );
         }
     }
 
@@ -92,26 +96,7 @@ impl KeyManager {
         // Advance XMSS key preparation window if the slot is outside the current window.
         // Each bottom tree covers 65,536 slots; the window holds 2 at a time.
         // Multiple advances may be needed if the node was offline for an extended period.
-        if !key_pair.attestation_key.is_prepared_for(slot) {
-            info!(validator_id, slot, "Advancing XMSS key preparation window");
-            let start = Instant::now();
-            while !key_pair.attestation_key.is_prepared_for(slot) {
-                let before = key_pair.attestation_key.get_prepared_interval();
-                key_pair.attestation_key.advance_preparation();
-                if key_pair.attestation_key.get_prepared_interval() == before {
-                    return Err(KeyManagerError::SigningError(format!(
-                        "XMSS key exhausted for validator {validator_id}: \
-                         slot {slot} is beyond the key's activation interval"
-                    )));
-                }
-            }
-            info!(
-                validator_id,
-                slot,
-                elapsed_ms = start.elapsed().as_millis() as u64,
-                "Advanced XMSS key preparation window"
-            );
-        }
+        advance_key(validator_id, &mut key_pair.attestation_key, slot)?;
 
         let signature: ValidatorSignature = {
             let _timing = metrics::time_pq_sig_attestation_signing();
@@ -141,29 +126,7 @@ impl KeyManager {
         // Advance XMSS key preparation window if the slot is outside the current window.
         // Each bottom tree covers 65,536 slots; the window holds 2 at a time.
         // Multiple advances may be needed if the node was offline for an extended period.
-        if !key_pair.proposal_key.is_prepared_for(slot) {
-            info!(
-                validator_id,
-                slot, "Advancing XMSS proposal key preparation window"
-            );
-            let start = Instant::now();
-            while !key_pair.proposal_key.is_prepared_for(slot) {
-                let before = key_pair.proposal_key.get_prepared_interval();
-                key_pair.proposal_key.advance_preparation();
-                if key_pair.proposal_key.get_prepared_interval() == before {
-                    return Err(KeyManagerError::SigningError(format!(
-                        "XMSS proposal key exhausted for validator {validator_id}: \
-                         slot {slot} is beyond the key's activation interval"
-                    )));
-                }
-            }
-            info!(
-                validator_id,
-                slot,
-                elapsed_ms = start.elapsed().as_millis() as u64,
-                "Advanced XMSS proposal key preparation window"
-            );
-        }
+        advance_key(validator_id, &mut key_pair.proposal_key, slot)?;
 
         let signature: ValidatorSignature = key_pair
             .proposal_key
@@ -176,9 +139,13 @@ impl KeyManager {
     }
 }
 
-fn advance_key(validator_id: u64, key: &mut ValidatorSecretKey, slot: u32) {
+fn advance_key(
+    validator_id: u64,
+    key: &mut ValidatorSecretKey,
+    slot: u32,
+) -> Result<(), KeyManagerError> {
     if key.is_prepared_for(slot) {
-        return;
+        return Ok(());
     }
     info!(validator_id, slot, "Advancing XMSS key preparation window");
     let start = Instant::now();
@@ -186,16 +153,19 @@ fn advance_key(validator_id: u64, key: &mut ValidatorSecretKey, slot: u32) {
         let before = key.get_prepared_interval();
         key.advance_preparation();
         if key.get_prepared_interval() == before {
-            warn!(validator_id, slot, "XMSS key activation interval exhausted");
-            break;
+            return Err(KeyManagerError::SigningError(format!(
+                "XMSS key exhausted for validator {validator_id}: \
+                 slot {slot} is beyond the key's activation interval"
+            )));
         }
     }
     info!(
         validator_id,
         slot,
-        elapsed_ms = start.elapsed().as_millis() as u64,
+        elapsed = ?start.elapsed(),
         "Advanced XMSS key preparation window"
     );
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 🗒️ Description / Motivation

This PR addresses review comments from #332.

`sign_with_attestation_key` and `sign_with_proposal_key` had inline copies of the same advance loop that lives in the `advance_key` helper. This PR routes them through the helper so there's a single implementation.

Also switches the tracing field for elapsed durations from `elapsed_ms = ... as u64` to `elapsed = ?duration` so the `Duration`'s `Debug` impl is used.

## What Changed

**`crates/blockchain/src/key_manager.rs`**
- `advance_key` now returns `Result<(), KeyManagerError>` and returns the same `SigningError("XMSS key exhausted...")` the inline loops previously produced.
- `sign_with_attestation_key` and `sign_with_proposal_key` replace their inline advance loops with `advance_key(...)?`.
- `advance_keys_to` swallows the new `Result` via `inspect_err` so one exhausted key doesn't abort iteration; logs a `warn` per failure.
- All three `elapsed_ms = ... as u64` fields → `elapsed = ?start.elapsed()`.

## Correctness / Behavior Guarantees

- Signing-path behavior is unchanged: same control flow, same `is_prepared_for` check, same `advance_preparation` loop, same exhaustion detection, same returned error string.
- The exhaustion error message no longer distinguishes attestation vs proposal in its text (both say `"XMSS key exhausted..."`). `validator_id` and `slot` are still in the message.
- Tracing field change is observability-only — printed value is now human-readable (`1.234s`) instead of a raw millisecond count.

## Tests Added / Run

- `make fmt` clean
- `make lint` clean
- `make test` passes

The refactor is logic-preserving, so the existing `signature_spectests` and `forkchoice_spectests` continue to exercise the signing paths through the new `advance_key` indirection.

## Related Issues / PRs

- Closes #383
- Follow-up to #332

## ✅ Verification Checklist

- [x] `make fmt`
- [x] `make lint`
- [x] `make test`