### PR TITLE
chore(deps): bump leanSpec to f12000b (pre-devnet5), rename fork to Lstar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Generate test fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'
         working-directory: leanSpec
-        run: uv run fill --fork=Devnet --scheme prod -o fixtures -n auto
+        run: uv run fill --fork=Lstar --scheme prod -o fixtures -n auto
 
       # Save fixtures even if a later step fails, so a re-run does not
       # have to regenerate them. See: https://github.com/actions/cache/tree/main/save#always-save-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,21 @@ jobs:
           path: leanSpec/packages/testing/src/consensus_testing/test_keys/prod_scheme
           key: prod-keys-${{ steps.prod-keys-url.outputs.hash }}
 
+      # Download + extract the keys ourselves rather than via
+      # `consensus_testing.keys --download`. The pinned leanSpec commit predates
+      # leanSpec PR #745, whose `download_keys` reads the still-open (unflushed)
+      # download tempfile, intermittently truncating the gzip tail and aborting
+      # with EOFError. curl+tar fully writes the archive before reading it.
+      # Remove once the pin moves past PR #745.
       - name: Download production keys
         if: steps.cache-fixtures.outputs.cache-hit != 'true' && steps.cache-prod-keys.outputs.cache-hit != 'true'
         working-directory: leanSpec
-        run: uv run python -m consensus_testing.keys --download --scheme prod
+        run: |
+          KEYS_URL=$(uv run python -c "from consensus_testing.keys import KEY_DOWNLOAD_URLS; print(KEY_DOWNLOAD_URLS['prod'])")
+          KEYS_DIR=packages/testing/src/consensus_testing/test_keys
+          mkdir -p "$KEYS_DIR"
+          curl -sSL "$KEYS_URL" -o /tmp/prod_scheme.tar.gz
+          tar -xzf /tmp/prod_scheme.tar.gz -C "$KEYS_DIR"
 
       # Save production keys even if a later step fails, so a re-run does
       # not have to re-download. See: https://github.com/actions/cache/tree/main/save#always-save-cache

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,27 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-# 2026-05-21
-LEAN_SPEC_COMMIT_HASH:=825bec6bf278920cfc56730d64a7c90522a0bb6c
+# 2026-05-17
+LEAN_SPEC_COMMIT_HASH:=f12000bd68a9640cffdfbd9a07503c9112d32bee
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch
 	cd leanSpec && git checkout $(LEAN_SPEC_COMMIT_HASH)
 
+# Pre-download the prod keys ourselves before `fill`. The pinned leanSpec
+# commit predates leanSpec PR #745, whose `download_keys` reads the still-open
+# (unflushed) download tempfile, intermittently truncating the gzip tail and
+# aborting with EOFError. A plain curl+tar fully writes the archive before
+# reading it, sidestepping the bug. `fill` then sees the keys already present
+# and skips its own download. Remove once the pin moves past PR #745.
 leanSpec/fixtures: leanSpec
-	cd leanSpec && uv run fill --fork Lstar -n auto --scheme prod -o fixtures
+	cd leanSpec && \
+		KEYS_URL=$$(uv run python -c "from consensus_testing.keys import KEY_DOWNLOAD_URLS; print(KEY_DOWNLOAD_URLS['prod'])") && \
+		KEYS_DIR=packages/testing/src/consensus_testing/test_keys && \
+		mkdir -p $$KEYS_DIR && \
+		curl -sSL "$$KEYS_URL" -o /tmp/prod_scheme.tar.gz && \
+		tar -xzf /tmp/prod_scheme.tar.gz -C $$KEYS_DIR && \
+		uv run fill --fork Lstar -n auto --scheme prod -o fixtures
 
 lean-quickstart:
 	git clone https://github.com/blockblaz/lean-quickstart.git --depth 1 --single-branch

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,15 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-# 2026-04-29
-LEAN_SPEC_COMMIT_HASH:=18fe71fee49f8865a5c8a4cb8b1787b0cbc9e25b
+# 2026-05-21
+LEAN_SPEC_COMMIT_HASH:=825bec6bf278920cfc56730d64a7c90522a0bb6c
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch
 	cd leanSpec && git checkout $(LEAN_SPEC_COMMIT_HASH)
 
 leanSpec/fixtures: leanSpec
-	cd leanSpec && uv run fill --fork devnet -n auto --scheme=prod -o fixtures
+	cd leanSpec && uv run fill --fork Lstar -n auto --scheme prod -o fixtures
 
 lean-quickstart:
 	git clone https://github.com/blockblaz/lean-quickstart.git --depth 1 --single-branch


### PR DESCRIPTION
## Summary

The pinned `LEAN_SPEC_COMMIT_HASH` (`18fe71f`, 2026-04-29) can no longer generate fixtures: the released `latest` test keys moved to the new key JSON schema (`attestation_keypair.public_key` etc.), so the old code fails with `KeyError: 'attestation_public'` during fixture generation.

The fix bumps the pin to **`f12000b`** (leanSpec PR #725, 2026-05-17), which reads the new key schema. This is the commit **just before** leanSpec's devnet5 work, chosen deliberately:

- An earlier draft of this PR pinned to `825bec6` (the #745 download fix). That commit unavoidably includes leanSpec PR #717 (`ac5f259`), which switched the aggregated-proof wire format to **devnet5**. The Rust client still runs `leanMultisig@5eba3b1` (pre-devnet5), so the forkchoice spec tests failed with `AggregateVerificationFailed(DeserializationFailed)`. The devnet5 proof format requires the full crypto-stack migration tracked in #378/#370, which is not yet on `main`.
- `f12000b` predates #717, so fixtures keep the **old proof format** that the current crypto stack deserializes correctly. No Rust changes are needed.

Also rename `--fork devnet` → `--fork Lstar` to match the upstream fork rename (already in effect at `f12000b`).

### Download workaround

`f12000b` predates leanSpec PR #745, whose `download_keys` reads the still-open (unflushed) download tempfile, intermittently truncating the gzip tail and aborting with `EOFError` (surfaced as `Aborted!`). Both the Makefile and CI now fetch+extract the prod keys with `curl`+`tar` before `fill`, which fully writes the archive before reading it; `fill` then sees the keys present and skips its own buggy download. Both blocks are commented `Remove once the pin moves past PR #745.`

## Why not 825bec6 / devnet5?

The devnet5 aggregated-proof wire format and the matching `ethlambda-crypto` rewrite live in #378 / #370 and are not yet merged to `main`. Bumping fixtures to a devnet5 leanSpec commit here would require duplicating that crypto work. This PR stays scoped to "unbreak fixture generation on `main`" and remains on the pre-devnet5 format until the devnet5 PRs land.

## Test plan

- [x] `rm -rf leanSpec && make leanSpec/fixtures` — clean download (via curl+tar) + extract, 554 fixtures generated, no `Aborted!`.
- [x] `cargo test -p ethlambda-blockchain --test forkchoice_spectests` — 84/0.
- [x] `cargo test -p ethlambda-blockchain --test signature_spectests` — 11/0.
- [x] `make test` — full workspace suite, 421/0.
- [ ] CI runs green.
