### PR TITLE
docs: fix gean repository URL in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,5 +419,5 @@ cargo test -p ethlambda-blockchain --test forkchoice_spectests -- --test-threads
 - ream (Rust): <https://github.com/ReamLabs/ream>
 - qlean (C++): <https://github.com/qdrvm/qlean-mini>
 - grandine (Rust): <https://github.com/grandinetech/lean/tree/main/lean_client>
-- gean (Go): <https://github.com/devlongs/gean>
+- gean (Go): <https://github.com/geanlabs/gean>
 - Lantern (C): <https://github.com/Pier-Two/lantern>


### PR DESCRIPTION
## What

Fix the gean (Go) client link in `CLAUDE.md`.

## Why

The link pointed to `devlongs/gean`, an outdated mirror (45 stars, last pushed Jan 2026). The canonical, actively-maintained repo is `geanlabs/gean` (82 stars, pushed today).

```diff
-- gean (Go): <https://github.com/devlongs/gean>
+- gean (Go): <https://github.com/geanlabs/gean>
```