### PR TITLE
fix(devnet5): don't register block-attestation data at import (broke Type-2 merge)

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -495,30 +495,32 @@ fn on_block_core(
     store.insert_signed_block(block_root, signed_block.clone());
     store.insert_state(block_root, post_state);
 
-    // Process block body attestations and feed them into the payload buffer
-    // so fork choice's LMD GHOST overlay can see block-only votes.
+    // Register each block attestation's data in the known payload buffer with
+    // no proofs, mirroring the spec's on_block.
     //
-    // Per-attestation participant bitfields come straight from
-    // `block.body.attestations[i].aggregation_bits`. Standalone Type-1
-    // proof bytes are not recoverable from a block at import time;
-    // downstream re-aggregation has to come from the gossip channel or be
-    // recovered by SNARK-splitting `signed_block.proof` via
-    // `split_type_2_by_message`. The entries inserted here are info-only,
-    // used only for fork-choice vote bookkeeping.
+    // The block carries one merged Type-2 proof binding all its attestations;
+    // that proof is verified as a whole and not decomposed here. Standalone
+    // Type-1 bytes for an individual attestation are not recoverable at import
+    // time, so we only reserve the data key. Real per-attestation proofs reach
+    // the pool later through reaggregation (SNARK-splitting `signed_block.proof`
+    // via `split_type_2_by_message`) and the gossip channel.
+    //
+    // Consequence: a block's own attestations contribute zero fork-choice weight
+    // to the head computation triggered by this import. The recovered Type-1
+    // proofs land in the new pool and migrate to known at the next acceptance
+    // tick, so block-imported vote weight is deferred by up to one slot.
     let aggregated_attestations = &block.body.attestations;
 
-    let mut known_entries: Vec<(HashedAttestationData, TypeOneMultiSignature)> =
+    let mut known_data: Vec<HashedAttestationData> =
         Vec::with_capacity(aggregated_attestations.len());
     for att in aggregated_attestations.iter() {
-        let hashed = HashedAttestationData::new(att.data.clone());
-        let type_one = TypeOneMultiSignature::empty(att.aggregation_bits.clone());
-        known_entries.push((hashed, type_one));
+        known_data.push(HashedAttestationData::new(att.data.clone()));
         // Count each participating validator as a valid attestation.
         let count = validator_indices(&att.aggregation_bits).count() as u64;
         metrics::inc_attestations_valid(count);
     }
 
-    store.insert_known_aggregated_payloads_batch(known_entries);
+    store.register_known_aggregated_data_batch(known_data);
 
     // Update forkchoice head based on new block and attestations
     update_head(store, false);

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -495,32 +495,17 @@ fn on_block_core(
     store.insert_signed_block(block_root, signed_block.clone());
     store.insert_state(block_root, post_state);
 
-    // Register each block attestation's data in the known payload buffer with
-    // no proofs, mirroring the spec's on_block.
-    //
-    // The block carries one merged Type-2 proof binding all its attestations;
-    // that proof is verified as a whole and not decomposed here. Standalone
-    // Type-1 bytes for an individual attestation are not recoverable at import
-    // time, so we only reserve the data key. Real per-attestation proofs reach
-    // the pool later through reaggregation (SNARK-splitting `signed_block.proof`
-    // via `split_type_2_by_message`) and the gossip channel.
-    //
-    // Consequence: a block's own attestations contribute zero fork-choice weight
-    // to the head computation triggered by this import. The recovered Type-1
-    // proofs land in the new pool and migrate to known at the next acceptance
-    // tick, so block-imported vote weight is deferred by up to one slot.
-    let aggregated_attestations = &block.body.attestations;
-
-    let mut known_data: Vec<HashedAttestationData> =
-        Vec::with_capacity(aggregated_attestations.len());
-    for att in aggregated_attestations.iter() {
-        known_data.push(HashedAttestationData::new(att.data.clone()));
+    // A block ships one merged Type-2 proof binding all its attestations; it is
+    // verified as a whole and never decomposed at import. Standalone per-attestation
+    // Type-1 proofs are not recoverable here, so block-borne votes carry no
+    // fork-choice weight until reaggregation (SNARK-splitting the block proof via
+    // `split_type_2_by_message`) and gossip deliver real Type-1s into the pool.
+    // Block-imported vote weight is therefore deferred by up to one slot.
+    for att in block.body.attestations.iter() {
         // Count each participating validator as a valid attestation.
         let count = validator_indices(&att.aggregation_bits).count() as u64;
         metrics::inc_attestations_valid(count);
     }
-
-    store.register_known_aggregated_data_batch(known_data);
 
     // Update forkchoice head based on new block and attestations
     update_head(store, false);

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -37,7 +37,7 @@ fn accept_new_attestations(store: &mut Store, log_tree: bool) {
 ///
 /// When `log_tree` is true, also computes block weights and logs an ASCII
 /// fork choice tree to the terminal.
-fn update_head(store: &mut Store, log_tree: bool) {
+pub fn update_head(store: &mut Store, log_tree: bool) {
     let blocks = store.get_live_chain();
     let attestations = store.extract_latest_known_attestations();
     let old_head = store.head();

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -413,8 +413,8 @@ pub fn on_block_without_verification(
 
 /// Core block processing logic.
 ///
-/// When `verify` is true, cryptographic signatures are validated and stored
-/// for future block building. When false, all signature checks are skipped.
+/// When `verify` is true, cryptographic signatures are verified.
+/// When false, all signature checks are skipped.
 fn on_block_core(
     store: &mut Store,
     signed_block: SignedBlock,
@@ -495,12 +495,6 @@ fn on_block_core(
     store.insert_signed_block(block_root, signed_block.clone());
     store.insert_state(block_root, post_state);
 
-    // A block ships one merged Type-2 proof binding all its attestations; it is
-    // verified as a whole and never decomposed at import. Standalone per-attestation
-    // Type-1 proofs are not recoverable here, so block-borne votes carry no
-    // fork-choice weight until reaggregation (SNARK-splitting the block proof via
-    // `split_type_2_by_message`) and gossip deliver real Type-1s into the pool.
-    // Block-imported vote weight is therefore deferred by up to one slot.
     for att in block.body.attestations.iter() {
         // Count each participating validator as a valid attestation.
         let count = validator_indices(&att.aggregation_bits).count() as u64;

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -7,7 +7,9 @@ use std::{
 use ethlambda_blockchain::{MILLISECONDS_PER_INTERVAL, MILLISECONDS_PER_SLOT, store};
 use ethlambda_storage::{Store, backend::InMemoryBackend};
 use ethlambda_types::{
-    attestation::{AttestationData, SignedAggregatedAttestation, SignedAttestation},
+    attestation::{
+        AttestationData, HashedAttestationData, SignedAggregatedAttestation, SignedAttestation,
+    },
     block::{Block, TypeOneMultiSignature},
     primitives::{ByteList, H256, HashTreeRoot as _},
     state::{State, anchor_pair_is_consistent},
@@ -97,7 +99,39 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
                     // NOTE: the has_proposal argument is set to true, following the spec
                     store::on_tick(&mut store, block_time_ms, true);
                     let result = store::on_block_without_verification(&mut store, signed_block);
+                    let import_ok = result.is_ok();
                     assert_step_outcome(step_idx, step.valid, result)?;
+
+                    // Deconstruct the imported block into per-attestation Type-1s,
+                    // mirroring the node's post-import reaggregation. The real node
+                    // SNARK-splits the block's merged Type-2 proof and folds the
+                    // recovered Type-1s into the pool so block-borne votes carry
+                    // fork-choice weight; leanSpec's fork-choice harness gets the
+                    // same effect by simulating the proposer build. Fixture blocks
+                    // are blank (no real proof to split), so reconstruct structurally
+                    // from the body's aggregation_bits — fork choice reads only the
+                    // participant set, not the proof bytes. The recovered entries go
+                    // straight into the known pool to match the proposer-view store
+                    // the fixtures encode.
+                    if import_ok {
+                        let block = block_data.to_block();
+                        let entries: Vec<(HashedAttestationData, TypeOneMultiSignature)> = block
+                            .body
+                            .attestations
+                            .iter()
+                            .map(|att| {
+                                (
+                                    HashedAttestationData::new(att.data.clone()),
+                                    TypeOneMultiSignature::empty(att.aggregation_bits.clone()),
+                                )
+                            })
+                            .collect();
+                        store.insert_known_aggregated_payloads_batch(entries);
+                        // on_block already ran the head update before these votes
+                        // existed; recompute so the head reflects the block's own
+                        // attestations, matching the proposer-view store.
+                        store::update_head(&mut store, false);
+                    }
                 }
                 "tick" => {
                     // Fixtures use either `time` (UNIX seconds) or `interval`

--- a/crates/common/types/src/block.rs
+++ b/crates/common/types/src/block.rs
@@ -126,9 +126,6 @@ pub type ByteList512KiB = ByteList<524_288>;
 /// Maximum number of distinct `AttestationData` entries permitted in a single
 /// block. Canonical home for the cap shared across `ethlambda-blockchain`,
 /// `ethlambda-test-fixtures`, and the wire types in this crate.
-///
-/// See: leanSpec PR #717, which lowered the cap from 16 to 8 alongside the
-/// merged block-proof refactor.
 pub const MAX_ATTESTATIONS_DATA: usize = 8;
 
 /// A Type-1 single-message proof aggregating signatures from many validators.

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -202,6 +202,31 @@ impl PayloadBuffer {
         }
     }
 
+    /// Register an attestation data key carrying no proofs.
+    ///
+    /// Mirrors the spec, which records each block attestation's data with an
+    /// empty proof set at import time. The bare key reserves its insertion-order
+    /// slot so equivocation tie-breaking stays deterministic once real proofs
+    /// arrive later through reaggregation.
+    ///
+    /// No-op when the data is already present, so a real proof is never replaced
+    /// by a later bare key. Carries no proof bytes, so it adds zero fork-choice
+    /// weight until reaggregation fills it.
+    fn register_data(&mut self, hashed: HashedAttestationData) {
+        let (data_root, att_data) = hashed.into_parts();
+        if self.data.contains_key(&data_root) {
+            return;
+        }
+        self.data.insert(
+            data_root,
+            PayloadEntry {
+                data: att_data,
+                proofs: Vec::new(),
+            },
+        );
+        self.order.push_back(data_root);
+    }
+
     /// Take all entries, leaving the buffer empty.
     ///
     /// Drains in insertion order (via `self.order`) so downstream consumers
@@ -1191,6 +1216,19 @@ impl Store {
         entries: Vec<(HashedAttestationData, TypeOneMultiSignature)>,
     ) {
         self.known_payloads.lock().unwrap().push_batch(entries);
+    }
+
+    /// Register block-attestation data keys in the known buffer with no proofs.
+    ///
+    /// Spec parity: on_block records each block attestation's data with an empty
+    /// proof set. These entries carry no proof bytes, so they contribute zero
+    /// fork-choice weight; the weight arrives once reaggregation recovers real
+    /// Type-1 proofs for the same data into the pool.
+    pub fn register_known_aggregated_data_batch(&mut self, entries: Vec<HashedAttestationData>) {
+        let mut buf = self.known_payloads.lock().unwrap();
+        for hashed in entries {
+            buf.register_data(hashed);
+        }
     }
 
     // ============ New Aggregated Payloads ============

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -202,31 +202,6 @@ impl PayloadBuffer {
         }
     }
 
-    /// Register an attestation data key carrying no proofs.
-    ///
-    /// Mirrors the spec, which records each block attestation's data with an
-    /// empty proof set at import time. The bare key reserves its insertion-order
-    /// slot so equivocation tie-breaking stays deterministic once real proofs
-    /// arrive later through reaggregation.
-    ///
-    /// No-op when the data is already present, so a real proof is never replaced
-    /// by a later bare key. Carries no proof bytes, so it adds zero fork-choice
-    /// weight until reaggregation fills it.
-    fn register_data(&mut self, hashed: HashedAttestationData) {
-        let (data_root, att_data) = hashed.into_parts();
-        if self.data.contains_key(&data_root) {
-            return;
-        }
-        self.data.insert(
-            data_root,
-            PayloadEntry {
-                data: att_data,
-                proofs: Vec::new(),
-            },
-        );
-        self.order.push_back(data_root);
-    }
-
     /// Take all entries, leaving the buffer empty.
     ///
     /// Drains in insertion order (via `self.order`) so downstream consumers
@@ -1216,19 +1191,6 @@ impl Store {
         entries: Vec<(HashedAttestationData, TypeOneMultiSignature)>,
     ) {
         self.known_payloads.lock().unwrap().push_batch(entries);
-    }
-
-    /// Register block-attestation data keys in the known buffer with no proofs.
-    ///
-    /// Spec parity: on_block records each block attestation's data with an empty
-    /// proof set. These entries carry no proof bytes, so they contribute zero
-    /// fork-choice weight; the weight arrives once reaggregation recovers real
-    /// Type-1 proofs for the same data into the pool.
-    pub fn register_known_aggregated_data_batch(&mut self, entries: Vec<HashedAttestationData>) {
-        let mut buf = self.known_payloads.lock().unwrap();
-        for hashed in entries {
-            buf.register_data(hashed);
-        }
     }
 
     // ============ New Aggregated Payloads ============


### PR DESCRIPTION
## Summary

Fixes the devnet error `Failed to merge Type-1s into Type-2 ... child proof deserialization failed at index N`.

**Root cause:** block import seeded the known payload pool with `TypeOneMultiSignature::empty(bits)` placeholders (participant bits, *empty proof bytes*) so block-borne votes carried fork-choice weight. Block building read the same pool and fed those empty bytes into the Type-2 merge, where lean-multisig decompression failed.

**Fix:** stop registering block-attestation data in the pool at import altogether.

A first pass mirrored leanSpec's `on_block` — registering each attestation's data key with an *empty proof set* instead of a proof-less placeholder. That removed the crash, but the empty entries turned out to be inert in our weight model and introduced an unbounded-growth path (see below), so the final version drops the registration entirely.

## Why removing it is safe

ethlambda derives fork-choice weight from proof **participant bits**, not from data-key presence:

- `extract_latest_attestations` iterates `entry.proofs`; an empty proof set yields zero voters.
- the block builder scores candidates by voters-from-proofs, so an empty entry is never selected and never reaches `merge_type_1s_into_type_2`.

So a registered-but-empty entry contributed **zero weight** and zero merge input. Its only observable effect was reserving an insertion-order slot for same-slot equivocation tie-breaking, which reaggregation re-establishes in block-attestation order anyway.

Block-borne vote weight is still recovered: reaggregation SNARK-splits the block's merged Type-2 into per-attestation Type-1s (`split_type_2_by_message`) into the new pool, and gossip delivers them; both migrate to the known pool at the next acceptance tick. This matches the spec's documented one-slot deferral.

## Bonus: closes an unbounded-growth path

The empty-proof entries bypassed the payload buffer's only capacity limit. `PayloadBuffer` evicts when `total_proofs > capacity`, but the bare-key insertion never incremented `total_proofs`, so a non-finalizing chain could grow `known_payloads` past its bound. Removing the registration eliminates this by construction (flagged by all four PR reviewers).

## Changes

- `crates/blockchain/src/store.rs`: `on_block_core` no longer registers block-attestation data keys (keeps the per-validator attestation-valid metric).
- `crates/storage/src/store.rs`: delete the now-dead `PayloadBuffer::register_data` and `Store::register_known_aggregated_data_batch`.
- `crates/blockchain/tests/forkchoice_spectests.rs`: the harness deconstructs each imported block into per-attestation Type-1s (structurally, from `aggregation_bits`) into the known pool and recomputes the head — reproducing the proposer-view store the fixtures encode, the role leanSpec's harness fills via its proposer-build simulation. These entries go through `push`, so they are properly accounted and bounded.

## Notes / follow-ups

- The spec routes block-reaggregated votes to the `new` pool (deferred), which a leanSpec reviewer flagged as leaving receiving nodes with zero block-vote weight (leanEthereum/leanSpec#717, discussion_r3259006576). The `new`-vs-`known` question remains open upstream.
- Backfilling nodes don't run reaggregation (it is `synced`-gated in `lib.rs`), so block-borne votes during sync rely on gossip re-delivery. Accepted as an OK tradeoff for now; tracked as a follow-up.

## Test plan

- [x] `cargo test --workspace --release` — full suite passes (forkchoice 84, stf 51, signature 13, storage 38, ssz 118, …; 0 failures)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --release -- -D warnings` clean