### PR TITLE
fix(docs): restore docs.ethlambda.xyz custom domain on deploy

### DIFF
--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -110,8 +110,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: book/html
           destination_dir: .
-          # Re-write the CNAME file on every deploy so the custom domain
-          # binding survives. Without this, peaceiris republishes book/html
-          # without a CNAME, which wipes the custom domain (resetting Pages
-          # `cname` to null) and makes docs.ethlambda.xyz return 404.
           cname: docs.ethlambda.xyz

--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -110,3 +110,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: book/html
           destination_dir: .
+          # Re-write the CNAME file on every deploy so the custom domain
+          # binding survives. Without this, peaceiris republishes book/html
+          # without a CNAME, which wipes the custom domain (resetting Pages
+          # `cname` to null) and makes docs.ethlambda.xyz return 404.
+          cname: docs.ethlambda.xyz


### PR DESCRIPTION
## Problem

https://docs.ethlambda.xyz/ returns **404**, even though the docs build and deploy succeed and `https://lambdaclass.github.io/ethlambda/` serves **200**.

### Root cause

| Check | Result |
|-------|--------|
| `lambdaclass.github.io/ethlambda/` | 200 (content live) |
| `docs.ethlambda.xyz` | 404 |
| DNS → GitHub Pages IPs | correct |
| Pages API `cname` field | `null` |
| `CNAME` file in `gh-pages` | absent |

The deploy step used `peaceiris/actions-gh-pages@v4` **without a `cname:` parameter**, so every deploy republished `book/html` without a `CNAME` file. The custom domain (originally set via the Pages UI, which writes a `CNAME` file) got wiped by a later deploy, resetting Pages `cname` to `null`. DNS still points the browser at GitHub's edge, but Pages no longer associates `docs.ethlambda.xyz` with this repo, so it 404s.

## Fix

Add `cname: docs.ethlambda.xyz` to the deploy step so the `CNAME` file is re-written on every deploy, making the custom domain binding durable.

## Note (manual step to restore *now*)

This makes future deploys self-healing. To restore the live site immediately, the domain must also be re-set once: merge this (the deploy on `main` will write the CNAME and re-bind the domain), or re-enter the domain under **Settings → Pages → Custom domain**.