### PR TITLE
Add per-subnet attestation aggregate count coverage to metrics

### DIFF
--- a/crates/blockchain/src/coverage.rs
+++ b/crates/blockchain/src/coverage.rs
@@ -56,15 +56,27 @@ fn cov_add(seen: &mut [bool], has_subnet: &mut [bool], bits: &AggregationBits) {
 }
 
 fn cov_record(section: &str, seen: &[bool], has_subnet: &[bool]) {
-    // TODO(#398): emit a per-subnet breakdown (subnet=subnet_N) alongside the
-    // subnet=combined total. `has_subnet` already tracks which subnets are
-    // covered, but we only report the aggregate count here; the per-subnet
-    // label is reserved in the metric definition and not yet populated.
     metrics::set_attestation_aggregate_coverage_validators(
         section,
         "combined",
         seen.iter().filter(|&&b| b).count() as i64,
     );
+    let cc = has_subnet.len();
+    if cc > 0 {
+        let mut subnet_counts = vec![0i64; cc];
+        for (vid, &was_seen) in seen.iter().enumerate() {
+            if was_seen {
+                subnet_counts[vid % cc] += 1;
+            }
+        }
+        for (i, &count) in subnet_counts.iter().enumerate() {
+            metrics::set_attestation_aggregate_coverage_validators(
+                section,
+                &format!("subnet_{i}"),
+                count,
+            );
+        }
+    }
     metrics::set_attestation_aggregate_coverage_subnets(
         section,
         has_subnet.iter().filter(|&&b| b).count() as i64,

--- a/crates/blockchain/src/metrics.rs
+++ b/crates/blockchain/src/metrics.rs
@@ -128,9 +128,8 @@ static LEAN_ATTESTATION_AGGREGATE_COVERAGE_VALIDATORS: std::sync::LazyLock<IntGa
         register_int_gauge_vec!(
             "lean_attestation_aggregate_coverage_validators",
             "Validator coverage in attestation aggregate reports, labeled by section and \
-             subnet. Only subnet=combined (the section total) is currently emitted; the \
-             subnet=subnet_N per-subnet breakdown is reserved and not yet populated. \
-             Updated each slot (slot is the X-axis).",
+             subnet. subnet=combined is the section total; subnet=subnet_N is the count of \
+             validators in subnet N that were seen. Updated each slot (slot is the X-axis).",
             &["section", "subnet"]
         )
         .unwrap()

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -131,7 +131,7 @@ Observability into how many validators/subnets are covered by the attestations t
 
 | Name | Type | Usage | Sample collection event | Labels |
 |------|------|-------|-------------------------|--------|
-| `lean_attestation_aggregate_coverage_validators` | Gauge | Validator coverage in attestation aggregate reports | Per round, per section (see note above) | section=timely,late,block,combined,agg_start_new,proposal_combined<br>subnet=combined (per-subnet breakdown reserved, not yet populated) |
+| `lean_attestation_aggregate_coverage_validators` | Gauge | Validator coverage in attestation aggregate reports | Per round, per section (see note above) | section=timely,late,block,combined,agg_start_new,proposal_combined<br>subnet=combined,subnet_0,subnet_1,…,subnet_N-1 |
 | `lean_attestation_aggregate_coverage_subnets` | Gauge | Number of covered subnets in attestation aggregate reports | Per round, per section (see note above) | section=timely,late,block,combined,agg_start_new,proposal_combined |
 | `lean_attestation_aggregate_coverage_diff_validators` | Gauge | Validators in the symmetric difference between block-included aggregates and locally-aggregated timely aggregates for the same slot | On block import, when the head carries the round's votes (see note above) | direction=block_only,timely_only |
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

`lean_attestation_aggregate_coverage_validators` is registered with `[section, subnet]` labels, but only the `subnet=combined` total was emitted, while the per-subnet series was reserved in the metric definition and left empty. This PR populates `subnet=subnet_N` for each subnet alongside the existing combined total, surfacing per-subnet validator coverage in dashboards/alerts.

## What Changed

- `crates/blockchain/src/coverage.rs` — `cov_record` now derives a per-subnet validator count from the `seen` bitmap (`vid % committee_count` bucketing, same formula as the existing gossip subnet assignment) and emits one `subnet=subnet_<i>` gauge per subnet. Removed the resolved `TODO(#398)` comment.
- `crates/blockchain/src/metrics.rs` — updated the `lean_attestation_aggregate_coverage_validators` description to reflect that both label values are now populated.
- `docs/metrics.md` — updated the labels column for the same metric.

## Correctness / Behavior Guarantees

- `cov_add` is unchanged; the new per-subnet counts are derived at emit time inside `cov_record`. No signature changes, no caller updates.
- The new `subnet=subnet_<i>` series is **additive**: the existing `subnet=combined` value is unchanged, so any pre-existing query/alert keeps working.
- `cov_record` emits per-subnet values for every `i ∈ [0, committee_count)`, including zero counts — so dashboards see a flat-zero series rather than missing samples when a subnet has no coverage.
- `lean_attestation_aggregate_coverage_subnets` (separate metric, counts how many subnets had any coverage) is unchanged.

### Cardinality

Series = `sections × (subnets + 1)` per the issue. With 6 sections (`timely`, `late`, `block`, `combined`, `agg_start_new`, `proposal_combined`) and the typical configured `attestation_committee_count` (1–4 on current devnets), the metric tops out at ~30 series. Bounded by `ATTESTATION_COMMITTEE_COUNT`.

## Tests Added / Run

None added. Verified manually by running a local devnet and confirming `/metrics` exposes one `subnet=subnet_N` series per configured subnet for every section, with the combined-vs-sum-of-subnets invariant holding.

## Related Issues / PRs

- Closes #398

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `cargo test --workspace --release` — all passing
- [x] Ran local devnet and checked the `/metrics` endpoint's response