### PR TITLE
chore: bump leanVM to 8fcbd779 and leanSpec to latest main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,26 +118,16 @@ jobs:
           key: ${{ steps.cache-prod-keys.outputs.cache-primary-key }}
 
       # `-n 1` (not `-n auto`) runs a single leanVM prover at a time. The
-      # devnet5 prover peaks at ~4-5 GiB per proof; more workers multiply that
-      # past the 4-vCPU/16 GiB runner's RAM. `-n auto` (4 provers) OOM-killed
-      # the runner outright; `-n 2` (2 provers) thrashed and lost its heartbeat
-      # mid-generation, so GitHub cancelled the job. One prover (~4.5 GiB)
-      # should stay responsive. The Makefile keeps `-n auto` for local machines.
-      #
-      # The background sampler logs RAM/swap every 15s so we can confirm memory
-      # is the cause and tune the worker count. Remove once generation is green.
+      # devnet5 prover peaks at ~12 GiB per proof (measured), so more workers
+      # blow past the 4-vCPU/16 GiB runner's RAM: `-n auto` (4 provers) hard
+      # OOM-killed the runner, `-n 2` thrashed and lost its heartbeat so GitHub
+      # cancelled the job. One prover peaks ~12.4 GiB with 0 swap and completes
+      # in ~2h36m. The Makefile keeps `-n auto` for local machines with more RAM.
       - name: Generate test fixtures
         id: generate-fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'
         working-directory: leanSpec
-        run: |
-          ( while true; do
-              echo "[mem $(date -u +%H:%M:%S)] $(free -m | awk 'NR==2{m=sprintf("mem_used=%sMiB avail=%sMiB",$3,$7)} NR==3{s=sprintf("swap_used=%sMiB",$3)} END{print m, s}')"
-              sleep 15
-            done ) &
-          MON=$!
-          trap 'kill "$MON" 2>/dev/null' EXIT
-          uv run fill --fork Lstar -n 1 --scheme prod -o fixtures
+        run: uv run fill --fork Lstar -n 1 --scheme prod -o fixtures
 
       # Save fixtures only when generation actually SUCCEEDED. A bare
       # `always()` here previously saved the (empty) fixtures dir when

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,16 +117,26 @@ jobs:
           path: leanSpec/packages/testing/src/consensus_testing/test_keys/prod_scheme
           key: ${{ steps.cache-prod-keys.outputs.cache-primary-key }}
 
-      # `-n 2` (not `-n auto`) caps the number of concurrent leanVM provers.
-      # The devnet5 prover peaks at ~4-5 GiB per proof; `-n auto` on the
-      # 4-vCPU/16 GiB GitHub runner spawns 4 provers (~18 GiB) and OOM-kills
-      # the runner mid-generation. Proving is core-bound (rayon saturates all
-      # cores per proof), so fewer workers barely affects wall-time. The
-      # Makefile keeps `-n auto` for local machines with more memory.
+      # `-n 1` (not `-n auto`) runs a single leanVM prover at a time. The
+      # devnet5 prover peaks at ~4-5 GiB per proof; more workers multiply that
+      # past the 4-vCPU/16 GiB runner's RAM. `-n auto` (4 provers) OOM-killed
+      # the runner outright; `-n 2` (2 provers) thrashed and lost its heartbeat
+      # mid-generation, so GitHub cancelled the job. One prover (~4.5 GiB)
+      # should stay responsive. The Makefile keeps `-n auto` for local machines.
+      #
+      # The background sampler logs RAM/swap every 15s so we can confirm memory
+      # is the cause and tune the worker count. Remove once generation is green.
       - name: Generate test fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'
         working-directory: leanSpec
-        run: uv run fill --fork Lstar -n 2 --scheme prod -o fixtures
+        run: |
+          ( while true; do
+              echo "[mem $(date -u +%H:%M:%S)] $(free -m | awk 'NR==2{m=sprintf("mem_used=%sMiB avail=%sMiB",$3,$7)} NR==3{s=sprintf("swap_used=%sMiB",$3)} END{print m, s}')"
+              sleep 15
+            done ) &
+          MON=$!
+          trap "kill $MON 2>/dev/null" EXIT
+          uv run fill --fork Lstar -n 1 --scheme prod -o fixtures
 
       # Save fixtures even if a later step fails, so a re-run does not
       # have to regenerate them. See: https://github.com/actions/cache/tree/main/save#always-save-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,16 @@ jobs:
           path: leanSpec/packages/testing/src/consensus_testing/test_keys/prod_scheme
           key: ${{ steps.cache-prod-keys.outputs.cache-primary-key }}
 
+      # `-n 2` (not `-n auto`) caps the number of concurrent leanVM provers.
+      # The devnet5 prover peaks at ~4-5 GiB per proof; `-n auto` on the
+      # 4-vCPU/16 GiB GitHub runner spawns 4 provers (~18 GiB) and OOM-kills
+      # the runner mid-generation. Proving is core-bound (rayon saturates all
+      # cores per proof), so fewer workers barely affects wall-time. The
+      # Makefile keeps `-n auto` for local machines with more memory.
       - name: Generate test fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'
         working-directory: leanSpec
-        run: uv run fill --fork Lstar -n auto --scheme prod -o fixtures
+        run: uv run fill --fork Lstar -n 2 --scheme prod -o fixtures
 
       # Save fixtures even if a later step fails, so a re-run does not
       # have to regenerate them. See: https://github.com/actions/cache/tree/main/save#always-save-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
               sleep 15
             done ) &
           MON=$!
-          trap "kill $MON 2>/dev/null" EXIT
+          trap 'kill "$MON" 2>/dev/null' EXIT
           uv run fill --fork Lstar -n 1 --scheme prod -o fixtures
 
       # Save fixtures even if a later step fails, so a re-run does not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
       # The background sampler logs RAM/swap every 15s so we can confirm memory
       # is the cause and tune the worker count. Remove once generation is green.
       - name: Generate test fixtures
+        id: generate-fixtures
         if: steps.cache-fixtures.outputs.cache-hit != 'true'
         working-directory: leanSpec
         run: |
@@ -138,10 +139,18 @@ jobs:
           trap 'kill "$MON" 2>/dev/null' EXIT
           uv run fill --fork Lstar -n 1 --scheme prod -o fixtures
 
-      # Save fixtures even if a later step fails, so a re-run does not
-      # have to regenerate them. See: https://github.com/actions/cache/tree/main/save#always-save-cache
+      # Save fixtures only when generation actually SUCCEEDED. A bare
+      # `always()` here previously saved the (empty) fixtures dir when
+      # generation was cancelled or OOM-killed mid-run, poisoning the cache:
+      # later runs hit the empty cache, skipped generation, and the Rust tests
+      # failed with no fixtures. Gating on the generate step's outcome keeps
+      # the "save even if the later Rust test step fails" intent without ever
+      # persisting a partial fixture set.
       - name: Save test fixtures cache
-        if: always() && steps.cache-fixtures.outputs.cache-hit != 'true'
+        if: >-
+          always()
+          && steps.cache-fixtures.outputs.cache-hit != 'true'
+          && steps.generate-fixtures.outcome == 'success'
         uses: actions/cache/save@v5
         with:
           path: leanSpec/fixtures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1940,7 +1940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "clap",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "include_dir",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4898,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "serde",
 ]
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -5099,7 +5099,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6378,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "include_dir",
@@ -6699,7 +6699,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7211,7 +7211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "libc",
  "rayon",
@@ -7549,7 +7549,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8071,7 +8071,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "tracing",
@@ -8370,7 +8370,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9037,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "libc",
  "system-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -3664,7 +3664,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "clap",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "include_dir",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4898,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "serde",
 ]
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -5302,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5346,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-field 0.5.1",
  "p3-maybe-rayon 0.5.1",
@@ -5372,14 +5372,14 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
  "p3-matrix 0.5.1",
  "p3-maybe-rayon 0.5.1",
  "p3-util 0.5.1",
- "spin 0.11.0",
+ "spin 0.10.0",
  "tracing",
 ]
 
@@ -5400,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5432,7 +5432,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5462,7 +5462,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5482,7 +5482,7 @@ checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 
 [[package]]
 name = "p3-mds"
@@ -5502,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-dft 0.5.1",
  "p3-field 0.5.1",
@@ -5514,7 +5514,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5530,17 +5530,16 @@ dependencies = [
  "paste",
  "rand 0.10.1",
  "serde",
- "spin 0.11.0",
+ "spin 0.10.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-field 0.5.1",
- "p3-mds 0.5.1",
  "p3-symmetric 0.5.1",
  "rand 0.10.1",
 ]
@@ -5562,7 +5561,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "p3-field 0.5.1",
  "p3-mds 0.5.1",
@@ -5585,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5605,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#2aeaa17557e7f54b0caa0add42e7d5b9aec4f564"
+source = "git+https://github.com/Plonky3/Plonky3.git#3f67d136c71bec40f180c85d0bb2b654acddef22"
 dependencies = [
  "serde",
  "transpose",
@@ -6379,7 +6378,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "include_dir",
@@ -7357,9 +7356,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
@@ -7428,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7522,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "libc",
  "rayon",
@@ -7547,7 +7546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
@@ -8072,7 +8071,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "backend",
  "tracing",
@@ -9038,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=0520822#0520822dc64df67886f4a053b60b4de14b181348"
 dependencies = [
  "libc",
  "system-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -3664,7 +3664,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "clap",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "include_dir",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4830,11 +4830,11 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
- "num-bigint 0.4.6",
+ "num-bigint 0.3.3",
  "paste",
  "rand 0.10.1",
  "rayon",
@@ -4845,12 +4845,12 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
  "mt-utils",
- "num-bigint 0.4.6",
+ "num-bigint 0.3.3",
  "paste",
  "rand 0.10.1",
  "rayon",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4898,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "serde",
 ]
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -6379,7 +6379,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "include_dir",
@@ -7428,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "libc",
  "rayon",
@@ -8072,7 +8072,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "backend",
  "tracing",
@@ -9038,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=0242c909#0242c909260c9e16893baae3004667230429808d"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77#8fcbd77958a58666e828315de2d6ce7c93297117"
 dependencies = [
  "libc",
  "system-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,4 +76,3 @@ eyre = "0.6"
 # Allocator + heap profiling
 tikv-jemallocator = { version = "0.6", features = ["stats", "unprefixed_malloc_on_supported_platforms", "profiling"] }
 jemalloc_pprof = { version = "0.8", features = ["flamegraph"] }
-

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ docker-build: ## 🐳 Build the Docker image
 		-t ghcr.io/lambdaclass/ethlambda:$(DOCKER_TAG) .
 	@echo
 
-# 2026-05-21
-LEAN_SPEC_COMMIT_HASH:=825bec6bf278920cfc56730d64a7c90522a0bb6c
+# 2026-06-03
+LEAN_SPEC_COMMIT_HASH:=30ffb6cab54ca6d2e2e1c82e8e2713ebb9a8fa3f
 
 leanSpec:
 	git clone https://github.com/leanEthereum/leanSpec.git --single-branch

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -12,9 +12,9 @@ version.workspace = true
 [dependencies]
 ethlambda-types.workspace = true
 
-lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8fcbd77" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "0520822" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8fcbd77" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "0520822" }
 
 leansig.workspace = true
 thiserror.workspace = true

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -12,9 +12,9 @@ version.workspace = true
 [dependencies]
 ethlambda-types.workspace = true
 
-lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "0242c909" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8fcbd77" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "0242c909" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8fcbd77" }
 
 leansig.workspace = true
 thiserror.workspace = true

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -12,9 +12,9 @@ version.workspace = true
 [dependencies]
 ethlambda-types.workspace = true
 
-lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "0520822" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd779" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "0520822" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd779" }
 
 leansig.workspace = true
 thiserror.workspace = true

--- a/crates/common/crypto/src/lib.rs
+++ b/crates/common/crypto/src/lib.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 /// log(1/rate) for the WHIR commitment scheme used inside lean-multisig.
 /// 2 matches the devnet-4 cross-client convention (zeam, ream, grandine, lantern
-/// all use 2); the leanMultisig devnet5 examples also use 2 for recursion.
+/// all use 2); the leanVM devnet5 examples also use 2 for recursion.
 const LOG_INV_RATE: usize = 2;
 
 // Lazy initialization for prover and verifier setup

--- a/crates/common/test-fixtures/src/common.rs
+++ b/crates/common/test-fixtures/src/common.rs
@@ -98,10 +98,10 @@ impl From<BlockHeader> for ethlambda_types::block::BlockHeader {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Validator {
     index: u64,
-    #[serde(rename = "attestationPubkey")]
+    #[serde(rename = "attestationPublicKey")]
     #[serde(deserialize_with = "deser_pubkey_hex")]
     attestation_pubkey: ValidatorPubkeyBytes,
-    #[serde(rename = "proposalPubkey")]
+    #[serde(rename = "proposalPublicKey")]
     #[serde(deserialize_with = "deser_pubkey_hex")]
     proposal_pubkey: ValidatorPubkeyBytes,
 }

--- a/crates/common/test-fixtures/src/fork_choice.rs
+++ b/crates/common/test-fixtures/src/fork_choice.rs
@@ -84,7 +84,7 @@ fn default_true() -> bool {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct AttestationStepData {
-    #[serde(rename = "validatorId")]
+    #[serde(rename = "validatorIndex")]
     pub validator_id: Option<u64>,
     pub data: AttestationData,
     #[serde(default, deserialize_with = "deser_opt_xmss_hex")]

--- a/crates/common/test-fixtures/src/verify_signatures.rs
+++ b/crates/common/test-fixtures/src/verify_signatures.rs
@@ -56,7 +56,29 @@ pub struct VerifySignaturesTest {
 pub struct TestSignedBlock {
     #[serde(alias = "message")]
     pub block: Block,
-    pub proof: HexBytes,
+    pub proof: ProofField,
+}
+
+/// Merged Type-2 proof bytes, in either fixture shape.
+///
+/// leanSpec PR #799 typed `SignedBlock.proof` as a multi-signature container,
+/// nesting the bytes one level deeper: `{ "proof": { "data": "0x..." } }`.
+/// The flat `{ "data": "0x..." }` shape (PR #717) is still accepted since the
+/// Hive test driver receives the same JSON from older spec-assets simulators.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ProofField {
+    Typed { proof: HexBytes },
+    Flat(HexBytes),
+}
+
+impl ProofField {
+    pub fn decode(&self) -> Result<Vec<u8>, hex::FromHexError> {
+        match self {
+            Self::Typed { proof } => proof.decode(),
+            Self::Flat(bytes) => bytes.decode(),
+        }
+    }
 }
 
 /// `{ "data": "0x..." }` wrapper used by leanSpec fixtures for byte fields.
@@ -107,14 +129,22 @@ impl From<TestSignedBlock> for SignedBlock {
 impl TestSignedBlock {
     /// Materialize a `SignedBlock` preserving the fixture-supplied merged
     /// Type-2 proof bytes verbatim.
+    ///
+    /// The typed shape carries the raw lean-multisig wire, so it gets wrapped
+    /// into the SSZ-container envelope `SignedBlock.proof` stores. The flat
+    /// shape already includes that envelope and passes through unchanged.
     pub fn try_into_signed_block_with_proofs(self) -> Result<SignedBlock, SignedBlockConvertError> {
         let bytes = self
             .proof
             .decode()
             .map_err(|err| SignedBlockConvertError::InvalidProofHex(err.to_string()))?;
         let len = bytes.len();
-        let proof = ByteList512KiB::try_from(bytes)
-            .map_err(|_| SignedBlockConvertError::ProofTooLarge(len))?;
+        let proof = match self.proof {
+            ProofField::Typed { .. } => SignedBlock::wrap_merged_proof(&bytes)
+                .map_err(|_| SignedBlockConvertError::ProofTooLarge(len))?,
+            ProofField::Flat(_) => ByteList512KiB::try_from(bytes)
+                .map_err(|_| SignedBlockConvertError::ProofTooLarge(len))?,
+        };
         Ok(SignedBlock {
             message: self.block.into(),
             proof,

--- a/crates/common/test-fixtures/src/verify_signatures.rs
+++ b/crates/common/test-fixtures/src/verify_signatures.rs
@@ -1,17 +1,17 @@
-//! Signature-verification test fixture types (leanSpec PR #717 schema).
+//! Signature-verification test fixture types (leanSpec PR #799 schema).
 //!
 //! Used both by the offline spec-test runner and the Hive
 //! `/lean/v0/test_driver/verify_signatures/run` endpoint, which receive the
 //! same JSON shapes from the lean spec-assets simulator.
 //!
-//! Fixture shape after PR #717:
+//! Fixture shape after PR #799:
 //!
 //!   signedBlock:
 //!     block:  {...standard block fields...}
-//!     proof:  { data: "0x<hex-encoded merged Type-2 bytes>" }
+//!     proof:  { proof: { data: "0x<hex-encoded merged Type-2 bytes>" } }
 
 use crate::{Block, TestInfo, TestState};
-use ethlambda_types::block::{ByteList512KiB, SignedBlock};
+use ethlambda_types::block::SignedBlock;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt;
@@ -56,28 +56,21 @@ pub struct VerifySignaturesTest {
 pub struct TestSignedBlock {
     #[serde(alias = "message")]
     pub block: Block,
-    pub proof: ProofField,
+    pub proof: MergedProof,
 }
 
-/// Merged Type-2 proof bytes, in either fixture shape.
+/// Merged Type-2 proof container for `SignedBlock.proof` (leanSpec PR #799).
 ///
-/// leanSpec PR #799 typed `SignedBlock.proof` as a multi-signature container,
-/// nesting the bytes one level deeper: `{ "proof": { "data": "0x..." } }`.
-/// The flat `{ "data": "0x..." }` shape (PR #717) is still accepted since the
-/// Hive test driver receives the same JSON from older spec-assets simulators.
+/// The multi-signature container nests the raw lean-multisig wire one level
+/// deep: `{ "proof": { "data": "0x..." } }`.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(untagged)]
-pub enum ProofField {
-    Typed { proof: HexBytes },
-    Flat(HexBytes),
+pub struct MergedProof {
+    pub proof: HexBytes,
 }
 
-impl ProofField {
+impl MergedProof {
     pub fn decode(&self) -> Result<Vec<u8>, hex::FromHexError> {
-        match self {
-            Self::Typed { proof } => proof.decode(),
-            Self::Flat(bytes) => bytes.decode(),
-        }
+        self.proof.decode()
     }
 }
 
@@ -130,21 +123,16 @@ impl TestSignedBlock {
     /// Materialize a `SignedBlock` preserving the fixture-supplied merged
     /// Type-2 proof bytes verbatim.
     ///
-    /// The typed shape carries the raw lean-multisig wire, so it gets wrapped
-    /// into the SSZ-container envelope `SignedBlock.proof` stores. The flat
-    /// shape already includes that envelope and passes through unchanged.
+    /// The container carries the raw lean-multisig wire, so it gets wrapped
+    /// into the SSZ-container envelope that `SignedBlock.proof` stores.
     pub fn try_into_signed_block_with_proofs(self) -> Result<SignedBlock, SignedBlockConvertError> {
         let bytes = self
             .proof
             .decode()
             .map_err(|err| SignedBlockConvertError::InvalidProofHex(err.to_string()))?;
         let len = bytes.len();
-        let proof = match self.proof {
-            ProofField::Typed { .. } => SignedBlock::wrap_merged_proof(&bytes)
-                .map_err(|_| SignedBlockConvertError::ProofTooLarge(len))?,
-            ProofField::Flat(_) => ByteList512KiB::try_from(bytes)
-                .map_err(|_| SignedBlockConvertError::ProofTooLarge(len))?,
-        };
+        let proof = SignedBlock::wrap_merged_proof(&bytes)
+            .map_err(|_| SignedBlockConvertError::ProofTooLarge(len))?;
         Ok(SignedBlock {
             message: self.block.into(),
             proof,

--- a/crates/common/types/tests/ssz_types.rs
+++ b/crates/common/types/tests/ssz_types.rs
@@ -74,7 +74,7 @@ pub fn decode_hex_h256(hex_str: &str) -> Result<H256, Box<dyn std::error::Error>
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Attestation {
-    #[serde(rename = "validatorId")]
+    #[serde(rename = "validatorIndex")]
     pub validator_id: u64,
     pub data: AttestationData,
 }
@@ -107,7 +107,7 @@ where
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct SignedAttestation {
-    #[serde(rename = "validatorId")]
+    #[serde(rename = "validatorIndex")]
     pub validator_id: u64,
     pub data: AttestationData,
     #[serde(deserialize_with = "deser_signature_hex")]

--- a/crates/net/rpc/tests/test_driver_e2e.rs
+++ b/crates/net/rpc/tests/test_driver_e2e.rs
@@ -261,7 +261,7 @@ async fn verify_signatures_with_empty_validator_set_fails_cleanly() {
             "stateRoot": ZERO_ROOT,
             "body": {"attestations": {"data": []}},
         },
-        "proof": {"data": "0x"},
+        "proof": {"proof": {"data": "0x"}},
     });
 
     let body = json!({


### PR DESCRIPTION
## 🗒️ Description / Motivation

Recent leanVM changes introduced performance improvements. The upstream repo was also renamed from `leanMultisig` to `leanVM`. The pin matches the exact leanVM rev that leanSpec uses, so fixtures and client use the same prover/verifier.

## What Changed

- Bump the multisig dependency to commit `8fcbd779`: the leanVM devnet5 rev that leanSpec main locks via `lean-multisig-py` v0.0.6.
- Switch the git remote from `leanEthereum/leanMultisig` to the renamed `leanEthereum/leanVM`.
- Pin transitive Plonky3 to `3f67d136` (the rev leanVM `8fcbd779` locks against). The floating Plonky3 HEAD otherwise resolved to a newer rev that requires the unstable `maybe_uninit_slice` feature and fails to build on stable.
- Bump `LEAN_SPEC_COMMIT_HASH` in the Makefile to latest leanSpec main (`30ffb6ca`, 2026-06-03), which is what pulls in `lean-multisig-py` v0.0.6.