### PR TITLE
chore: point leanMultisig deps at renamed leanVM repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ actual_slot = finalized_slot + 1 + relative_index
 - Post-quantum signature scheme
 - 52-byte public keys, 3112-byte signatures
 - Epoch-based to prevent reuse
-- Aggregation via leanVM for efficiency
+- Aggregation via leanVM (previously leanMultisig) for efficiency
 
 **Signature Aggregation (Two-Phase):**
 1. **Gossip signatures**: Fresh XMSS from network → aggregate via leanVM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -3644,7 +3644,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "clap",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "lean_vm",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4804,11 +4804,11 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
- "num-bigint 0.4.6",
+ "num-bigint 0.3.3",
  "paste",
  "rand 0.10.1",
  "rayon",
@@ -4819,12 +4819,12 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
  "mt-utils",
- "num-bigint 0.4.6",
+ "num-bigint 0.3.3",
  "paste",
  "rand 0.10.1",
  "rayon",
@@ -4835,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4848,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "serde",
 ]
@@ -4879,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -6341,7 +6341,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "lean_compiler",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "lean_vm",
@@ -8021,7 +8021,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "tracing",

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -12,9 +12,11 @@ version.workspace = true
 [dependencies]
 ethlambda-types.workspace = true
 
-lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b1" }
+# lean-multisig is the XMSS signature aggregation crate from leanVM (the repo was
+# previously named leanMultisig). The crate package keeps the lean-multisig name.
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "5eba3b1" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b1" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "5eba3b1" }
 
 leansig.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

The leanMultisig project was renamed to **leanVM**, and its GitHub repo `leanEthereum/leanMultisig` now redirects to `leanEthereum/leanVM`. This points ethlambda's git dependencies at the new URL.

## Changes

| File | Change |
|------|--------|
| `crates/common/crypto/Cargo.toml` | `lean-multisig` + `leansig_wrapper` git URLs → `leanEthereum/leanVM.git` (rev `5eba3b1` unchanged); comment notes the repo rename |
| `Cargo.lock` | Re-resolved: 18 source URLs → `leanVM.git`; `num-bigint` corrected to the true tree (`0.4.6` → `0.3.3`) at the same rev |
| `CLAUDE.md` | Aggregation section notes `leanVM (previously leanMultisig)` |

## Left unchanged

The upstream Cargo **package** is still named `lean-multisig` (only the repo was renamed), so the dependency key, the `use lean_multisig::` import, and crate-name mentions in comments are kept as-is.

## Verification

- `cargo check -p ethlambda-crypto` passes against the new URL (all leanVM crates fetch cleanly).