### PR TITLE
chore: bump leanVM to f66d4a9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -740,7 +740,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1940,7 +1940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3394,6 +3394,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,7 +3663,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "clap",
@@ -3652,16 +3671,20 @@ dependencies = [
  "leansig_wrapper",
  "rand 0.10.1",
  "rec_aggregation",
+ "serde_json",
  "sub_protocols",
+ "system-info",
  "utils",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_vm",
  "pest",
  "pest_derive",
@@ -3674,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3683,6 +3706,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand 0.10.1",
+ "serde",
  "sub_protocols",
  "tracing",
  "utils",
@@ -3691,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3747,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4782,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4791,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4799,12 +4823,13 @@ dependencies = [
  "mt-utils",
  "rayon",
  "serde",
+ "tracing",
 ]
 
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -4819,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4835,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4843,12 +4868,13 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "system-info",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4861,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4871,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "serde",
 ]
@@ -4879,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -4891,6 +4917,7 @@ dependencies = [
  "mt-utils",
  "rand 0.10.1",
  "rayon",
+ "system-info",
  "tracing",
 ]
 
@@ -5071,7 +5098,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5208,6 +5235,16 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
 
 [[package]]
 name = "object"
@@ -5985,7 +6022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6341,14 +6378,17 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_compiler",
  "lean_prover",
  "lean_vm",
  "leansig_wrapper",
  "lz4_flex",
+ "objc2",
+ "objc2-foundation",
  "postcard",
  "rand 0.10.1",
  "serde",
@@ -6356,6 +6396,7 @@ dependencies = [
  "sub_protocols",
  "tracing",
  "utils",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -6658,7 +6699,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7170,7 +7211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7386,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7478,6 +7519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-info"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "rayon",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7496,10 +7546,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8021,7 +8071,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=5eba3b1#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "tracing",
@@ -8320,7 +8370,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8982,6 +9032,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zk-alloc"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "system-info",
 ]
 
 [[package]]

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -14,9 +14,9 @@ ethlambda-types.workspace = true
 
 # lean-multisig is the XMSS signature aggregation crate from leanVM (the repo was
 # previously named leanMultisig). The crate package keeps the lean-multisig name.
-lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "5eba3b1" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "f66d4a9" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "5eba3b1" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "f66d4a9" }
 
 leansig.workspace = true
 thiserror.workspace = true

--- a/crates/common/crypto/src/lib.rs
+++ b/crates/common/crypto/src/lib.rs
@@ -6,8 +6,8 @@ use ethlambda_types::{
     signature::{ValidatorPublicKey, ValidatorSignature},
 };
 use lean_multisig::{
-    AggregatedXMSS, ProofError, setup_prover, setup_verifier, xmss_aggregate,
-    xmss_verify_aggregation,
+    AggregatedXMSS, AggregationError as LeanAggregationError, ProofError, setup_prover,
+    setup_verifier, xmss_aggregate, xmss_verify_aggregation,
 };
 use leansig_wrapper::{XmssPublicKey as LeanSigPubKey, XmssSignature as LeanSigSignature};
 use thiserror::Error;
@@ -43,6 +43,9 @@ pub enum AggregationError {
 
     #[error("need at least 2 children for recursive aggregation, got {0}")]
     InsufficientChildren(usize),
+
+    #[error("aggregation failed: {0}")]
+    Upstream(#[from] LeanAggregationError),
 }
 
 /// Error type for signature verification operations.
@@ -104,7 +107,7 @@ pub fn aggregate_signatures(
     // log_inv_rate=2 matches the devnet-4 cross-client convention (zeam, ream,
     // grandine, lantern's c-leanvm-xmss all use 2). Ethlambda previously
     // hardcoded 1, which produced proofs incompatible with every other client.
-    let (_sorted_pubkeys, aggregate) = xmss_aggregate(&[], raw_xmss, &message.0, slot, 2);
+    let (_sorted_pubkeys, aggregate) = xmss_aggregate(&[], raw_xmss, &message.0, slot, 2)?;
 
     serialize_aggregate(aggregate)
 }
@@ -118,11 +121,8 @@ pub fn aggregate_signatures(
 /// Requires at least one raw signature OR at least 2 children. A lone child proof
 /// is already valid and needs no further aggregation.
 ///
-/// # Panics
-///
-/// Panics if any deserialized child proof is cryptographically invalid (e.g., was
-/// produced for a different message or slot). This is an upstream constraint of
-/// `xmss_aggregate`.
+/// Fails with [`AggregationError::Upstream`] if any deserialized child proof is
+/// cryptographically invalid (e.g., was produced for a different message or slot).
 pub fn aggregate_mixed(
     children: Vec<(Vec<ValidatorPublicKey>, ByteListMiB)>,
     raw_public_keys: Vec<ValidatorPublicKey>,
@@ -160,7 +160,7 @@ pub fn aggregate_mixed(
         .collect();
 
     let (_sorted_pubkeys, aggregate) =
-        xmss_aggregate(&children_refs, raw_xmss, &message.0, slot, 2);
+        xmss_aggregate(&children_refs, raw_xmss, &message.0, slot, 2)?;
 
     serialize_aggregate(aggregate)
 }
@@ -190,7 +190,7 @@ pub fn aggregate_proofs(
     let children_refs: Vec<(&[LeanSigPubKey], AggregatedXMSS)> =
         pks_list.iter().map(Vec::as_slice).zip(aggs).collect();
 
-    let (_sorted_pubkeys, aggregate) = xmss_aggregate(&children_refs, vec![], &message.0, slot, 2);
+    let (_sorted_pubkeys, aggregate) = xmss_aggregate(&children_refs, vec![], &message.0, slot, 2)?;
 
     serialize_aggregate(aggregate)
 }
@@ -206,7 +206,7 @@ fn deserialize_children(
         .map(|(i, (pubkeys, proof_data))| {
             let lean_pks: Vec<LeanSigPubKey> =
                 pubkeys.into_iter().map(|pk| pk.into_inner()).collect();
-            let aggregate = AggregatedXMSS::deserialize(proof_data.iter().as_slice())
+            let aggregate = AggregatedXMSS::decompress(proof_data.iter().as_slice())
                 .ok_or(AggregationError::ChildDeserializationFailed(i))?;
             Ok((lean_pks, aggregate))
         })
@@ -215,7 +215,7 @@ fn deserialize_children(
 
 /// Serialize an `AggregatedXMSS` into the `ByteListMiB` wire format.
 fn serialize_aggregate(aggregate: AggregatedXMSS) -> Result<ByteListMiB, AggregationError> {
-    let serialized = aggregate.serialize();
+    let serialized = aggregate.compress();
     let serialized_len = serialized.len();
     ByteListMiB::try_from(serialized).map_err(|_| AggregationError::ProofTooBig(serialized_len))
 }
@@ -250,7 +250,7 @@ pub fn verify_aggregated_signature(
         .collect();
 
     // Deserialize the aggregate proof
-    let aggregate = AggregatedXMSS::deserialize(proof_data.iter().as_slice())
+    let aggregate = AggregatedXMSS::decompress(proof_data.iter().as_slice())
         .ok_or(VerificationError::DeserializationFailed)?;
 
     // Verify using lean-multisig


### PR DESCRIPTION
## Motivation

Track upstream leanVM at `f66d4a9` (previously `5eba3b1`).

## Description

Two upstream API changes required adaptation in `ethlambda-crypto`:

| Upstream change | Adaptation |
|---|---|
| `xmss_aggregate` now returns `Result<_, AggregationError>` instead of panicking on invalid child proofs | New `AggregationError::Upstream` variant, `?` at the 3 call sites |
| `AggregatedXMSS::serialize`/`deserialize` renamed to `compress`/`decompress` (lz4+postcard) | Renamed calls in `serialize_aggregate`, `deserialize_children`, and verification |

Notes:
- The proof wire format changed (lz4+postcard compression), so proofs only interop with clients on a compatible leanVM rev.
- Plonky3 `p3-*` crates are pinned back to the previously locked `82cfad73`: newer Plonky3 commits use the unstable `maybe_uninit_slice` feature, which doesn't build on Rust 1.92.0.

The 24 `forkchoice_spectests` failures (`missing field proofData`) are pre-existing on `main` (stale local fixtures) and unrelated to this bump.