### PR TITLE
chore: bump leanVM to 2498896

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -663,8 +663,9 @@ dependencies = [
  "mt-symetric",
  "mt-utils",
  "mt-whir",
- "rayon",
+ "parallel",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -3663,12 +3664,13 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "clap",
  "lean_vm",
  "leansig_wrapper",
+ "parallel",
  "rand 0.10.1",
  "rec_aggregation",
  "serde_json",
@@ -3681,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "include_dir",
@@ -3697,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3715,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3771,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4806,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4815,13 +4817,13 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
  "mt-symetric",
  "mt-utils",
- "rayon",
+ "parallel",
  "serde",
  "tracing",
 ]
@@ -4829,14 +4831,14 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
  "num-bigint 0.3.3",
+ "parallel",
  "paste",
  "rand 0.10.1",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4844,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4852,7 +4854,6 @@ dependencies = [
  "num-bigint 0.3.3",
  "paste",
  "rand 0.10.1",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4860,44 +4861,47 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
  "mt-utils",
+ "parallel",
  "rand 0.10.1",
- "rayon",
  "serde",
  "system-info",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
  "mt-field",
  "mt-poly",
- "rayon",
+ "parallel",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
- "rayon",
+ "parallel",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "serde",
 ]
@@ -4905,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -4915,10 +4919,11 @@ dependencies = [
  "mt-sumcheck",
  "mt-symetric",
  "mt-utils",
+ "parallel",
  "rand 0.10.1",
- "rayon",
  "system-info",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -5617,6 +5622,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+dependencies = [
+ "system-info",
 ]
 
 [[package]]
@@ -6378,7 +6391,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "include_dir",
@@ -7427,10 +7440,11 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "lean_vm",
+ "parallel",
  "tracing",
  "utils",
 ]
@@ -7521,10 +7535,9 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "libc",
- "rayon",
 ]
 
 [[package]]
@@ -8071,7 +8084,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "backend",
  "tracing",
@@ -9037,9 +9050,10 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=f66d4a9#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
 dependencies = [
  "libc",
+ "parallel",
  "system-info",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1941,7 +1941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "clap",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "include_dir",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4817,7 +4817,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -4846,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4876,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "serde",
 ]
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -5103,7 +5103,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5306,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "p3-field 0.5.1",
  "p3-maybe-rayon 0.5.1",
@@ -5376,14 +5376,14 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
  "p3-matrix 0.5.1",
  "p3-maybe-rayon 0.5.1",
  "p3-util 0.5.1",
- "spin 0.11.0",
+ "spin 0.10.0",
  "tracing",
 ]
 
@@ -5404,7 +5404,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5436,7 +5436,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5466,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5486,7 +5486,7 @@ checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 
 [[package]]
 name = "p3-mds"
@@ -5506,7 +5506,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "p3-dft 0.5.1",
  "p3-field 0.5.1",
@@ -5518,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5534,17 +5534,16 @@ dependencies = [
  "paste",
  "rand 0.10.1",
  "serde",
- "spin 0.11.0",
+ "spin 0.10.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "p3-field 0.5.1",
- "p3-mds 0.5.1",
  "p3-symmetric 0.5.1",
  "rand 0.10.1",
 ]
@@ -5566,7 +5565,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "p3-field 0.5.1",
  "p3-mds 0.5.1",
@@ -5589,7 +5588,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5609,7 +5608,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#bde2e86e9a9ad3ed4ec5002bff31f88f23029e40"
 dependencies = [
  "serde",
  "transpose",
@@ -5627,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "parallel"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "system-info",
 ]
@@ -6391,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "include_dir",
@@ -6712,7 +6711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7224,7 +7223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7369,9 +7368,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
@@ -7440,7 +7439,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7535,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "libc",
 ]
@@ -7562,7 +7561,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8084,7 +8083,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "backend",
  "tracing",
@@ -8383,7 +8382,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9050,7 +9049,7 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=a44bca4#a44bca4d2b991175f3f176c03f9fe681227f5bdc"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "libc",
  "parallel",

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -14,9 +14,9 @@ ethlambda-types.workspace = true
 
 # lean-multisig is the XMSS signature aggregation crate from leanVM (the repo was
 # previously named leanMultisig). The crate package keeps the lean-multisig name.
-lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "a44bca4" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "2498896" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "a44bca4" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "2498896" }
 
 leansig.workspace = true
 thiserror.workspace = true

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -14,9 +14,9 @@ ethlambda-types.workspace = true
 
 # lean-multisig is the XMSS signature aggregation crate from leanVM (the repo was
 # previously named leanMultisig). The crate package keeps the lean-multisig name.
-lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "f66d4a9" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "a44bca4" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "f66d4a9" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "a44bca4" }
 
 leansig.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Motivation

Track upstream leanVM at `2498896` (previously `f66d4a9`).

## Description

No source changes were required: the XMSS aggregation API used by `ethlambda-crypto` (`xmss_aggregate`, `AggregatedXMSS::compress`/`decompress`) is unchanged at this rev. Only `crates/common/crypto/Cargo.toml` and `Cargo.lock` change.

Notes:
- `2498896` is one commit ahead of the previous candidate `a44bca4`: a whir prover perf fix (leanVM#250, avoids a serial 256 MiB copy of combined-statement weights).
- Plonky3 `p3-*` crates are pinned at `bde2e86e`, the commit locked by leanVM's own `Cargo.lock`. leanVM references Plonky3's default branch with no rev, so `cargo update` floats them forward; newer Plonky3 commits use the unstable `maybe_uninit_slice` feature, which doesn't build on Rust 1.92.0.

## Testing

- `cargo check --workspace` and `make lint` are clean.
- `cargo test --workspace --release`: all unit/integration tests pass. The spec fixture suites fail on stale local fixtures (`missing field attestationPubkey` at JSON parse time); verified via `git stash` that the failure is identical without this change.
- `cargo test -p ethlambda-crypto --release -- --ignored` (the slow XMSS aggregation/verification tests) all pass against the new rev.

> Note: previously targeted `8eec56c`, then `a44bca4`; updated to `2498896` (devnet4 HEAD).
