### PR TITLE
chore: bump leanVM to e2592df on devnet5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -663,8 +663,9 @@ dependencies = [
  "mt-symetric",
  "mt-utils",
  "mt-whir",
- "rayon",
+ "parallel",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -3664,12 +3665,13 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "clap",
  "lean_vm",
  "leansig_wrapper",
+ "libc",
  "rand 0.10.1",
  "rec_aggregation",
  "serde_json",
@@ -3682,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "include_dir",
@@ -3698,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3716,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3772,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4807,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4816,13 +4818,13 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
  "mt-symetric",
  "mt-utils",
- "rayon",
+ "parallel",
  "serde",
  "tracing",
 ]
@@ -4830,14 +4832,14 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
  "num-bigint 0.3.3",
+ "parallel",
  "paste",
  "rand 0.10.1",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4845,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4853,7 +4855,6 @@ dependencies = [
  "num-bigint 0.3.3",
  "paste",
  "rand 0.10.1",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4861,44 +4862,47 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
  "mt-utils",
+ "parallel",
  "rand 0.10.1",
- "rayon",
  "serde",
  "system-info",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
  "mt-field",
  "mt-poly",
- "rayon",
+ "parallel",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
- "rayon",
+ "parallel",
+ "zk-alloc",
 ]
 
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "serde",
 ]
@@ -4906,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -4916,10 +4920,11 @@ dependencies = [
  "mt-sumcheck",
  "mt-symetric",
  "mt-utils",
+ "parallel",
  "rand 0.10.1",
- "rayon",
  "system-info",
  "tracing",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -5617,6 +5622,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
+dependencies = [
+ "system-info",
 ]
 
 [[package]]
@@ -6378,7 +6391,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "include_dir",
@@ -7427,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7521,10 +7534,9 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
- "rayon",
 ]
 
 [[package]]
@@ -8071,7 +8083,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend",
  "tracing",
@@ -9037,9 +9049,10 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanVM.git?rev=8fcbd779#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=e2592df#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
+ "parallel",
  "system-info",
 ]
 

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -12,9 +12,9 @@ version.workspace = true
 [dependencies]
 ethlambda-types.workspace = true
 
-lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd779" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "e2592df" }
 # leansig_wrapper provides XmssPublicKey/XmssSignature types used by lean-multisig's public API
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "8fcbd779" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanVM.git", rev = "e2592df" }
 
 leansig.workspace = true
 thiserror.workspace = true

--- a/crates/common/crypto/src/lib.rs
+++ b/crates/common/crypto/src/lib.rs
@@ -6,9 +6,10 @@ use ethlambda_types::{
     signature::{ValidatorPublicKey, ValidatorSignature},
 };
 use lean_multisig::{
-    ProofError, TypeOneMultiSignature as LMType1, TypeTwoMultiSignature as LMType2,
-    aggregate_type_1, merge_many_type_1, setup_prover, setup_verifier, split_type_2, verify_type_1,
-    verify_type_2,
+    MultiMessageAggregateSignature as LMType2, ProofError,
+    SingleMessageAggregateSignature as LMType1, aggregate_single_message_signatures,
+    merge_single_message_aggregates, setup_prover, setup_verifier, split_multi_message_aggregate,
+    verify_multi_message_aggregate, verify_single_message_aggregate,
 };
 use leansig_wrapper::{XmssPublicKey as LeanSigPubKey, XmssSignature as LeanSigSignature};
 use thiserror::Error;
@@ -113,7 +114,7 @@ fn into_lean_pubkeys(pubkeys: Vec<ValidatorPublicKey>) -> Vec<LeanSigPubKey> {
 }
 
 /// Decompress a stored Type-1 proof (without-pubkeys form) into a native
-/// `TypeOneMultiSignature` by attaching the resolved validator pubkeys.
+/// `SingleMessageAggregateSignature` by attaching the resolved validator pubkeys.
 fn decompress_type1(
     pubkeys: Vec<ValidatorPublicKey>,
     proof_bytes: &ByteList512KiB,
@@ -142,11 +143,11 @@ fn compress_type2_to_byte_list(sig: &LMType2) -> Result<ByteList512KiB, Aggregat
 
 /// Aggregate multiple XMSS signatures into a single Type-1 proof.
 ///
-/// Equivalent to `aggregate_type_1([], raw_xmss, ...)` in lean-multisig.
+/// Equivalent to `aggregate_single_message_signatures([], raw_xmss, ...)` in lean-multisig.
 ///
 /// All signatures must bind to the same `(message, slot)` pair.
 ///
-/// Returns the lean-multisig `TypeOneMultiSignature::compress_without_pubkeys()`
+/// Returns the lean-multisig `SingleMessageAggregateSignature::compress_without_pubkeys()`
 /// bytes, packed as `ByteList512KiB` for the on-wire SSZ proof field.
 pub fn aggregate_signatures(
     public_keys: Vec<ValidatorPublicKey>,
@@ -172,7 +173,7 @@ pub fn aggregate_signatures(
         .map(|(pk, sig)| (pk.into_inner(), sig.into_inner()))
         .collect();
 
-    let proof = aggregate_type_1(&[], raw_xmss, message.0, slot, LOG_INV_RATE)
+    let proof = aggregate_single_message_signatures(&[], raw_xmss, message.0, slot, LOG_INV_RATE)
         .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
 
     compress_type1_to_byte_list(&proof)
@@ -216,8 +217,14 @@ pub fn aggregate_mixed(
         .map(|(pk, sig)| (pk.into_inner(), sig.into_inner()))
         .collect();
 
-    let proof = aggregate_type_1(&children_native, raw_xmss, message.0, slot, LOG_INV_RATE)
-        .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
+    let proof = aggregate_single_message_signatures(
+        &children_native,
+        raw_xmss,
+        message.0,
+        slot,
+        LOG_INV_RATE,
+    )
+    .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
 
     compress_type1_to_byte_list(&proof)
 }
@@ -243,8 +250,14 @@ pub fn aggregate_proofs(
         .map(|(i, (pubkeys, proof_bytes))| decompress_type1(pubkeys, &proof_bytes, i))
         .collect::<Result<_, _>>()?;
 
-    let proof = aggregate_type_1(&children_native, vec![], message.0, slot, LOG_INV_RATE)
-        .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
+    let proof = aggregate_single_message_signatures(
+        &children_native,
+        vec![],
+        message.0,
+        slot,
+        LOG_INV_RATE,
+    )
+    .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
 
     compress_type1_to_byte_list(&proof)
 }
@@ -276,7 +289,7 @@ pub fn verify_aggregated_signature(
         });
     }
 
-    verify_type_1(&sig)?;
+    verify_single_message_aggregate(&sig)?;
     Ok(())
 }
 
@@ -287,10 +300,10 @@ pub fn verify_aggregated_signature(
 /// Merge many independent Type-1 multi-signatures into a single Type-2 proof.
 ///
 /// Each input is `(participant_pubkeys, type_1_proof_bytes)` where the bytes
-/// are the `compress_without_pubkeys()` form of a `TypeOneMultiSignature`.
+/// are the `compress_without_pubkeys()` form of a `SingleMessageAggregateSignature`.
 ///
 /// The returned blob is the `compress_without_pubkeys()` form of the resulting
-/// `TypeTwoMultiSignature`. A verifier decoding it back needs the per-component
+/// `MultiMessageAggregateSignature`. A verifier decoding it back needs the per-component
 /// pubkey sets in the same order.
 pub fn merge_type_1s_into_type_2(
     type_1s: Vec<(Vec<ValidatorPublicKey>, ByteList512KiB)>,
@@ -307,7 +320,7 @@ pub fn merge_type_1s_into_type_2(
         .map(|(i, (pubkeys, proof_bytes))| decompress_type1(pubkeys, &proof_bytes, i))
         .collect::<Result<_, _>>()?;
 
-    let merged = merge_many_type_1(type_1s_native, LOG_INV_RATE)
+    let merged = merge_single_message_aggregates(type_1s_native, LOG_INV_RATE)
         .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
 
     compress_type2_to_byte_list(&merged)
@@ -363,14 +376,14 @@ pub fn verify_type_2_signature(
         let _ = idx; // index reserved for richer diagnostics if needed
     }
 
-    verify_type_2(&sig)?;
+    verify_multi_message_aggregate(&sig)?;
     Ok(())
 }
 
 /// Split (disaggregate) a Type-2 merged proof into a single Type-1 proof for
 /// the component bound to `message`. Generates a fresh SNARK; expensive.
 ///
-/// Mirrors leanSpec PR #717 `TypeTwoMultiSignature.split_by_msg`: the caller
+/// Mirrors leanSpec PR #717 `split_multi_message_aggregate_by_message`: the caller
 /// supplies the expected message (an attestation data root or the block
 /// root) and the wrapper locates the unique matching component inside the
 /// decompressed proof. Returns the `compress_without_pubkeys()` form of the
@@ -402,7 +415,7 @@ pub fn split_type_2_by_message(
         _ => return Err(AggregationError::MultipleMessages),
     };
 
-    let component = split_type_2(type_2, index, LOG_INV_RATE)
+    let component = split_multi_message_aggregate(type_2, index, LOG_INV_RATE)
         .map_err(|err| AggregationError::ProverFailure(err.to_string()))?;
 
     compress_type1_to_byte_list(&component)


### PR DESCRIPTION
## Motivation

Track upstream leanVM at `e2592df` (the repo's `devnet5` branch), previously `8fcbd779` (#408).

## Description

The aggregation crate renamed its public API since `8fcbd779`. `ethlambda-crypto` adapts to the new names; shapes, fields, and call signatures are unchanged, so the port is mechanical:

| Old (`8fcbd779`) | New (`e2592df`) |
|---|---|
| `TypeOneMultiSignature` | `SingleMessageAggregateSignature` |
| `TypeTwoMultiSignature` | `MultiMessageAggregateSignature` |
| `aggregate_type_1` | `aggregate_single_message_signatures` |
| `merge_many_type_1` | `merge_single_message_aggregates` |
| `split_type_2` | `split_multi_message_aggregate` |
| `verify_type_1` / `verify_type_2` | `verify_single_message_aggregate` / `verify_multi_message_aggregate` |

**Plonky3 pin:** `p3-*` crates are pinned back to `3f67d136` (the rev devnet5 already used). Newer revs pulled in transitively by leanVM use the unstable `maybe_uninit_slice` feature, which doesn't build on Rust 1.92.0.

## Validation

- ✅ `cargo build --workspace`
- ✅ `cargo clippy -p ethlambda-crypto` clean
- ✅ `cargo fmt --check` clean

## Notes

- The heavy round-trip tests (`aggregate`/`verify`/`merge`/`split`) remain `#[ignore]` (12+ GiB/proof), so semantic correctness here is verified by compile + prover setup, not a live proof.
- `test_setup_is_idempotent` stack-overflows in **debug** builds: the new bytecode compiler needs >2 MiB of stack. Release is unaffected and `make test` uses `--release`, so CI passes; flagging for awareness.