### PR TITLE
fix: skip ticks that don't advance past the store's interval counter

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -200,19 +200,19 @@ impl BlockChainServer {
             return;
         }
 
-        // Observe tick interval duration. Done after the idempotency guard so a
-        // skipped duplicate tick doesn't shorten the next real tick's sample.
-        if let Some(prev_instant) = self.last_tick_instant {
-            metrics::observe_tick_interval_duration(prev_instant.elapsed());
-        }
-        self.last_tick_instant = Some(Instant::now());
-
         // Fail fast: a state with zero validators is invalid and would cause
         // panics in proposer selection and attestation processing.
         if self.store.head_state().validators.is_empty() {
             error!("Head state has no validators, skipping tick");
             return;
         }
+
+        // Observe tick interval duration. Done after the idempotency guard so a
+        // skipped duplicate tick doesn't shorten the next real tick's sample.
+        if let Some(prev_instant) = self.last_tick_instant {
+            metrics::observe_tick_interval_duration(prev_instant.elapsed());
+        }
+        self.last_tick_instant = Some(Instant::now());
 
         // Update current slot metric
         metrics::update_current_slot(slot);

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -22,7 +22,7 @@ use spawned_concurrency::error::ActorError;
 use spawned_concurrency::protocol;
 use spawned_concurrency::tasks::{Actor, ActorRef, ActorStart, Context, Handler, send_after};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::store::StoreError;
 
@@ -185,6 +185,26 @@ impl BlockChainServer {
         let time_since_genesis_ms = timestamp_ms.saturating_sub(genesis_time_ms);
         let slot = time_since_genesis_ms / MILLISECONDS_PER_SLOT;
         let interval = (time_since_genesis_ms % MILLISECONDS_PER_SLOT) / MILLISECONDS_PER_INTERVAL;
+
+        // Idempotency guard
+        //
+        // `slot`/`interval` come from the wall clock, but the tick cadence is driven
+        // by the monotonic clock (`tokio::sleep`). The wall clock can drift behind it
+        // inside VMs, so a tick scheduled for the next interval boundary can fire
+        // while the wall clock still reads the previous interval.
+        let tick_interval = time_since_genesis_ms / MILLISECONDS_PER_INTERVAL;
+        let store_time = self.store.time();
+
+        if store_time > 0 && tick_interval <= store_time {
+            debug!(
+                %slot,
+                %interval,
+                tick_interval,
+                store_time,
+                "Skipping already-processed tick"
+            );
+            return;
+        }
 
         // Fail fast: a state with zero validators is invalid and would cause
         // panics in proposer selection and attestation processing.

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -173,12 +173,6 @@ pub struct BlockChainServer {
 
 impl BlockChainServer {
     async fn on_tick(&mut self, timestamp_ms: u64, ctx: &Context<Self>) {
-        // Observe tick interval duration before any processing
-        if let Some(prev_instant) = self.last_tick_instant {
-            metrics::observe_tick_interval_duration(prev_instant.elapsed());
-        }
-        self.last_tick_instant = Some(Instant::now());
-
         let genesis_time_ms = self.store.config().genesis_time * 1000;
 
         // Calculate current slot and interval from milliseconds
@@ -205,6 +199,13 @@ impl BlockChainServer {
             );
             return;
         }
+
+        // Observe tick interval duration. Done after the idempotency guard so a
+        // skipped duplicate tick doesn't shorten the next real tick's sample.
+        if let Some(prev_instant) = self.last_tick_instant {
+            metrics::observe_tick_interval_duration(prev_instant.elapsed());
+        }
+        self.last_tick_instant = Some(Instant::now());
 
         // Fail fast: a state with zero validators is invalid and would cause
         // panics in proposer selection and attestation processing.


### PR DESCRIPTION
## Motivation

A 200-slot local devnet surfaced a single `ERROR Failed to build block ... target slot 81 is in the past (current is 81)` on the proposing node at slot 81. Investigation traced it to a clock-domain mismatch, not the block-building path.

## Root cause

`on_tick` derives `slot`/`interval` from the **wall clock** (`unix_now_ms`, `SystemTime`), but the tick cadence is driven by the **monotonic clock** (`tokio::sleep`). When the wall clock drifts behind the monotonic clock, a tick scheduled for the next interval boundary fires while the wall clock still reads the *previous* interval, so `on_tick` re-runs that interval's duties.

For a proposer at interval 0 this re-enters `propose_block` for a slot the state has already advanced through, and the state transition rejects it with `StateSlotIsNewer`. The block itself was built, published, and imported correctly the first time, so impact was limited to a noisy error log (no double block, no fork), but the re-run is incorrect.

This is a known behavior of the Docker Desktop macOS VM, whose `CLOCK_REALTIME` runs slow and is periodically corrected, independently of `CLOCK_MONOTONIC`:
- https://www.docker.com/blog/addressing-time-drift-in-docker-desktop-for-mac/
- https://github.com/docker/for-mac/issues/17

## Fix

Guard `on_tick` with the store's existing monotonic interval counter (`store.time()`, which only moves forward in `store::on_tick`). If a tick does not advance past it, the interval's duties already ran, so skip. The genesis bootstrap (`store.time() == 0`) is exempt, since interval 0 has not run yet.

No new state is tracked — the guard reuses `store.time()`. This is the inverse-safe complement to the forward-only logic already in `store::on_tick`.

## Testing

- `cargo build`, `cargo clippy -D warnings`, `cargo fmt` pass.
- Not separately covered by a unit test (constructing the actor + `Context` has no existing harness); the guard is a pure comparison over `store.time()`.