### PR TITLE
fix: spec-faithful aggregation_bits bounds handling in process_attestations

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -37,6 +37,13 @@ pub enum Error {
     },
     #[error("zero hash found in justifications_roots")]
     ZeroHashInJustificationRoots,
+    #[error("aggregated attestation has no participants")]
+    EmptyAggregationBits,
+    #[error("aggregation bit set at index {index} beyond validator count {validator_count}")]
+    AggregationBitsOutOfBounds {
+        index: usize,
+        validator_count: usize,
+    },
 }
 
 /// Transition the given pre-state to the block's post-state.
@@ -276,14 +283,26 @@ fn process_attestations(
             continue;
         }
 
-        // Reject attestations with aggregation_bits longer than the validator set.
-        if attestation.aggregation_bits.len() > validator_count {
-            warn!(
-                bits_len = attestation.aggregation_bits.len(),
-                validator_count, "Skipping attestation: aggregation_bits exceeds validator count"
-            );
-            continue;
+        // The spec asserts that an aggregated attestation references at least
+        // one validator; the failed assert invalidates the whole block.
+        if attestation.aggregation_bits.count_ones() == 0 {
+            return Err(Error::EmptyAggregationBits);
         }
+
+        // The spec indexes the per-root vote list with each participant index,
+        // so a set bit beyond the validator set crashes it (IndexError) and
+        // invalidates the whole block; Zeam and Lantern also reject such
+        // blocks. The spec has no bitlist length check: oversized
+        // aggregation_bits whose set bits are all in range process normally.
+        let oob_bit = (validator_count..attestation.aggregation_bits.len())
+            .find(|&i| attestation.aggregation_bits.get(i) == Some(true));
+        if let Some(index) = oob_bit {
+            return Err(Error::AggregationBitsOutOfBounds {
+                index,
+                validator_count,
+            });
+        }
+
         // Record the vote
         attestations_processed += 1;
         let votes = justifications

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -276,13 +276,7 @@ fn process_attestations(
             continue;
         }
 
-        // Record the vote
-        attestations_processed += 1;
-        let votes = justifications
-            .entry(target.root)
-            .or_insert_with(|| std::iter::repeat_n(false, validator_count).collect());
         // Reject attestations with aggregation_bits longer than the validator set.
-        // The spec would crash (IndexError) on OOB access; Zeam and Lantern reject.
         if attestation.aggregation_bits.len() > validator_count {
             warn!(
                 bits_len = attestation.aggregation_bits.len(),
@@ -290,6 +284,12 @@ fn process_attestations(
             );
             continue;
         }
+        // Record the vote
+        attestations_processed += 1;
+        let votes = justifications
+            .entry(target.root)
+            .or_insert_with(|| std::iter::repeat_n(false, validator_count).collect());
+
         // Mark that each validator in this aggregation has voted for the target.
         for (validator_id, voted) in votes
             .iter_mut()


### PR DESCRIPTION
## Problem (audit finding C1)

`process_attestations` incremented `attestations_processed` and inserted an empty votes entry into `justifications` *before* the oversized `aggregation_bits` length check. A skipped attestation therefore still added an all-false justification root that got serialized into the post-state: a cross-client state-divergence vector.

## Changes

**Commit 1** moves the bounds check above the `entry()` insert, so a skipped attestation leaves no trace in the post-state.

**Commit 2** resolves the skip-vs-reject question by checking leanSpec at the pinned commit (`f12000b`, `src/lean_spec/forks/lstar/spec.py::process_attestations`). The spec has **no bitlist length check at all**. Its actual failure modes:

| Case | Spec behavior | ethlambda before | ethlambda after |
|------|--------------|------------------|-----------------|
| Set bit at index >= validator count | `IndexError` -> STF aborts -> **block rejected** | attestation skipped, block accepted | block rejected (`Error::AggregationBitsOutOfBounds`) |
| No bits set | `AssertionError` in `to_validator_indices` -> **block rejected** | processed as no-op + spurious all-false entry in post-state | block rejected (`Error::EmptyAggregationBits`) |
| Oversized bitlist, all set bits in range | processed normally | attestation skipped (post-state divergence) | processed normally |

Zeam and Lantern also reject such blocks (per the pre-existing in-code comment), so the previous skip-while-accepting behavior could split ethlambda off from the rest of the network on a crafted block.

The checks sit after `is_valid_vote`, matching the spec's filter order: an attestation that fails the vote-validity filters is skipped *without* touching its bits, exactly as the spec `continue`s before any bits access.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- STF spectests currently fail to *deserialize* fixtures locally (`missing field attestationPubkey`) because the local `leanSpec` checkout drifted off the pin; pre-existing and unrelated. CI regenerates fixtures from the pin.