### PR TITLE
docs: update README devnet support for pq-devnet-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Docker images are published to `ghcr.io/lambdaclass/ethlambda` with the followin
 
 ### pq-devnet-5
 
-We are running the `pq-devnet-5` spec. A Docker tag `devnet5` will be published for this version.
+We are running the `pq-devnet-5` spec. A Docker tag `devnet5` is available for this version.
 
 ### pq-devnet-6
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We are running the `pq-devnet-5` spec. A Docker tag `devnet5` is available for t
 
 ### pq-devnet-6
 
-`pq-devnet-6` is in a planning phase; no features have been specified yet. Likely candidates are replacing [LMD-GHOST](docs/lmd_ghost.md) and [3SF-mini](docs/3sf_mini.md), or execution layer integration.
+`pq-devnet-6` is in a planning phase; no features have been specified yet. Likely candidates are replacing [LMD-GHOST](docs/lmd_ghost.md) and [3SF-mini](docs/3sf_mini.md), or [execution layer integration](https://github.com/lambdaclass/ethlambda/pull/367).
 
 ### Older devnets
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We are running the `pq-devnet-5` spec. A Docker tag `devnet5` is available for t
 
 ### pq-devnet-6
 
-`pq-devnet-6` is in a planning phase; no features have been specified yet.
+`pq-devnet-6` is in a planning phase; no features have been specified yet. Likely candidates are replacing [LMD-GHOST](docs/lmd_ghost.md) and [3SF-mini](docs/3sf_mini.md), or execution layer integration.
 
 ### Older devnets
 

--- a/README.md
+++ b/README.md
@@ -118,17 +118,17 @@ Docker images are published to `ghcr.io/lambdaclass/ethlambda` with the followin
 
 [`RELEASE.md`](./RELEASE.md) has more details on our release process and how to tag new images.
 
-### pq-devnet-4
-
-We are running the `pq-devnet-4` spec. A Docker tag `devnet4` is available for this version.
-
 ### pq-devnet-5
 
-[We are working on adding support for the `pq-devnet-5` spec](https://github.com/lambdaclass/ethlambda/issues/285). A Docker tag `devnet5` will be published for this version.
+We are running the `pq-devnet-5` spec. A Docker tag `devnet5` will be published for this version.
+
+### pq-devnet-6
+
+`pq-devnet-6` is in a planning phase; no features have been specified yet.
 
 ### Older devnets
 
-Docker tags for each devnet are released, with format `devnetX` (i.e. `devnet1`, `devnet2`, `devnet3`).
+Docker tags for each devnet are released, with format `devnetX` (i.e. `devnet1`, `devnet2`, `devnet3`, `devnet4`).
 
 Support for older devnet releases is discontinued when the next devnet version is released.
 
@@ -136,7 +136,6 @@ Support for older devnet releases is discontinued when the next devnet version i
 
 Some features we are looking to implement in the near future, in order of priority:
 
-- [Add support for pq-devnet-5](https://github.com/lambdaclass/ethlambda/issues/285)
 - [RPC endpoints for chain data consumption](https://github.com/lambdaclass/ethlambda/issues/75)
 - [Add guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)
 

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -735,7 +735,7 @@ mod tests {
     use super::*;
 
     /// Validator-config snippet matching `lean-quickstart`'s ansible-devnet
-    /// (devnet-4) where networks share a non-default committee count.
+    /// where networks share a non-default committee count.
     const VC_WITH_COMMITTEE_COUNT: &str = r#"
 shuffle: roundrobin
 deployment_mode: ansible

--- a/crates/common/crypto/src/lib.rs
+++ b/crates/common/crypto/src/lib.rs
@@ -14,8 +14,6 @@ use leansig_wrapper::{XmssPublicKey as LeanSigPubKey, XmssSignature as LeanSigSi
 use thiserror::Error;
 
 /// log(1/rate) for the WHIR commitment scheme used inside lean-multisig.
-/// 2 matches the devnet-4 cross-client convention (zeam, ream, grandine, lantern
-/// all use 2); the leanVM devnet5 examples also use 2 for recursion.
 const LOG_INV_RATE: usize = 2;
 
 // Lazy initialization for prover and verifier setup


### PR DESCRIPTION
## Motivation

The devnet5 branch now runs the `pq-devnet-5` spec, but the README still lists `pq-devnet-4` as the current devnet.

## Description

- Move `pq-devnet-5` to current, with the `devnet5` Docker tag listed as available.
- Move `pq-devnet-4` to the older devnets list (`devnet4` tag remains available).
- Add a `pq-devnet-6` section noting it is in a planning phase with no features specified yet.
- Drop the completed "Add support for pq-devnet-5" item from incoming features.