### PR TITLE
refactor(types): derive MultiMessageAggregateError with thiserror

### DIFF
--- a/crates/common/types/src/block.rs
+++ b/crates/common/types/src/block.rs
@@ -77,21 +77,12 @@ impl MultiMessageAggregate {
 }
 
 /// Errors returned when constructing a [`MultiMessageAggregate`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum MultiMessageAggregateError {
     /// Proof bytes exceed `ByteList512KiB`'s cap.
+    #[error("proof {0} bytes exceeds 512 KiB cap")]
     ProofTooLarge(usize),
 }
-
-impl core::fmt::Display for MultiMessageAggregateError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::ProofTooLarge(n) => write!(f, "proof {n} bytes exceeds 512 KiB cap"),
-        }
-    }
-}
-
-impl std::error::Error for MultiMessageAggregateError {}
 
 // ============================================================================
 // Type-1 multi-signature


### PR DESCRIPTION
Addresses [review feedback on #426](https://github.com/lambdaclass/ethlambda/pull/426#discussion_r3389705475) left after merge: use `thiserror` instead of manual `Display` / `std::error::Error` impls for `MultiMessageAggregateError`.

No behavior change; the error message is identical.