### PR TITLE
fix: update spec-test runners for the latest leanSpec fixture schema

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -393,6 +393,26 @@ pub fn on_gossip_aggregated_attestation(
     store: &mut Store,
     aggregated: SignedAggregatedAttestation,
 ) -> Result<(), StoreError> {
+    on_gossip_aggregated_attestation_core(store, aggregated, true)
+}
+
+/// Process a gossiped aggregated attestation WITHOUT verifying its proof.
+///
+/// Only for spec tests whose fixtures carry mocked (placeholder) proofs
+/// (`proofSetting == 0`); production paths must use
+/// [`on_gossip_aggregated_attestation`].
+pub fn on_gossip_aggregated_attestation_without_verification(
+    store: &mut Store,
+    aggregated: SignedAggregatedAttestation,
+) -> Result<(), StoreError> {
+    on_gossip_aggregated_attestation_core(store, aggregated, false)
+}
+
+fn on_gossip_aggregated_attestation_core(
+    store: &mut Store,
+    aggregated: SignedAggregatedAttestation,
+    verify: bool,
+) -> Result<(), StoreError> {
     validate_attestation_data(store, &aggregated.data)
         .inspect_err(|_| metrics::inc_attestations_invalid())?;
 
@@ -420,7 +440,7 @@ pub fn on_gossip_aggregated_attestation(
     let data_root = hashed.root();
     let slot: u32 = aggregated.data.slot.try_into().expect("slot exceeds u32");
 
-    {
+    if verify {
         let _timing = metrics::time_pq_sig_aggregated_signatures_verification();
         ethlambda_crypto::verify_aggregated_signature(
             &aggregated.proof.proof,
@@ -428,8 +448,8 @@ pub fn on_gossip_aggregated_attestation(
             &data_root,
             slot,
         )
+        .map_err(StoreError::AggregateVerificationFailed)?;
     }
-    .map_err(StoreError::AggregateVerificationFailed)?;
 
     // Read stats before moving the proof into the store.
     let num_participants = aggregated.proof.participants.count_ones();

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -93,11 +93,14 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
 
                     let signed_block = block_data.to_blank_signed_block();
 
-                    let block_time_ms =
-                        genesis_time * 1000 + signed_block.message.slot * MILLISECONDS_PER_SLOT;
-
+                    // Advance time to the block's slot unless the test delivers
+                    // the block ahead of the store clock.
                     // NOTE: the has_proposal argument is set to true, following the spec
-                    store::on_tick(&mut store, block_time_ms, true);
+                    if step.tick_to_slot {
+                        let block_time_ms =
+                            genesis_time * 1000 + signed_block.message.slot * MILLISECONDS_PER_SLOT;
+                        store::on_tick(&mut store, block_time_ms, true);
+                    }
                     let result = store::on_block_without_verification(&mut store, signed_block);
                     let import_ok = result.is_ok();
                     assert_step_outcome(step_idx, step.valid, result)?;

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -41,6 +41,10 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
         }
         println!("Running test: {}", name);
 
+        // Mocked-proof vectors (`proofSetting == 0`) carry placeholder
+        // aggregation proofs that must not be cryptographically verified.
+        let proofs_are_mocked = test.proofs_are_mocked();
+
         // Initialize store from anchor state/block.
         //
         // Fixtures whose `steps` is empty are "anchor rejection" cases (e.g.
@@ -187,7 +191,13 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
                         TypeOneMultiSignature::new(proof_fixture.participants.into(), proof_data);
                     let aggregated = SignedAggregatedAttestation { data, proof };
 
-                    let result = store::on_gossip_aggregated_attestation(&mut store, aggregated);
+                    let result = if proofs_are_mocked {
+                        store::on_gossip_aggregated_attestation_without_verification(
+                            &mut store, aggregated,
+                        )
+                    } else {
+                        store::on_gossip_aggregated_attestation(&mut store, aggregated)
+                    };
                     assert_step_outcome(step_idx, step.valid, result)?;
                 }
                 other => {

--- a/crates/common/test-fixtures/src/fork_choice.rs
+++ b/crates/common/test-fixtures/src/fork_choice.rs
@@ -44,11 +44,28 @@ pub struct ForkChoiceTest {
     #[serde(rename = "anchorBlock")]
     pub anchor_block: Block,
     pub steps: Vec<ForkChoiceStep>,
+    /// Aggregation proof regime: 0 = mocked (placeholder bytes, must not be
+    /// verified), 1 = real and must verify, 2 = real and must fail
+    /// verification. Older fixtures lack the field and carry real proofs.
+    #[serde(rename = "proofSetting", default = "default_proof_setting")]
+    pub proof_setting: u8,
     #[serde(rename = "maxSlot")]
     #[allow(dead_code)]
     pub max_slot: u64,
     #[serde(rename = "_info")]
     pub info: TestInfo,
+}
+
+fn default_proof_setting() -> u8 {
+    1
+}
+
+impl ForkChoiceTest {
+    /// Whether the vector's aggregation proofs are placeholders that must
+    /// not be cryptographically verified (`proofSetting == 0`).
+    pub fn proofs_are_mocked(&self) -> bool {
+        self.proof_setting == 0
+    }
 }
 
 // ============================================================================

--- a/crates/common/test-fixtures/src/fork_choice.rs
+++ b/crates/common/test-fixtures/src/fork_choice.rs
@@ -76,6 +76,11 @@ pub struct ForkChoiceStep {
     pub has_proposal: Option<bool>,
     #[serde(rename = "isAggregator")]
     pub is_aggregator: Option<bool>,
+    /// Whether the harness must advance the store clock to the block's slot
+    /// before delivering a `block` step. Early-arrival tests set this to
+    /// `false` to deliver the block ahead of the store clock.
+    #[serde(rename = "tickToSlot", default = "default_true")]
+    pub tick_to_slot: bool,
 }
 
 fn default_true() -> bool {

--- a/crates/common/test-fixtures/src/state_transition.rs
+++ b/crates/common/test-fixtures/src/state_transition.rs
@@ -19,6 +19,6 @@ use serde::Deserialize;
 pub struct StateTransitionRunRequest {
     pub pre: TestState,
     pub blocks: Vec<Block>,
-    #[serde(default, rename = "expectException")]
+    #[serde(default, rename = "expectException", alias = "rejectionReason")]
     pub expect_exception: Option<String>,
 }

--- a/crates/common/test-fixtures/src/verify_signatures.rs
+++ b/crates/common/test-fixtures/src/verify_signatures.rs
@@ -44,7 +44,10 @@ pub struct VerifySignaturesTest {
     pub anchor_state: TestState,
     #[serde(rename = "signedBlock")]
     pub signed_block: TestSignedBlock,
-    #[serde(rename = "expectException")]
+    /// Expected rejection, when present. Newer fixtures name this field
+    /// `rejectionReason` (leanSpec replaced `expectException`); both
+    /// spellings are accepted.
+    #[serde(default, rename = "expectException", alias = "rejectionReason")]
     pub expect_exception: Option<String>,
     #[serde(rename = "_info")]
     #[allow(dead_code)]

--- a/crates/common/types/tests/ssz_spectests.rs
+++ b/crates/common/types/tests/ssz_spectests.rs
@@ -5,18 +5,16 @@ use ethlambda_types::primitives::HashTreeRoot;
 mod ssz_types;
 use ssz_types::{SszTestCase, SszTestVector, decode_hex, decode_hex_h256};
 
-/// Newer leanSpec releases name the format `ssz_test`; the pinned-commit
-/// fixtures still use `ssz`. Accept both.
-const SUPPORTED_FIXTURE_FORMATS: &[&str] = &["ssz", "ssz_test"];
+const SUPPORTED_FIXTURE_FORMAT: &str = "ssz_test";
 
 fn run(path: &Path) -> datatest_stable::Result<()> {
     let tests = SszTestVector::from_file(path)?;
 
     for (name, test) in tests.tests {
-        if !SUPPORTED_FIXTURE_FORMATS.contains(&test.info.fixture_format.as_str()) {
+        if test.info.fixture_format != SUPPORTED_FIXTURE_FORMAT {
             return Err(format!(
-                "Unsupported fixture format: {} (expected one of {:?})",
-                test.info.fixture_format, SUPPORTED_FIXTURE_FORMATS
+                "Unsupported fixture format: {} (expected {})",
+                test.info.fixture_format, SUPPORTED_FIXTURE_FORMAT
             )
             .into());
         }

--- a/crates/common/types/tests/ssz_spectests.rs
+++ b/crates/common/types/tests/ssz_spectests.rs
@@ -5,16 +5,18 @@ use ethlambda_types::primitives::HashTreeRoot;
 mod ssz_types;
 use ssz_types::{SszTestCase, SszTestVector, decode_hex, decode_hex_h256};
 
-const SUPPORTED_FIXTURE_FORMAT: &str = "ssz";
+/// Newer leanSpec releases name the format `ssz_test`; the pinned-commit
+/// fixtures still use `ssz`. Accept both.
+const SUPPORTED_FIXTURE_FORMATS: &[&str] = &["ssz", "ssz_test"];
 
 fn run(path: &Path) -> datatest_stable::Result<()> {
     let tests = SszTestVector::from_file(path)?;
 
     for (name, test) in tests.tests {
-        if test.info.fixture_format != SUPPORTED_FIXTURE_FORMAT {
+        if !SUPPORTED_FIXTURE_FORMATS.contains(&test.info.fixture_format.as_str()) {
             return Err(format!(
-                "Unsupported fixture format: {} (expected {})",
-                test.info.fixture_format, SUPPORTED_FIXTURE_FORMAT
+                "Unsupported fixture format: {} (expected one of {:?})",
+                test.info.fixture_format, SUPPORTED_FIXTURE_FORMATS
             )
             .into());
         }

--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -356,10 +356,13 @@ fn apply_step(store: &mut Store, step: ForkChoiceStep) -> Result<(), String> {
                 .ok_or_else(|| "block step missing block data".to_string())?;
             let signed_block = block_data.to_blank_signed_block();
             // Match the spec-test runner: advance time to the block's slot
-            // before importing so the future-slot guard doesn't reject it.
-            let block_time_ms = store.config().genesis_time * 1000
-                + signed_block.message.slot * MILLISECONDS_PER_SLOT;
-            store::on_tick(store, block_time_ms, true);
+            // before importing, unless the step delivers the block ahead of
+            // the store clock.
+            if step.tick_to_slot {
+                let block_time_ms = store.config().genesis_time * 1000
+                    + signed_block.message.slot * MILLISECONDS_PER_SLOT;
+                store::on_tick(store, block_time_ms, true);
+            }
             store::on_block_without_verification(store, signed_block).map_err(|e| e.to_string())
         }
         "attestation" => {


### PR DESCRIPTION
## Motivation

#385 switched CI to download the latest leanSpec fixtures release instead of generating them from a pinned commit. The current release carries fixture-schema changes the test runners don't understand yet, so the Test job on `main` fails.

Note: leanSpec's release is a single rolling `latest` tag — it was republished mid-review (2026-06-10 17:31 UTC), which is what the second commit addresses.

## Description

Runner/harness-only changes — no consensus behavior is touched, and ethlambda already matches the spec in every affected case:

- **`tickToSlot` (fork-choice block steps):** new flag, default `true`. The early-arrival tests set it to `false` to deliver a block ahead of the store clock and assert the clock doesn't move. The forkchoice spectest runner and the Hive test driver now only tick to the block's slot when the flag is set.
- **`rejectionReason`:** leanSpec renamed `expectException`. The `verify_signatures` and `state_transition` fixture types accept both spellings via a serde alias.
- **`ssz_test`:** the SSZ fixture format string was renamed from `ssz`; the runner accepts both.
- **`proofSetting` / mocked proofs:** leanSpec now fills most vectors with placeholder aggregation proofs (`MOCKED-AGGREGATION-PROOF` sentinel) instead of paying for recursive SNARK merges, marking the regime in a top-level `proofSetting` field (0 = mocked, must not be verified; 1 = real and valid; 2 = real and invalid). The forkchoice runner routes mocked vectors through a new `on_gossip_aggregated_attestation_without_verification` (mirroring the `on_block`/`on_block_without_verification` split). Production paths always verify.

Known follow-ups (out of scope):
- The Hive test driver receives fork-choice steps one at a time with no fixture-level context, so it cannot honor `proofSetting` yet; Hive runs against mocked-proof fixtures will need a protocol addition.
- Tracking the rolling `latest` release means any upstream republish can break `main`'s CI at any time; pinning the fixtures tarball SHA256 would restore reproducibility.

## How to Test

```
make test   # downloads latest release fixtures, all suites green
```

Locally verified against the 2026-06-10 17:31 UTC fixtures drop: full `cargo test --workspace --release` passes (108 forkchoice, 118 SSZ, 67 STF, all remaining suites green).