### PR TITLE
fix: don't bound source-target distance

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -116,12 +116,6 @@ fn update_safe_target(store: &mut Store) {
     store.set_safe_target(safe_target);
 }
 
-/// Maximum number of parent links [`checkpoint_is_ancestor`] walks before
-/// giving up. Bounds the per-attestation work on the gossip path; a vote whose
-/// source/target sits more than this many slots below the descendant is
-/// conservatively rejected.
-const MAX_ANCESTRY_WALK_SLOTS: u64 = 128;
-
 /// Return whether `ancestor` lies on `descendant`'s parent chain.
 ///
 /// `descendant_header` is the descendant's already-fetched header, so the walk
@@ -144,20 +138,11 @@ fn checkpoint_is_ancestor(
 
     // The descendant header is already in hand, so begin the walk at its parent.
     let mut current_root = descendant_header.parent_root;
-    let mut steps: u64 = 0;
     while let Some(current_header) = store.get_block_header(&current_root) {
         if current_header.slot == ancestor.slot {
             return current_root == ancestor.root;
         }
         if current_header.slot < ancestor.slot {
-            return false;
-        }
-        steps += 1;
-        if steps >= MAX_ANCESTRY_WALK_SLOTS {
-            warn!(
-                cap = MAX_ANCESTRY_WALK_SLOTS,
-                "Attestation ancestry walk exceeded cap, rejecting"
-            );
             return false;
         }
         current_root = current_header.parent_root;

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -120,10 +120,8 @@ fn update_safe_target(store: &mut Store) {
 ///
 /// `descendant_header` is the descendant's already-fetched header, so the walk
 /// starts from its parent without re-reading it. Walks parent links down to the
-/// ancestor's slot, up to [`MAX_ANCESTRY_WALK_SLOTS`] steps. Empty (skipped)
-/// slots on the path are traversed transparently since they carry no block.
-/// Conservative: a block missing from the store, or exceeding the walk cap,
-/// yields `false`.
+/// ancestor's slot. Empty (skipped) slots on the path are traversed transparently
+/// since they carry no block. A block missing from the store yields `false`.
 fn checkpoint_is_ancestor(
     store: &Store,
     ancestor: &Checkpoint,


### PR DESCRIPTION
## 🗒️ Description / Motivation

This PR fixes an issue we found during some devnet runs, that a step-limit we added to bound the ancestor-check loop inadvertently also capped the finality period to 128 slots before the devnet stopped including attestations.
