### PR TITLE
fix: unify sync-status definition across metric, duties, and reaggregation

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -775,11 +775,7 @@ impl BlockChainServer {
                 // Recover per-attestation Type-1 proofs from the block's
                 // merged Type-2 and fold them into the local pool. Only
                 // run when the chain is in sync — backfilling nodes must
-                // not spam gossip with rederived aggregates. Reuse the sync
-                // gate that governs validator duties so "in sync" has a single
-                // spec-aligned definition. Non-validator nodes still benefit
-                // from the store update because the recovered proofs feed fork
-                // choice on the next acceptance tick.
+                // not spam gossip with rederived aggregates.
                 if self.sync_status.duties_allowed() {
                     self.run_reaggregate_from_block(&block_for_reaggregate);
                 }

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -630,10 +630,6 @@ impl BlockChainServer {
     }
 
     /// Run block import and refresh metrics.
-    ///
-    /// Sync status is owned solely by [`SyncStatusTracker`], refreshed on each
-    /// tick via [`Self::update_sync_status`], so this path does not touch
-    /// `lean_node_sync_status`.
     fn process_block(&mut self, signed_block: SignedBlock) -> Result<(), StoreError> {
         store::on_block(&mut self.store, signed_block)?;
         metrics::update_head_slot(self.store.head_slot());

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -629,30 +629,22 @@ impl BlockChainServer {
         info!(%slot, %validator_id, "Published block");
     }
 
-    /// Run block import, refresh metrics, and report whether the node is in
-    /// sync with the wall-clock slot after the import.
-    fn process_block(&mut self, signed_block: SignedBlock) -> Result<bool, StoreError> {
+    /// Run block import and refresh metrics.
+    ///
+    /// Sync status is owned solely by [`SyncStatusTracker`], refreshed on each
+    /// tick via [`Self::update_sync_status`], so this path does not touch
+    /// `lean_node_sync_status`.
+    fn process_block(&mut self, signed_block: SignedBlock) -> Result<(), StoreError> {
         store::on_block(&mut self.store, signed_block)?;
-        let head_slot = self.store.head_slot();
-        metrics::update_head_slot(head_slot);
+        metrics::update_head_slot(self.store.head_slot());
         metrics::update_latest_justified_slot(self.store.latest_justified().slot);
         metrics::update_latest_finalized_slot(self.store.latest_finalized().slot);
         metrics::update_validators_count(self.key_manager.validator_ids().len() as u64);
 
-        // Update sync status based on head slot vs wall clock slot
-        let current_slot = self.store.time() / INTERVALS_PER_SLOT;
-        let synced = head_slot >= current_slot;
-        let status = if synced {
-            metrics::SyncStatus::Synced
-        } else {
-            metrics::SyncStatus::Syncing
-        };
-        metrics::set_node_sync_status(status);
-
         for table in ALL_TABLES {
             metrics::update_table_bytes(table.name(), self.store.estimate_table_bytes(table));
         }
-        Ok(synced)
+        Ok(())
     }
 
     /// Process a newly received block.
@@ -775,7 +767,7 @@ impl BlockChainServer {
         // `process_block` consumes the original for the storage layer.
         let block_for_reaggregate = signed_block.clone();
         match self.process_block(signed_block) {
-            Ok(synced) => {
+            Ok(()) => {
                 info!(
                     %slot,
                     proposer,
@@ -787,11 +779,12 @@ impl BlockChainServer {
                 // Recover per-attestation Type-1 proofs from the block's
                 // merged Type-2 and fold them into the local pool. Only
                 // run when the chain is in sync — backfilling nodes must
-                // not spam gossip with rederived aggregates. Non-validator
-                // nodes still benefit from the store update because the
-                // recovered proofs feed fork choice on the next acceptance
-                // tick.
-                if synced {
+                // not spam gossip with rederived aggregates. Reuse the sync
+                // gate that governs validator duties so "in sync" has a single
+                // spec-aligned definition. Non-validator nodes still benefit
+                // from the store update because the recovered proofs feed fork
+                // choice on the next acceptance tick.
+                if self.sync_status.duties_allowed() {
                     self.run_reaggregate_from_block(&block_for_reaggregate);
                 }
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

PR #417 added the spec-aligned `SyncStatusTracker` (4-slot lag threshold, hysteresis, network-stall detection) and pointed `lean_node_sync_status` at it. But the **legacy heuristic in `process_block`** (`head_slot >= current_slot`, 0-slot tolerance, no hysteresis, no stall awareness) kept writing the **same metric** on every block import.

The two writers raced on `set_node_sync_status`:
- on **tick**: spec heuristic (4-slot lag)
- on **block import**: strict 0-lag heuristic

Whichever ran last won, so the gauge flapped between two contradictory definitions of "synced", and #417's goal of aligning the metric with leanSpec was only half-done.

## What Changed

- Drop the `set_node_sync_status` write from `process_block`. `SyncStatusTracker` (refreshed on each tick via `update_sync_status`) is now the single source of truth for the metric.
- `process_block` no longer computes/returns the `synced` bool; it returns `Result<(), StoreError>`.
- Gate post-import reaggregation on `sync_status.duties_allowed()` instead of the strict bool, so reaggregation, validator duties, and the metric all share one spec-aligned definition of "in sync".

## Behavior

| Concern | Before | After |
|---|---|---|
| `lean_node_sync_status` | raced between tick (4-slot) and import (0-slot) | tracker only (spec 4-slot + hysteresis + stall) |
| validator duties gate | tracker (#418) | tracker (unchanged) |
| reaggregation gate | strict `head >= current` | `duties_allowed()` (tracker) |

Note: the reaggregation gate now reads the last-tick tracker assessment rather than recomputing at import time. During backfill the tracker reports `syncing` (large head-lag), so reaggregation stays suppressed as intended; the only difference is sub-interval staleness, which is harmless here.

## Tests

- `cargo test -p ethlambda-blockchain --lib` — 38 passed.
- `cargo clippy -p ethlambda-blockchain --lib -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

## Related

- Follows #417 (sync heuristic) and #418 (duty gating).
- Follows leanEthereum/leanSpec#708.