### PR TITLE
docs: drop implemented RPC endpoints from the near-future roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Support for older devnet releases is discontinued when the next devnet version i
 
 Some features we are looking to implement in the near future, in order of priority:
 
-- [RPC endpoints for chain data consumption](https://github.com/lambdaclass/ethlambda/issues/75)
 - [Add guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)
 
 ### Experimental features


### PR DESCRIPTION
## 🗒️ Description / Motivation
The roadmap's "near future" section still listed [RPC endpoints for chain data consumption (#75)](https://github.com/lambdaclass/ethlambda/issues/75) as upcoming work. The RPC API server already exposes chain-data endpoints (finalized state, blocks, headers, justified checkpoint, fork choice), so this item no longer belongs in the upcoming-features list.

## What Changed
- `README.md`: removed the #75 RPC endpoints line item from the near-future features list.

## Correctness / Behavior Guarantees
- Documentation only; no behavior change.

## Tests Added / Run
- None (docs-only change).

## Related Issues / PRs
- Closes #75
