### PR TITLE
fix(fork-choice): reject attestation slot before head block slot

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -225,8 +225,6 @@ fn validate_attestation_data(store: &Store, data: &AttestationData) -> Result<()
 
     // Head Consistency Check - A vote cannot have observed its head before that
     // head existed, so the vote's slot must not precede the head block's slot.
-    // This lower bound also keeps the wire slot clear of the overflow edge that a
-    // crafted near-`u64::MAX` slot would otherwise probe in the time check below.
     if data.slot < data.head.slot {
         return Err(StoreError::AttestationSlotBeforeHead {
             attestation_slot: data.slot,

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -163,7 +163,8 @@ fn checkpoint_is_ancestor(
 ///     3. The head must be at least as recent as source and target.
 ///     4. Checkpoint slots must match the actual block slots.
 ///     5. Source, target, and head must lie on one parent chain.
-///     6. The vote's slot must have started locally (a small disparity margin is allowed).
+///     6. The vote's slot cannot precede the slot of the head it claims to have seen.
+///     7. The vote's slot must have started locally (a small disparity margin is allowed).
 fn validate_attestation_data(store: &Store, data: &AttestationData) -> Result<(), StoreError> {
     let _timing = metrics::time_attestation_validation();
 
@@ -220,6 +221,17 @@ fn validate_attestation_data(store: &Store, data: &AttestationData) -> Result<()
     }
     if !checkpoint_is_ancestor(store, &data.target, &data.head, &head_header) {
         return Err(StoreError::TargetNotAncestorOfHead);
+    }
+
+    // Head Consistency Check - A vote cannot have observed its head before that
+    // head existed, so the vote's slot must not precede the head block's slot.
+    // This lower bound also keeps the wire slot clear of the overflow edge that a
+    // crafted near-`u64::MAX` slot would otherwise probe in the time check below.
+    if data.slot < data.head.slot {
+        return Err(StoreError::AttestationSlotBeforeHead {
+            attestation_slot: data.slot,
+            head_slot: data.head.slot,
+        });
     }
 
     // Time Check - Honest validators emit votes only after their slot has begun.
@@ -858,6 +870,12 @@ pub enum StoreError {
     #[error("Target checkpoint must be ancestor of head")]
     TargetNotAncestorOfHead,
 
+    #[error("Attestation slot {attestation_slot} precedes head block slot {head_slot}")]
+    AttestationSlotBeforeHead {
+        attestation_slot: u64,
+        head_slot: u64,
+    },
+
     #[error(
         "Attestation slot {attestation_slot} is too far in future (store time: {store_time} intervals)"
     )]
@@ -1270,6 +1288,81 @@ mod tests {
         assert!(
             matches!(result, Err(StoreError::SourceNotAncestorOfTarget)),
             "Expected SourceNotAncestorOfTarget, got: {result:?}"
+        );
+    }
+
+    /// leanSpec #1020: a vote whose slot precedes the slot of the head block it
+    /// claims to have seen must be rejected. The vote cannot have observed its
+    /// head before that head existed.
+    #[test]
+    fn validate_attestation_rejects_slot_before_head() {
+        let mut store = new_test_store();
+        let genesis = store.head();
+
+        let b1 = H256([1u8; 32]);
+        let b2 = H256([2u8; 32]);
+        let b3 = H256([3u8; 32]);
+        insert_test_block(&mut store, b1, 1, genesis);
+        insert_test_block(&mut store, b2, 2, b1);
+        insert_test_block(&mut store, b3, 3, b2);
+        store.set_time(3 * INTERVALS_PER_SLOT);
+
+        // head=b3 at slot 3, but the vote's own slot is 2: it claims to have seen
+        // a head that did not yet exist when the vote was cast.
+        let data = AttestationData {
+            slot: 2,
+            source: Checkpoint {
+                root: genesis,
+                slot: 0,
+            },
+            target: Checkpoint { root: b2, slot: 2 },
+            head: Checkpoint { root: b3, slot: 3 },
+        };
+
+        let result = validate_attestation_data(&store, &data);
+        assert!(
+            matches!(
+                result,
+                Err(StoreError::AttestationSlotBeforeHead {
+                    attestation_slot: 2,
+                    head_slot: 3,
+                })
+            ),
+            "Expected AttestationSlotBeforeHead, got: {result:?}"
+        );
+    }
+
+    /// leanSpec #1020: a vote whose slot sits at the unsigned 64-bit ceiling must
+    /// be rejected cleanly as too-far-in-future, without overflowing the
+    /// slot-to-interval multiplication. `saturating_mul` clamps the product at
+    /// `u64::MAX` rather than panicking on overflow.
+    #[test]
+    fn validate_attestation_rejects_ceiling_slot_without_overflow() {
+        let mut store = new_test_store();
+        let genesis = store.head();
+
+        let b1 = H256([1u8; 32]);
+        let b2 = H256([2u8; 32]);
+        insert_test_block(&mut store, b1, 1, genesis);
+        insert_test_block(&mut store, b2, 2, b1);
+        store.set_time(2 * INTERVALS_PER_SLOT);
+
+        // A crafted gossip vote with a near-`u64::MAX` slot. The head-consistency
+        // check passes (slot >= head.slot), so this exercises the time check.
+        let data = AttestationData {
+            slot: u64::MAX,
+            source: Checkpoint {
+                root: genesis,
+                slot: 0,
+            },
+            target: Checkpoint { root: b1, slot: 1 },
+            head: Checkpoint { root: b2, slot: 2 },
+        };
+
+        let result = validate_attestation_data(&store, &data);
+        assert!(
+            matches!(result, Err(StoreError::AttestationTooFarInFuture { .. })),
+            "Expected AttestationTooFarInFuture, got: {result:?}"
         );
     }
 


### PR DESCRIPTION
## What

Ports the head-consistency guard from [leanSpec PR #1020](https://github.com/leanEthereum/leanSpec/pull/1020) into `validate_attestation_data`.

A gossip attestation's slot records *when* the head was observed, so it cannot precede the slot of the head block it claims to have seen. We did not enforce this lower bound: the wire `slot` field was untethered from any real block, free to be set arbitrarily relative to the observed head.

## Why

| Property | Risk without the guard |
|----------|------------------------|
| Soundness | An unbounded slot violates 3SF attestation semantics: the slot is meant to anchor when the head was seen. |
| Liveness (spec context) | In leanSpec a crafted near-`2**64` slot overflowed the slot→interval constructor and crashed the node (remote DoS). |

**Note on the overflow half:** ethlambda's time check already uses `saturating_mul` (`data.slot.saturating_mul(INTERVALS_PER_SLOT)`), so a near-`u64::MAX` slot saturates to `u64::MAX` and is rejected cleanly as too-far-in-future rather than panicking. The Rust port was never crashable the way the unchecked Python constructor was, so no change to the time-check arithmetic is needed; the spec's switch to slot-unit comparison is mathematically equivalent to the existing interval comparison. This PR adds the genuinely missing piece: the semantic lower bound.

## Change

- New `StoreError::AttestationSlotBeforeHead { attestation_slot, head_slot }` rejection.
- Check `data.slot < data.head.slot` after the ancestry checks, before the time check (mirrors the spec's ordering).
- Two unit tests: a vote whose slot precedes its head (rejected as `AttestationSlotBeforeHead`), and a `u64::MAX` ceiling slot (rejected as `AttestationTooFarInFuture`, confirming no overflow).

Applies to both gossip paths via the shared `validate_attestation_data` (`on_gossip_attestation` and `on_gossip_aggregated_attestation`).

## Testing

```
cargo test -p ethlambda-blockchain --lib validate_attestation   # 5 passed
cargo fmt --all && cargo clippy -p ethlambda-blockchain --lib    # clean
```

https://claude.ai/code/session_018pvnQJkom3DobK9oSbK42T