### PR TITLE
refactor(blockchain): drop SyncStatusTracker::gate_proposer

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -236,7 +236,8 @@ impl BlockChainServer {
         let scheduled_proposer = (interval == 0 && slot > 0)
             .then(|| self.get_our_proposer(slot))
             .flatten();
-        let proposer_validator_id = self.sync_status.gate_proposer(scheduled_proposer);
+        let proposer_validator_id =
+            scheduled_proposer.filter(|_| self.sync_status.duties_allowed());
 
         if let Some(validator_id) = scheduled_proposer
             && proposer_validator_id.is_none()

--- a/crates/blockchain/src/sync_status.rs
+++ b/crates/blockchain/src/sync_status.rs
@@ -45,10 +45,6 @@ impl SyncStatusTracker {
     pub(crate) fn duties_allowed(&self) -> bool {
         !self.syncing
     }
-
-    pub(crate) fn gate_proposer(&self, proposer: Option<u64>) -> Option<u64> {
-        proposer.filter(|_| self.duties_allowed())
-    }
 }
 
 #[cfg(test)]
@@ -111,33 +107,5 @@ mod tests {
         let mut tracker = SyncStatusTracker::default();
 
         assert_eq!(tracker.update(15, 20, 20), SyncStatus::Synced);
-    }
-
-    #[test]
-    fn syncing_gates_proposals_and_attestations() {
-        let mut tracker = SyncStatusTracker::default();
-        tracker.update(20, 0, 20);
-
-        assert!(!tracker.duties_allowed());
-        assert_eq!(tracker.gate_proposer(Some(3)), None);
-    }
-
-    #[test]
-    fn caught_up_node_allows_proposals_and_attestations() {
-        let mut tracker = SyncStatusTracker::default();
-        tracker.update(20, 0, 20);
-        tracker.update(20, 18, 20);
-
-        assert!(tracker.duties_allowed());
-        assert_eq!(tracker.gate_proposer(Some(3)), Some(3));
-    }
-
-    #[test]
-    fn network_stall_keeps_proposals_and_attestations_enabled() {
-        let mut tracker = SyncStatusTracker::default();
-        tracker.update(100, 0, 0);
-
-        assert!(tracker.duties_allowed());
-        assert_eq!(tracker.gate_proposer(Some(3)), Some(3));
     }
 }


### PR DESCRIPTION
Split out of #445 (proposer pre-build).

`gate_proposer` was a one-line wrapper over `duties_allowed()` with a single call site. This inlines it as `scheduled_proposer.filter(|_| self.sync_status.duties_allowed())` and removes the method, so the sync gate reads the same way everywhere.

**Behavior-preserving** — `proposer_validator_id` is computed identically; every downstream use (the skip-while-syncing log, the `store::on_tick` proposal flag, the proposal call) is untouched.

The three `gate_proposer`-only unit tests collapse onto the `duties_allowed()` assertions they already made.

Stacked under the on_tick-regrouping PR; #445 will drop these hunks once both land.