### PR TITLE
refactor(blockchain): group on_tick conditionals by interval

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -251,11 +251,6 @@ impl BlockChainServer {
         // (interval 4), so the post-block report for this round sees its
         // "timely" cohort just before it is promoted out of `new_payloads`.
         //
-        // This MUST stay ahead of `store::on_tick` below: the interval-4 tick
-        // promotes `new_payloads` out, so snapshotting afterwards would capture
-        // an already-drained set. It is the one interval action that cannot live
-        // in its grouped block downstream.
-        //
         // Only interval 4 — not the proposer's interval-0 promote. By interval 0
         // the round's votes have already been promoted at the previous slot's
         // interval 4; `new_payloads` then holds only stragglers, and snapshotting

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -230,21 +230,6 @@ impl BlockChainServer {
         let is_aggregator = self.aggregator.is_enabled();
         metrics::set_is_aggregator(is_aggregator);
 
-        // At interval 0, check if we will propose (but don't build the block yet).
-        // Tick forkchoice first to accept attestations, then build the block
-        // using the freshly-accepted attestations.
-        let scheduled_proposer = (interval == 0 && slot > 0)
-            .then(|| self.get_our_proposer(slot))
-            .flatten();
-        let proposer_validator_id =
-            scheduled_proposer.filter(|_| self.sync_status.duties_allowed());
-
-        if let Some(validator_id) = scheduled_proposer
-            && proposer_validator_id.is_none()
-        {
-            info!(%slot, %validator_id, "Skipping block proposal while syncing");
-        }
-
         // ==== interval 4 (pre-tick) ====
 
         // Snapshot the pre-merge `new_payloads` set at the end-of-slot promote
@@ -264,18 +249,23 @@ impl BlockChainServer {
             self.pre_merge_coverage = Some(snapshot);
         }
 
+        let scheduled_proposer = (interval == 0 && slot > 0)
+            .then(|| self.get_our_proposer(slot))
+            .flatten();
+        let is_proposer = scheduled_proposer.is_some();
+
         // Tick the store first - this accepts attestations at interval 0 if we have a proposal
-        store::on_tick(
-            &mut self.store,
-            timestamp_ms,
-            proposer_validator_id.is_some(),
-        );
+        store::on_tick(&mut self.store, timestamp_ms, is_proposer);
 
         // ==== interval 0 ====
 
         // Now build and publish the block (after attestations have been accepted)
-        if let Some(validator_id) = proposer_validator_id {
-            self.propose_block(slot, validator_id);
+        if let Some(validator_id) = scheduled_proposer {
+            if self.sync_status.duties_allowed() {
+                self.propose_block(slot, validator_id);
+            } else {
+                info!(%slot, %validator_id, "Skipping block proposal while syncing");
+            }
         }
 
         // ==== interval 1 ====

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -245,9 +245,16 @@ impl BlockChainServer {
             info!(%slot, %validator_id, "Skipping block proposal while syncing");
         }
 
+        // ==== interval 4 (pre-tick) ====
+
         // Snapshot the pre-merge `new_payloads` set at the end-of-slot promote
         // (interval 4), so the post-block report for this round sees its
         // "timely" cohort just before it is promoted out of `new_payloads`.
+        //
+        // This MUST stay ahead of `store::on_tick` below: the interval-4 tick
+        // promotes `new_payloads` out, so snapshotting afterwards would capture
+        // an already-drained set. It is the one interval action that cannot live
+        // in its grouped block downstream.
         //
         // Only interval 4 — not the proposer's interval-0 promote. By interval 0
         // the round's votes have already been promoted at the previous slot's
@@ -269,22 +276,14 @@ impl BlockChainServer {
             proposer_validator_id.is_some(),
         );
 
-        if interval == 2 {
-            if is_aggregator {
-                coverage::emit_agg_start_new_coverage(
-                    &self.store,
-                    self.attestation_committee_count,
-                );
-                self.start_aggregation_session(slot, ctx).await;
-            } else {
-                metrics::inc_aggregator_skipped_not_aggregator();
-            }
-        }
+        // ==== interval 0 ====
 
         // Now build and publish the block (after attestations have been accepted)
         if let Some(validator_id) = proposer_validator_id {
             self.propose_block(slot, validator_id);
         }
+
+        // ==== interval 1 ====
 
         // Produce attestations at interval 1 (all validators including proposer).
         // Reuse the same snapshot so self-delivery decisions match the rest
@@ -308,6 +307,24 @@ impl BlockChainServer {
                 info!(%slot, "Skipping attestations while syncing");
             }
         }
+
+        // ==== interval 2 ====
+
+        if interval == 2 {
+            if is_aggregator {
+                coverage::emit_agg_start_new_coverage(
+                    &self.store,
+                    self.attestation_committee_count,
+                );
+                self.start_aggregation_session(slot, ctx).await;
+            } else {
+                metrics::inc_aggregator_skipped_not_aggregator();
+            }
+        }
+
+        // ==== interval 3 ====
+
+        // Interval 3 (safe-target update) is handled inside `store::on_tick`.
 
         // Update safe target slot metric (updated by store.on_tick at interval 3)
         metrics::update_safe_target_slot(self.store.safe_target_slot());

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -321,6 +321,10 @@ impl BlockChainServer {
 
         // Interval 3 (safe-target update) is handled inside `store::on_tick`.
 
+        // ==== interval 4 ====
+
+        // Handled by the pre-tick snapshot above.
+
         // Update safe target slot metric (updated by store.on_tick at interval 3)
         metrics::update_safe_target_slot(self.store.safe_target_slot());
         // Update head slot metric (head may change when attestations are promoted at intervals 0/4)


### PR DESCRIPTION
Split out of #445 (proposer pre-build). **Stacked on #449** (`gate_proposer` removal) — review/merge that first; this PR's base retargets to `main` once #449 lands.

`on_tick` ran its per-interval blocks out of order (interval-4 snapshot, then tick, then 2, 0, 1). This regroups them into ascending interval order behind `==== interval N ====` markers so the slot timeline reads top-to-bottom and lines up with the duty schedule.

**Pure reorder, behavior unchanged.**

### One block intentionally does *not* move
The interval-4 `new_payloads` snapshot stays **ahead** of `store::on_tick`. At interval 4 the tick runs `accept_new_attestations → promote_new_aggregated_payloads()`, which drains `new_payloads`; snapshotting after the tick would capture an already-drained set and silently break the post-block coverage report's "timely" cohort. A comment now pins that ordering constraint.

> Note: commit `7474c15` on #445 currently moves this snapshot *into* the post-tick interval-4 group, which hits exactly that regression (observability-only, so devnet doesn't surface it). #445 should adopt this PR's placement when it rebases.