### PR TITLE
feat(blockchain): add --disable-duty-sync-gate to ungate duties

### DIFF
--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -131,6 +131,15 @@ struct CliOptions {
     /// Directory for RocksDB storage
     #[arg(long, default_value = "./data")]
     data_dir: PathBuf,
+    /// Disable the sync-gate's suppression of validator duties.
+    ///
+    /// By default a node that judges itself to be syncing (local head lagging
+    /// wall clock while the network still progresses) skips block proposal,
+    /// attestation production, and aggregate re-derivation. With this flag the
+    /// sync state is still tracked and exported via `lean_node_sync_status`,
+    /// but it no longer suppresses any duty: the gate becomes observe-only.
+    #[arg(long, default_value = "false")]
+    disable_duty_sync_gate: bool,
 }
 
 // Shadow single-steps execution in a discrete-event simulation, so the default
@@ -284,6 +293,7 @@ async fn main() -> eyre::Result<()> {
         validator_keys,
         aggregator.clone(),
         attestation_committee_count,
+        !options.disable_duty_sync_gate,
     );
 
     // Note: SwarmConfig.is_aggregator is intentionally a plain bool, not the

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -265,6 +265,13 @@ impl BlockChainServer {
         // Now build and publish the block (after attestations have been accepted)
         if let Some(validator_id) = scheduled_proposer {
             if self.sync_status.duties_allowed() {
+                if self.sync_status.duty_gate_overridden() {
+                    warn!(
+                        %slot,
+                        %validator_id,
+                        "Proposing block while syncing: duty sync-gate disabled"
+                    );
+                }
                 self.propose_block(slot, validator_id);
             } else {
                 info!(%slot, %validator_id, "Skipping block proposal while syncing");
@@ -290,6 +297,11 @@ impl BlockChainServer {
                 );
             }
             if self.sync_status.duties_allowed() {
+                if self.sync_status.duty_gate_overridden()
+                    && !self.key_manager.validator_ids().is_empty()
+                {
+                    warn!(%slot, "Producing attestations while syncing: duty sync-gate disabled");
+                }
                 self.produce_attestations(slot, is_aggregator);
             } else if !self.key_manager.validator_ids().is_empty() {
                 info!(%slot, "Skipping attestations while syncing");
@@ -739,6 +751,9 @@ impl BlockChainServer {
                 // run when the chain is in sync — backfilling nodes must
                 // not spam gossip with rederived aggregates.
                 if self.sync_status.duties_allowed() {
+                    if self.sync_status.duty_gate_overridden() {
+                        warn!(%slot, "Re-aggregating while syncing: duty sync-gate disabled");
+                    }
                     self.run_reaggregate_from_block(&block_for_reaggregate);
                 }
 

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -81,6 +81,7 @@ impl BlockChain {
         validator_keys: HashMap<u64, ValidatorKeyPair>,
         aggregator: AggregatorController,
         attestation_committee_count: u64,
+        gate_duties: bool,
     ) -> BlockChain {
         metrics::set_is_aggregator(aggregator.is_enabled());
         metrics::set_node_sync_status(metrics::SyncStatus::Idle);
@@ -106,7 +107,7 @@ impl BlockChain {
             last_tick_instant: None,
             attestation_committee_count,
             pre_merge_coverage: None,
-            sync_status: SyncStatusTracker::default(),
+            sync_status: SyncStatusTracker::new(gate_duties),
         }
         .start();
         let time_until_genesis = (SystemTime::UNIX_EPOCH + Duration::from_secs(genesis_time))
@@ -172,7 +173,9 @@ pub struct BlockChainServer {
     /// Observability-only.
     pre_merge_coverage: Option<coverage::CoverageSnapshot>,
 
-    /// Stateful sync heuristic used by `lean_node_sync_status`.
+    /// Stateful sync heuristic used by `lean_node_sync_status`. Also gates
+    /// validator duties while syncing, unless that gating was disabled at
+    /// startup via `--disable-duty-sync-gate` (then it is metric-only).
     sync_status: SyncStatusTracker,
 }
 

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -265,13 +265,6 @@ impl BlockChainServer {
         // Now build and publish the block (after attestations have been accepted)
         if let Some(validator_id) = scheduled_proposer {
             if self.sync_status.duties_allowed() {
-                if self.sync_status.duty_gate_overridden() {
-                    warn!(
-                        %slot,
-                        %validator_id,
-                        "Proposing block while syncing: duty sync-gate disabled"
-                    );
-                }
                 self.propose_block(slot, validator_id);
             } else {
                 info!(%slot, %validator_id, "Skipping block proposal while syncing");
@@ -297,11 +290,6 @@ impl BlockChainServer {
                 );
             }
             if self.sync_status.duties_allowed() {
-                if self.sync_status.duty_gate_overridden()
-                    && !self.key_manager.validator_ids().is_empty()
-                {
-                    warn!(%slot, "Producing attestations while syncing: duty sync-gate disabled");
-                }
                 self.produce_attestations(slot, is_aggregator);
             } else if !self.key_manager.validator_ids().is_empty() {
                 info!(%slot, "Skipping attestations while syncing");
@@ -751,9 +739,6 @@ impl BlockChainServer {
                 // run when the chain is in sync — backfilling nodes must
                 // not spam gossip with rederived aggregates.
                 if self.sync_status.duties_allowed() {
-                    if self.sync_status.duty_gate_overridden() {
-                        warn!(%slot, "Re-aggregating while syncing: duty sync-gate disabled");
-                    }
                     self.run_reaggregate_from_block(&block_for_reaggregate);
                 }
 

--- a/crates/blockchain/src/sync_status.rs
+++ b/crates/blockchain/src/sync_status.rs
@@ -1,3 +1,5 @@
+use tracing::debug;
+
 use crate::metrics::SyncStatus;
 
 /// Local head lag beyond which the node is considered to be syncing.
@@ -49,6 +51,7 @@ impl SyncStatusTracker {
     ) -> SyncStatus {
         let head_lag = current_slot.saturating_sub(head_slot);
         let network_lag = current_slot.saturating_sub(max_seen_slot);
+        let was_syncing = self.syncing;
 
         if network_lag > NETWORK_STALL_THRESHOLD {
             self.syncing = false;
@@ -56,6 +59,18 @@ impl SyncStatusTracker {
             self.syncing = head_lag > SYNC_LAG_THRESHOLD.saturating_sub(SYNC_HYSTERESIS_BAND);
         } else {
             self.syncing = head_lag > SYNC_LAG_THRESHOLD;
+        }
+
+        if self.syncing != was_syncing {
+            debug!(
+                current_slot,
+                head_slot,
+                max_seen_slot,
+                head_lag,
+                network_lag,
+                syncing = self.syncing,
+                "Sync status changed"
+            );
         }
 
         if self.syncing {
@@ -68,13 +83,6 @@ impl SyncStatusTracker {
     pub(crate) fn duties_allowed(&self) -> bool {
         // Gate disabled: the syncing state is observe-only, never suppresses duties.
         !self.gate_duties || !self.syncing
-    }
-
-    /// Whether a duty is running only because the gate is disabled: the node
-    /// believes it is syncing, so with gating on the duty would have been
-    /// suppressed. Lets call sites log the counterfactual suppression.
-    pub(crate) fn duty_gate_overridden(&self) -> bool {
-        !self.gate_duties && self.syncing
     }
 }
 

--- a/crates/blockchain/src/sync_status.rs
+++ b/crates/blockchain/src/sync_status.rs
@@ -69,6 +69,13 @@ impl SyncStatusTracker {
         // Gate disabled: the syncing state is observe-only, never suppresses duties.
         !self.gate_duties || !self.syncing
     }
+
+    /// Whether a duty is running only because the gate is disabled: the node
+    /// believes it is syncing, so with gating on the duty would have been
+    /// suppressed. Lets call sites log the counterfactual suppression.
+    pub(crate) fn duty_gate_overridden(&self) -> bool {
+        !self.gate_duties && self.syncing
+    }
 }
 
 #[cfg(test)]
@@ -131,23 +138,5 @@ mod tests {
         let mut tracker = SyncStatusTracker::default();
 
         assert_eq!(tracker.update(15, 20, 20), SyncStatus::Synced);
-    }
-
-    #[test]
-    fn gating_on_by_default_suppresses_duties_while_syncing() {
-        let mut tracker = SyncStatusTracker::default();
-
-        assert_eq!(tracker.update(20, 0, 20), SyncStatus::Syncing);
-        assert!(!tracker.duties_allowed());
-    }
-
-    #[test]
-    fn disabled_gate_still_tracks_status_but_allows_duties() {
-        let mut tracker = SyncStatusTracker::new(false);
-
-        // Status still tracked for the metric...
-        assert_eq!(tracker.update(20, 0, 20), SyncStatus::Syncing);
-        // ...but duties are never suppressed.
-        assert!(tracker.duties_allowed());
     }
 }

--- a/crates/blockchain/src/sync_status.rs
+++ b/crates/blockchain/src/sync_status.rs
@@ -12,12 +12,35 @@ const NETWORK_STALL_THRESHOLD: u64 = 8;
 /// Recovery band that prevents the sync status from flapping near the threshold.
 const SYNC_HYSTERESIS_BAND: u64 = 2;
 
-#[derive(Default)]
 pub(crate) struct SyncStatusTracker {
     syncing: bool,
+    /// Whether the syncing state suppresses validator duties.
+    ///
+    /// When `false`, [`Self::update`] still tracks `syncing` and drives the
+    /// `lean_node_sync_status` metric, but [`Self::duties_allowed`] always
+    /// returns `true`: the gate is observe-only. Seeded from the CLI
+    /// `--disable-duty-sync-gate` flag (gating stays on by default).
+    gate_duties: bool,
+}
+
+impl Default for SyncStatusTracker {
+    fn default() -> Self {
+        Self {
+            syncing: false,
+            gate_duties: true,
+        }
+    }
 }
 
 impl SyncStatusTracker {
+    /// Build a tracker, choosing whether the syncing state gates duties.
+    pub(crate) fn new(gate_duties: bool) -> Self {
+        Self {
+            gate_duties,
+            ..Self::default()
+        }
+    }
+
     pub(crate) fn update(
         &mut self,
         current_slot: u64,
@@ -43,7 +66,8 @@ impl SyncStatusTracker {
     }
 
     pub(crate) fn duties_allowed(&self) -> bool {
-        !self.syncing
+        // Gate disabled: the syncing state is observe-only, never suppresses duties.
+        !self.gate_duties || !self.syncing
     }
 }
 
@@ -107,5 +131,23 @@ mod tests {
         let mut tracker = SyncStatusTracker::default();
 
         assert_eq!(tracker.update(15, 20, 20), SyncStatus::Synced);
+    }
+
+    #[test]
+    fn gating_on_by_default_suppresses_duties_while_syncing() {
+        let mut tracker = SyncStatusTracker::default();
+
+        assert_eq!(tracker.update(20, 0, 20), SyncStatus::Syncing);
+        assert!(!tracker.duties_allowed());
+    }
+
+    #[test]
+    fn disabled_gate_still_tracks_status_but_allows_duties() {
+        let mut tracker = SyncStatusTracker::new(false);
+
+        // Status still tracked for the metric...
+        assert_eq!(tracker.update(20, 0, 20), SyncStatus::Syncing);
+        // ...but duties are never suppressed.
+        assert!(tracker.duties_allowed());
     }
 }


### PR DESCRIPTION
## What

Adds a `--disable-duty-sync-gate` CLI flag (default `false`, so current behavior is preserved). When set, the sync-gate becomes **observe-only**: it still tracks the syncing state and exports `lean_node_sync_status`, but no longer suppresses any validator duty.

## Why

The sync-gate suppresses three things while a node judges itself to be syncing (local head lagging wall clock while the network still progresses):

| Site | `lib.rs` | Duty |
|------|----------|------|
| Block proposal | `:264` | propose |
| Attestation production | `:289` | attest |
| Aggregate re-derivation | `:738` | reaggregate-from-block |

On the devnets this gate has repeatedly driven a head-finalized **sawtooth / non-finality** feedback loop: dead or slow proposers create empty slots, head lag crosses `SYNC_LAG_THRESHOLD`, nodes flap into `Syncing` and stop attesting, which only widens the gap. This flag lets us A/B that hypothesis on a live devnet without a rebuild, keeping the metric intact for observability.

## How

- `SyncStatusTracker` gains a `gate_duties` field (default `true`).
- `update()` (the metric path) is unchanged.
- `duties_allowed()` returns `true` unconditionally when gating is disabled.
- All three gate sites read `duties_allowed()`, so the flag covers proposal, attestation, **and** reaggregation uniformly.

## Behavior matrix

| `--disable-duty-sync-gate` | `lean_node_sync_status` | duties while syncing |
|---|---|---|
| absent (default) | tracked | **suppressed** (unchanged) |
| present | tracked | **run** |

## Testing

- `cargo test -p ethlambda-blockchain sync_status` — 8/8 pass, incl. two new tests covering gate-on (default) and gate-disabled.
- `cargo build`, `cargo fmt`, `cargo clippy` clean.

Draft: intended for devnet experimentation, not immediate merge.