### PR TITLE
refactor(rpc): compose api router from per-feature route modules

### DIFF
--- a/crates/net/rpc/src/admin.rs
+++ b/crates/net/rpc/src/admin.rs
@@ -12,16 +12,25 @@
 //! the role (hot-standby model). See leanSpec PR #636 for the full rationale.
 
 use axum::{
-    Extension, Json,
+    Extension, Json, Router,
     http::StatusCode,
     response::{IntoResponse, Response},
+    routing::get,
 };
+use ethlambda_storage::Store;
 use ethlambda_types::aggregator::AggregatorController;
 use serde::Serialize;
 use serde_json::Value;
 use tracing::info;
 
 use crate::json_response;
+
+pub(crate) fn routes() -> Router<Store> {
+    Router::new().route(
+        "/lean/v0/admin/aggregator",
+        get(get_aggregator).post(post_aggregator),
+    )
+}
 
 #[derive(Serialize)]
 struct StatusResponse {
@@ -44,7 +53,9 @@ struct ToggleResponse {
 /// `Extension<T>` would cause axum to short-circuit with a 500 when the
 /// extension is missing, whereas `Option` yields `None` and lets us return
 /// a clean 503 with a useful message.
-pub async fn get_aggregator(controller: Option<Extension<AggregatorController>>) -> Response {
+pub(crate) async fn get_aggregator(
+    controller: Option<Extension<AggregatorController>>,
+) -> Response {
     match controller {
         Some(Extension(controller)) => json_response(StatusResponse {
             is_aggregator: controller.is_enabled(),
@@ -62,7 +73,7 @@ pub async fn get_aggregator(controller: Option<Extension<AggregatorController>>)
 /// `Extension<T>` would cause axum to short-circuit with a 500 when the
 /// extension is missing, whereas `Option` yields `None` and lets us return
 /// a clean 503 with a useful message.
-pub async fn post_aggregator(
+pub(crate) async fn post_aggregator(
     controller: Option<Extension<AggregatorController>>,
     body: Option<Json<Value>>,
 ) -> Response {

--- a/crates/net/rpc/src/base.rs
+++ b/crates/net/rpc/src/base.rs
@@ -15,7 +15,7 @@ pub(crate) fn routes() -> Router<Store> {
         .route("/lean/v0/blocks/finalized", get(get_latest_finalized_block))
         .route(
             "/lean/v0/checkpoints/justified",
-            get(get_latest_justified_state),
+            get(get_latest_justified_checkpoint),
         )
 }
 
@@ -40,14 +40,15 @@ pub(crate) async fn get_latest_finalized_block(
     axum::extract::State(store): axum::extract::State<Store>,
 ) -> impl IntoResponse {
     let finalized = store.latest_finalized();
-    // Returns 404 for genesis since it doesn't have a valid signature
+    // Genesis has no stored signature; `get_signed_block` synthesizes a
+    // placeholder blank proof so this always returns 200.
     match store.get_signed_block(&finalized.root) {
         Some(block) => ssz_response(block.to_ssz()),
         None => axum::http::StatusCode::NOT_FOUND.into_response(),
     }
 }
 
-pub(crate) async fn get_latest_justified_state(
+pub(crate) async fn get_latest_justified_checkpoint(
     axum::extract::State(store): axum::extract::State<Store>,
 ) -> impl IntoResponse {
     let checkpoint = store.latest_justified();

--- a/crates/net/rpc/src/blocks.rs
+++ b/crates/net/rpc/src/blocks.rs
@@ -1,7 +1,9 @@
 use axum::{
+    Router,
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
+    routing::get,
 };
 use ethlambda_storage::Store;
 use ethlambda_types::primitives::H256;
@@ -9,10 +11,16 @@ use serde_json::json;
 
 use crate::json_response;
 
+pub(crate) fn routes() -> Router<Store> {
+    Router::new()
+        .route("/lean/v0/blocks/{block_id}", get(get_block))
+        .route("/lean/v0/blocks/{block_id}/header", get(get_block_header))
+}
+
 /// `GET /lean/v0/blocks/:block_id` — returns the block as JSON.
 ///
 /// `block_id` can be a `0x`-prefixed 32-byte hex root or a decimal slot.
-pub async fn get_block(
+pub(crate) async fn get_block(
     Path(block_id): Path<String>,
     State(store): State<Store>,
 ) -> impl IntoResponse {
@@ -28,7 +36,7 @@ pub async fn get_block(
 }
 
 /// `GET /lean/v0/blocks/:block_id/header` — returns the block header as JSON.
-pub async fn get_block_header(
+pub(crate) async fn get_block_header(
     Path(block_id): Path<String>,
     State(store): State<Store>,
 ) -> impl IntoResponse {

--- a/crates/net/rpc/src/core.rs
+++ b/crates/net/rpc/src/core.rs
@@ -1,0 +1,73 @@
+use axum::{
+    Json, Router,
+    http::{HeaderValue, header},
+    response::IntoResponse,
+    routing::get,
+};
+use ethlambda_storage::Store;
+use ethlambda_types::primitives::H256;
+use libssz::SszEncode;
+
+pub(crate) fn routes() -> Router<Store> {
+    Router::new()
+        .route("/lean/v0/health", get(crate::metrics::get_health))
+        .route("/lean/v0/states/finalized", get(get_latest_finalized_state))
+        .route("/lean/v0/blocks/finalized", get(get_latest_finalized_block))
+        .route(
+            "/lean/v0/checkpoints/justified",
+            get(get_latest_justified_state),
+        )
+}
+
+pub(crate) async fn get_latest_finalized_state(
+    axum::extract::State(store): axum::extract::State<Store>,
+) -> impl IntoResponse {
+    let finalized = store.latest_finalized();
+    let mut state = store
+        .get_state(&finalized.root)
+        .expect("finalized state exists");
+
+    // Zero state_root to match the canonical post-state representation.
+    // The spec's state_transition sets state_root to zero during process_block_header,
+    // and only fills it in lazily at the next slot's process_slots.
+    // Serving the canonical form ensures checkpoint sync interoperability.
+    state.latest_block_header.state_root = H256::ZERO;
+
+    ssz_response(state.to_ssz())
+}
+
+pub(crate) async fn get_latest_finalized_block(
+    axum::extract::State(store): axum::extract::State<Store>,
+) -> impl IntoResponse {
+    let finalized = store.latest_finalized();
+    // Returns 404 for genesis since it doesn't have a valid signature
+    match store.get_signed_block(&finalized.root) {
+        Some(block) => ssz_response(block.to_ssz()),
+        None => axum::http::StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+pub(crate) async fn get_latest_justified_state(
+    axum::extract::State(store): axum::extract::State<Store>,
+) -> impl IntoResponse {
+    let checkpoint = store.latest_justified();
+    json_response(checkpoint)
+}
+
+pub(crate) fn json_response<T: serde::Serialize>(value: T) -> axum::response::Response {
+    let mut response = Json(value).into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(crate::JSON_CONTENT_TYPE),
+    );
+    response
+}
+
+fn ssz_response(bytes: Vec<u8>) -> axum::response::Response {
+    let mut response = bytes.into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(crate::SSZ_CONTENT_TYPE),
+    );
+    response
+}

--- a/crates/net/rpc/src/fork_choice.rs
+++ b/crates/net/rpc/src/fork_choice.rs
@@ -1,9 +1,15 @@
-use axum::{http::HeaderValue, http::header, response::IntoResponse};
+use axum::{Router, http::HeaderValue, http::header, response::IntoResponse, routing::get};
 use ethlambda_storage::Store;
 use ethlambda_types::{checkpoint::Checkpoint, primitives::H256};
 use serde::Serialize;
 
 use crate::json_response;
+
+pub(crate) fn routes() -> Router<Store> {
+    Router::new()
+        .route("/lean/v0/fork_choice", get(get_fork_choice))
+        .route("/lean/v0/fork_choice/ui", get(get_fork_choice_ui))
+}
 
 const HTML_CONTENT_TYPE: &str = "text/html; charset=utf-8";
 const FORK_CHOICE_HTML: &str = include_str!("../static/fork_choice.html");
@@ -27,7 +33,7 @@ pub struct ForkChoiceNode {
     weight: u64,
 }
 
-pub async fn get_fork_choice(
+pub(crate) async fn get_fork_choice(
     axum::extract::State(store): axum::extract::State<Store>,
 ) -> impl IntoResponse {
     let blocks = store.get_live_chain();
@@ -75,7 +81,7 @@ pub async fn get_fork_choice(
     json_response(response)
 }
 
-pub async fn get_fork_choice_ui() -> impl IntoResponse {
+pub(crate) async fn get_fork_choice_ui() -> impl IntoResponse {
     let mut response = FORK_CHOICE_HTML.into_response();
     response.headers_mut().insert(
         header::CONTENT_TYPE,
@@ -87,7 +93,7 @@ pub async fn get_fork_choice_ui() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{Router, body::Body, http::Request, http::StatusCode, routing::get};
+    use axum::{Router, body::Body, http::Request, http::StatusCode};
     use ethlambda_storage::{Store, backend::InMemoryBackend};
     use http_body_util::BodyExt;
     use std::sync::Arc;
@@ -96,10 +102,7 @@ mod tests {
     use crate::test_utils::create_test_state;
 
     fn build_test_router(store: Store) -> Router {
-        Router::new()
-            .route("/lean/v0/fork_choice", get(get_fork_choice))
-            .route("/lean/v0/fork_choice/ui", get(get_fork_choice_ui))
-            .with_state(store)
+        routes().with_state(store)
     }
 
     #[tokio::test]

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -1,15 +1,8 @@
 use std::net::{IpAddr, SocketAddr};
 
-use axum::{
-    Extension, Json, Router,
-    http::{HeaderValue, StatusCode, header},
-    response::IntoResponse,
-    routing::get,
-};
+use axum::{Extension, Router};
 use ethlambda_storage::Store;
 use ethlambda_types::aggregator::AggregatorController;
-use ethlambda_types::primitives::H256;
-use libssz::SszEncode;
 use tokio_util::sync::CancellationToken;
 
 pub(crate) const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
@@ -17,10 +10,13 @@ pub(crate) const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
 
 mod admin;
 mod blocks;
+mod core;
 mod fork_choice;
 mod heap_profiling;
 pub mod metrics;
 pub mod test_driver;
+
+pub(crate) use core::json_response;
 
 #[derive(Debug, Clone)]
 pub struct RpcConfig {
@@ -100,91 +96,22 @@ pub async fn start_rpc_server(
 /// know about it and admin handlers extract it independently.
 fn build_api_router(store: Store) -> Router {
     Router::new()
-        .route("/lean/v0/health", get(metrics::get_health))
-        .route("/lean/v0/states/finalized", get(get_latest_finalized_state))
-        .route("/lean/v0/blocks/finalized", get(get_latest_finalized_block))
-        .route(
-            "/lean/v0/checkpoints/justified",
-            get(get_latest_justified_state),
-        )
-        .route("/lean/v0/fork_choice", get(fork_choice::get_fork_choice))
-        .route(
-            "/lean/v0/fork_choice/ui",
-            get(fork_choice::get_fork_choice_ui),
-        )
-        .route("/lean/v0/blocks/{block_id}", get(blocks::get_block))
-        .route(
-            "/lean/v0/blocks/{block_id}/header",
-            get(blocks::get_block_header),
-        )
-        .route(
-            "/lean/v0/admin/aggregator",
-            get(admin::get_aggregator).post(admin::post_aggregator),
-        )
+        .merge(core::routes())
+        .merge(blocks::routes())
+        .merge(fork_choice::routes())
+        .merge(admin::routes())
         .with_state(store)
 }
 
 /// Build the debug router for profiling endpoints.
 fn build_debug_router() -> Router {
+    use axum::routing::get;
     Router::new()
         .route("/debug/pprof/allocs", get(heap_profiling::handle_get_heap))
         .route(
             "/debug/pprof/allocs/flamegraph",
             get(heap_profiling::handle_get_heap_flamegraph),
         )
-}
-
-async fn get_latest_finalized_state(
-    axum::extract::State(store): axum::extract::State<Store>,
-) -> impl IntoResponse {
-    let finalized = store.latest_finalized();
-    let mut state = store
-        .get_state(&finalized.root)
-        .expect("finalized state exists");
-
-    // Zero state_root to match the canonical post-state representation.
-    // The spec's state_transition sets state_root to zero during process_block_header,
-    // and only fills it in lazily at the next slot's process_slots.
-    // Serving the canonical form ensures checkpoint sync interoperability.
-    state.latest_block_header.state_root = H256::ZERO;
-
-    ssz_response(state.to_ssz())
-}
-
-async fn get_latest_finalized_block(
-    axum::extract::State(store): axum::extract::State<Store>,
-) -> impl IntoResponse {
-    let finalized = store.latest_finalized();
-    // Returns 404 for genesis since it doesn't have a valid signature
-    match store.get_signed_block(&finalized.root) {
-        Some(block) => ssz_response(block.to_ssz()),
-        None => StatusCode::NOT_FOUND.into_response(),
-    }
-}
-
-async fn get_latest_justified_state(
-    axum::extract::State(store): axum::extract::State<Store>,
-) -> impl IntoResponse {
-    let checkpoint = store.latest_justified();
-    json_response(checkpoint)
-}
-
-fn json_response<T: serde::Serialize>(value: T) -> axum::response::Response {
-    let mut response = Json(value).into_response();
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static(JSON_CONTENT_TYPE),
-    );
-    response
-}
-
-fn ssz_response(bytes: Vec<u8>) -> axum::response::Response {
-    let mut response = bytes.into_response();
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static(SSZ_CONTENT_TYPE),
-    );
-    response
 }
 
 #[cfg(test)]
@@ -267,7 +194,7 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{body::Body, http::Request};
+    use axum::{body::Body, http::Request, http::StatusCode, http::header};
     use ethlambda_storage::{ForkCheckpoints, Store, backend::InMemoryBackend};
     use http_body_util::BodyExt;
     use serde_json::json;

--- a/crates/net/rpc/src/lib.rs
+++ b/crates/net/rpc/src/lib.rs
@@ -9,14 +9,14 @@ pub(crate) const JSON_CONTENT_TYPE: &str = "application/json; charset=utf-8";
 pub(crate) const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
 
 mod admin;
+mod base;
 mod blocks;
-mod core;
 mod fork_choice;
 mod heap_profiling;
 pub mod metrics;
 pub mod test_driver;
 
-pub(crate) use core::json_response;
+pub(crate) use base::json_response;
 
 #[derive(Debug, Clone)]
 pub struct RpcConfig {
@@ -96,7 +96,7 @@ pub async fn start_rpc_server(
 /// know about it and admin handlers extract it independently.
 fn build_api_router(store: Store) -> Router {
     Router::new()
-        .merge(core::routes())
+        .merge(base::routes())
         .merge(blocks::routes())
         .merge(fork_choice::routes())
         .merge(admin::routes())


### PR DESCRIPTION
Behavior-preserving refactor of the RPC crate's router setup. Instead of a single monolithic router, routes are now composed from per-feature modules, each responsible for registering its own handlers.

This scaffolding is a prerequisite for the stacked endpoint PRs that follow: each new endpoint is added as its own module without touching unrelated code.

Passes clippy with `-D warnings` and all existing tests.