### PR TITLE
test(forkchoice): support "signatures" attestation-check location

### DIFF
--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -427,6 +427,7 @@ fn validate_attestation_check(
     let attestations: HashMap<u64, AttestationData> = match location {
         "new" => st.extract_latest_new_attestations(),
         "known" => st.extract_latest_known_attestations(),
+        "signatures" => st.extract_latest_signature_attestations(),
         other => {
             return Err(
                 format!("Step {}: unknown attestation location: {}", step_idx, other).into(),

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -446,6 +446,32 @@ impl GossipSignatureBuffer {
             .collect()
     }
 
+    /// Extract per-validator latest attestations from the raw signature pool.
+    ///
+    /// Mirrors `PayloadBuffer::extract_latest_attestations`: iterate data_roots
+    /// in insertion order (via `self.order`) so that, when two votes share the
+    /// same `slot`, the first-observed one wins for the validators present in
+    /// both. This matches the leanSpec `location == "signatures"` checker, which
+    /// folds `attestation_signatures` keeping each validator's highest-slot vote
+    /// with first-seen-wins on slot ties.
+    fn extract_latest_attestations(&self) -> HashMap<u64, AttestationData> {
+        let mut result: HashMap<u64, AttestationData> = HashMap::new();
+        for data_root in &self.order {
+            let Some(entry) = self.data.get(data_root) else {
+                continue;
+            };
+            for &vid in entry.signatures.keys() {
+                let should_update = result
+                    .get(&vid)
+                    .is_none_or(|existing| existing.slot < entry.data.slot);
+                if should_update {
+                    result.insert(vid, entry.data.clone());
+                }
+            }
+        }
+        result
+    }
+
     /// Returns the total number of individual signatures stored.
     fn total_signatures(&self) -> usize {
         self.total_signatures
@@ -1165,6 +1191,19 @@ impl Store {
     /// Extract per-validator latest attestations from new (pending) payloads.
     pub fn extract_latest_new_attestations(&self) -> HashMap<u64, AttestationData> {
         self.new_payloads
+            .lock()
+            .unwrap()
+            .extract_latest_attestations()
+    }
+
+    /// Extract per-validator latest attestations from the raw gossip signature
+    /// pool (the spec's `attestation_signatures`).
+    ///
+    /// Unlike the aggregated pools, this pool holds one entry per validator per
+    /// vote, so it reflects raw per-validator signatures before aggregation.
+    /// Each validator maps to its highest-slot vote (first-seen-wins on ties).
+    pub fn extract_latest_signature_attestations(&self) -> HashMap<u64, AttestationData> {
+        self.gossip_signatures
             .lock()
             .unwrap()
             .extract_latest_attestations()


### PR DESCRIPTION
## What

The latest leanSpec fixtures added a third `attestationChecks` location, `"signatures"`, alongside the existing `"new"` and `"known"`. It first appears in `test_attestation_source_divergence/test_honest_vote_sources_from_head_chain_not_store`.

`make test` re-downloads the latest released fixtures, so the fork-choice spec runner started failing:

```
---- run::lstar/fork_choice/test_attestation_source_divergence/test_honest_vote_sources_from_head_chain_not_store.json ----
"Step 4: unknown attestation location: signatures"
test result: FAILED. 115 passed; 1 failed; ...
```

## Root cause

The `"signatures"` location reads the spec's raw per-validator signature pool (`store.attestation_signatures`), which is ethlambda's `gossip_signatures` buffer. The runner's `match location` only mapped the two aggregated pools (`new`/`known`), so the new location was rejected.

This is a **test-harness-only** gap:
- the fixture parser already accepts the location (it's a free `String`);
- the production path (`on_gossip_attestation` with `is_aggregator`) already fills `gossip_signatures`.

## Fix

- Add `Store::extract_latest_signature_attestations`, folding the gossip pool to each validator's highest-slot vote, **first-seen-wins on slot ties**, iterating in insertion order to match both the aggregated-pool extractor and the leanSpec `location == "signatures"` checker.
- Wire the `"signatures"` arm into the fork-choice spec runner.

Verified the spec semantics against leanSpec `packages/testing/src/consensus_testing/test_types/store_checks.py` (the `location == "signatures"` fold over `store.attestation_signatures`).

## Tests

- `forkchoice_spectests`: **116 passed; 0 failed** (was 115 + 1 failed).
- `cargo fmt` + `clippy -D warnings` clean.