### PR TITLE
feat(rpc): add /health endpoint on the metrics server

### DIFF
--- a/crates/net/rpc/src/metrics.rs
+++ b/crates/net/rpc/src/metrics.rs
@@ -3,7 +3,9 @@ use ethlambda_metrics::gather_default_metrics;
 use tracing::warn;
 
 pub fn start_prometheus_metrics_api() -> Router {
-    Router::new().route("/metrics", get(get_metrics))
+    Router::new()
+        .route("/metrics", get(get_metrics))
+        .route("/health", get(get_health))
 }
 
 pub(crate) async fn get_health() -> impl IntoResponse {


### PR DESCRIPTION
Adds a plain `GET /health` liveness probe on the metrics port (5054), alongside `/metrics`.

The handler reuses the existing `get_health` function, so the response body and content-type are identical to the API server's `/lean/v0/health`. This lets k8s/ops probe the metrics port independently of the API server.

- `GET /health` → 200 `{"status":"healthy","service":"lean-rpc-api"}` with `application/json`
- `GET /metrics` unchanged

Two unit tests cover the new route and regression-check `/metrics`.

Stacked on #454.