### PR TITLE
docs(readme): expand roadmap with near-term priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Some features we are looking to implement in the near future, in order of priori
 
 - [Optimize block building](https://github.com/lambdaclass/ethlambda/issues/465)
 - [Use state-diffs for storing states in the database](https://github.com/lambdaclass/ethlambda/issues/238)
-- Prototype Goldfish + RLMD GHOST + BFT — devnet-6
+- [Prototype Goldfish + RLMD GHOST + BFT — devnet-6](https://github.com/lambdaclass/ethlambda/pull/434)
 - [Integrate with execution clients](https://github.com/lambdaclass/ethlambda/pull/367), in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7
 - Replace libp2p with the experimental [ethp2p](https://github.com/ethp2p/ethp2p), which we are porting to Rust
 - [Add a guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ We wrote a [blogpost](https://blog.lambdaclass.com/ethlambda-devnet-5-and-beyond
 
 Some features we are looking to implement in the near future, in order of priority:
 
-- Optimize block building
+- [Optimize block building](https://github.com/lambdaclass/ethlambda/issues/465)
 - Store the state-diff in the database
 - Prototype Goldfish + RLMD GHOST + BFT — devnet-6
 - Integrate with execution clients, in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7

--- a/README.md
+++ b/README.md
@@ -132,11 +132,19 @@ Docker tags for each devnet are released, with format `devnetX` (i.e. `devnet1`,
 
 Support for older devnet releases is discontinued when the next devnet version is released.
 
-## Incoming features
+## Incoming features / Roadmap
+
+We wrote a [blogpost](https://blog.lambdaclass.com/ethlambda-devnet-5-and-beyond/) about what we think should be included in the near future.
 
 Some features we are looking to implement in the near future, in order of priority:
 
-- [Add guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)
+- Optimize block building
+- Store the state-diff in the database
+- Prototype Goldfish + RLMD GHOST + BFT — devnet-6
+- Integrate with execution clients, in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7
+- Replace libp2p with the experimental [ethp2p](https://github.com/ethp2p/ethp2p), which we are porting to Rust
+- [Add a guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)
+- Rewrite the STF in a concrete language to enable formal verification
 
 ### Experimental features
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ We wrote a [blogpost](https://blog.lambdaclass.com/ethlambda-devnet-5-and-beyond
 Some features we are looking to implement in the near future, in order of priority:
 
 - [Optimize block building](https://github.com/lambdaclass/ethlambda/issues/465)
-- Store the state-diff in the database
+- [Use state-diffs for storing states in the database](https://github.com/lambdaclass/ethlambda/issues/238)
 - Prototype Goldfish + RLMD GHOST + BFT — devnet-6
 - Integrate with execution clients, in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7
 - Replace libp2p with the experimental [ethp2p](https://github.com/ethp2p/ethp2p), which we are porting to Rust

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Some features we are looking to implement in the near future, in order of priori
 - [Optimize block building](https://github.com/lambdaclass/ethlambda/issues/465)
 - [Use state-diffs for storing states in the database](https://github.com/lambdaclass/ethlambda/issues/238)
 - Prototype Goldfish + RLMD GHOST + BFT — devnet-6
-- Integrate with execution clients, in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7
+- [Integrate with execution clients](https://github.com/lambdaclass/ethlambda/pull/367), in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7
 - Replace libp2p with the experimental [ethp2p](https://github.com/ethp2p/ethp2p), which we are porting to Rust
 - [Add a guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)
 - Rewrite the STF in the concrete programming language to enable formal verification

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Some features we are looking to implement in the near future, in order of priori
 - Integrate with execution clients, in particular [ethrex](https://github.com/lambdaclass/ethrex) — devnet-7
 - Replace libp2p with the experimental [ethp2p](https://github.com/ethp2p/ethp2p), which we are porting to Rust
 - [Add a guest program and ZK proving of the STF](https://github.com/lambdaclass/ethlambda/issues/156)
-- Rewrite the STF in a concrete language to enable formal verification
+- Rewrite the STF in the concrete programming language to enable formal verification
 
 ### Experimental features
 


### PR DESCRIPTION
## Motivation

The README's "Incoming features" section listed only a single item. This updates it to reflect our near-term roadmap, in priority order, and links to the blogpost where we lay out our thinking.

## Description

- Rename **Incoming features** → **Incoming features / Roadmap**
- Link to the [ethlambda devnet-5 and beyond](https://blog.lambdaclass.com/ethlambda-devnet-5-and-beyond/) blogpost
- Replace the single roadmap entry with a prioritized list:
  - Optimize block building
  - Store the state-diff in the database
  - Prototype Goldfish + RLMD GHOST + BFT — devnet-6
  - Integrate with execution clients, in particular ethrex — devnet-7
  - Replace libp2p with the experimental ethp2p (being ported to Rust)
  - Add a guest program and ZK proving of the STF
  - Rewrite the STF in a concrete language to enable formal verification