### PR TITLE
feat(blockchain): log when block building finishes

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -618,6 +618,8 @@ impl BlockChainServer {
         // not count toward the block-building metric.
         drop(timing);
 
+        info!(%slot, %validator_id, "Finished building block");
+
         let now_ms = unix_now_ms();
 
         // Align publication to the slot boundary. If the build finished before


### PR DESCRIPTION
## What

Adds an info-level `"Finished building block"` log in `propose_block`, emitted right after the block-building timing guard is dropped.

## Why

The timing guard is dropped deliberately before the publish-alignment wait so that wait does not count toward the `block_building` metric. Logging at that exact point makes the build's completion visible and marks the boundary between build time and the alignment wait in logs, complementing the existing `"We are the proposer for this slot"` (start) and `"Published block"` (publish) lines.

Follows the established `%slot, %validator_id` field convention used throughout the function.