### PR TITLE
Add a link to the project website (ethlambda.xyz) in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Minimalist, fast and modular implementation of the Lean Ethereum client written in Rust.
 
+🌐 Visit our website at [**ethlambda.xyz**](https://ethlambda.xyz) to learn more about the project.
+
 ## Getting started
 
 ### Prerequisites


### PR DESCRIPTION
## Motivation
The project has a website at [ethlambda.xyz](https://ethlambda.xyz), but it isn't referenced anywhere in the README.

## Description
Adds a link to the website right under the tagline at the top of the README, with an invitation for readers to visit it. This is the first thing a reader sees, so the invitation lands where attention is highest.

## How to Test
Open `README.md` and confirm the link appears below the tagline and points to `https://ethlambda.xyz`.