### PR TITLE
feat(blockchain): warn instead of failing on unclosed justified divergence

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -825,17 +825,23 @@ pub fn produce_block_with_signatures(
         )?
     };
 
-    // Invariant (leanSpec #595): the produced block must not lag the store's
-    // justified checkpoint. Otherwise peers processing this block would never
-    // see justification advance, degrading liveness: the fixed-point loop in
-    // `build_block` is expected to incorporate pool attestations that close
-    // any divergence inherited from a minority fork.
+    // leanSpec #595: ideally the produced block should not lag the store's
+    // justified checkpoint, since peers processing it would not see
+    // justification advance, degrading liveness. The fixed-point loop in
+    // `build_block` is expected to incorporate pool attestations that close any
+    // divergence inherited from a minority fork, but it may not always
+    // converge. We still publish the block in that case (halting block
+    // production freezes the chain, which is worse) and only log the divergence.
     let store_justified_slot = store.latest_justified().slot;
     if post_checkpoints.justified.slot < store_justified_slot {
-        return Err(StoreError::JustifiedDivergenceNotClosed {
-            block_justified_slot: post_checkpoints.justified.slot,
+        warn!(
+            %slot,
+            proposer = validator_index,
+            block_justified_slot = post_checkpoints.justified.slot,
             store_justified_slot,
-        });
+            "Produced block justified slot is behind store justified slot; \
+             fixed-point attestation loop did not converge"
+        );
     }
 
     metrics::observe_block_aggregated_payloads(signatures.len());
@@ -942,16 +948,6 @@ pub enum StoreError {
 
     #[error("Block contains {count} distinct AttestationData entries; maximum is {max}")]
     TooManyAttestationData { count: usize, max: usize },
-
-    #[error(
-        "Produced block justified slot {block_justified_slot} \
-         is behind store justified slot {store_justified_slot}; \
-         fixed-point attestation loop did not converge"
-    )]
-    JustifiedDivergenceNotClosed {
-        block_justified_slot: u64,
-        store_justified_slot: u64,
-    },
 }
 
 /// Full verification of a signed block's merged Type-2 proof.

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -710,8 +710,8 @@ mod tests {
     /// unconditional `state.latest_justified = target` assignment caused the
     /// post-state to end at `latest_justified.slot = 27974`. Because the
     /// store had already latched `latest_justified = 27978` from importing a
-    /// fork block, every subsequent proposal produced a block whose justified
-    /// slot lagged the store and the chain froze.
+    /// fork block, every subsequent proposal failed
+    /// `JustifiedDivergenceNotClosed` and the chain froze.
     ///
     /// Compressed setup: finalized=0, source=3 (justified), targets in body
     /// order 4 / 9 / 6 — all justifiable from finalized=0 (Δ=4 ≤ 5, Δ=9=3²,

--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -710,8 +710,8 @@ mod tests {
     /// unconditional `state.latest_justified = target` assignment caused the
     /// post-state to end at `latest_justified.slot = 27974`. Because the
     /// store had already latched `latest_justified = 27978` from importing a
-    /// fork block, every subsequent proposal failed
-    /// `JustifiedDivergenceNotClosed` and the chain froze.
+    /// fork block, every subsequent proposal produced a block whose justified
+    /// slot lagged the store and the chain froze.
     ///
     /// Compressed setup: finalized=0, source=3 (justified), targets in body
     /// order 4 / 9 / 6 — all justifiable from finalized=0 (Δ=4 ≤ 5, Δ=9=3²,


### PR DESCRIPTION
## What

`produce_block_with_signatures` checks that a produced block's justified
slot does not lag the store's justified checkpoint (leanSpec #595). When it
did, the function returned `StoreError::JustifiedDivergenceNotClosed`, which
aborted block production for that slot.

This PR removes that error variant and replaces the hard failure with a
warn-level log, then publishes the block anyway.

## Why

Aborting production on this condition halts the chain rather than recovering
from it. The proposer cannot re-justify the head because validators source
from the store-justified checkpoint, so every subsequent proposal hits the
same divergence and block production freezes indefinitely (observed as a
"did not converge" stall).

Publishing a block whose justified slot lags by one fork is the lesser evil:
the chain keeps making progress and pool attestations get a chance to close
the divergence on later slots. The divergence is now surfaced as a warning
instead of silently halting the node.

This mirrors the upstream spec change in
leanEthereum/leanSpec#1168.

## Changes

- `crates/blockchain/src/store.rs`: replace the `return Err(JustifiedDivergenceNotClosed)` with a `warn!` log; remove the now-unused `StoreError::JustifiedDivergenceNotClosed` variant.
- `crates/blockchain/state_transition/src/lib.rs`: reword a test doc comment that referenced the removed error type by name.

## Testing

- `cargo build -p ethlambda-blockchain` ✅
- `cargo clippy -p ethlambda-blockchain --all-targets` ✅ (no warnings)

## References

- Upstream spec change: leanEthereum/leanSpec#1168