### PR TITLE
fix: skip one signature aggregation jobs

### DIFF
--- a/crates/blockchain/src/aggregation.rs
+++ b/crates/blockchain/src/aggregation.rs
@@ -205,7 +205,12 @@ fn build_job(
 
     let (children, accepted_child_ids) = resolve_child_pubkeys(&child_proofs, validators);
 
+    // Skip aggregation when there's nothing to aggregate
     if raw_ids.is_empty() && children.len() < 2 {
+        return None;
+    }
+    // Skip aggregation when there's only a single raw signature to aggregate.
+    if children.is_empty() && raw_ids.len() <= 1 {
         return None;
     }
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

`build_job` (`crates/blockchain/src/aggregation.rs`) already skipped aggregation when there was nothing at all to do (no raw signatures and fewer than 2 children), but it missed one case: exactly **one** raw gossip signature with **no** children to merge it with.

That job still went to the worker and ran the full `aggregate_mixed` leanVM/XMSS proving pipeline, just to wrap a single signature into a 1-participant `TypeOneMultiSignature`. That proof is no smaller or cheaper to verify than the raw signature it wraps, so the proving cost was paid for zero compression benefit, every interval-2 tick, for every attestation-data root that happened to have only one signer so far (e.g. early in a slot, before other votes arrive). `aggregate_mixed`'s own doc comment already calls this out for the "lone child" case ("A lone child is already a valid Type-1; further aggregation is wasted work") but the equivalent "lone raw signature" case wasn't covered.

Aggregation runs on a tight [`AGGREGATION_DEADLINE`](crates/blockchain/src/aggregation.rs) budget shared across all groups in a session, so every wasted proof is time taken away from groups that actually need it.

## What Changed

- `crates/blockchain/src/aggregation.rs`: `build_job` now also returns `None` when `children.is_empty() && raw_ids.len() <= 1`, skipping job creation for a lone, companion-less raw signature.

## Correctness / Behavior Guarantees

- No votes are lost: a skipped signature simply stays in the in-memory `gossip_signatures` buffer (it's never added to `keys_to_delete`), so it's reconsidered on the next interval-2 tick once a companion signature or mergeable proof shows up for the same attestation data. It remains subject to the buffer's existing FIFO eviction and finalization pruning, same as before.
- Purely a CPU-cost optimization on the aggregation hot path; it does not change which attestations eventually reach a block, only avoids a wasted leanVM call when one would have produced a no-op (1-in, 1-out) proof.

## Tests Added / Run

- No new tests added; this is a one-line guard mirroring the existing pattern just above it.
- Ran `cargo test -p ethlambda-blockchain --release` (incl. `forkchoice_spectests` signature-aggregation cases) — all passing.

## Related Issues / PRs

- N/A

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `cargo test --workspace --release` — all passing
