### PR TITLE
fix(test-driver): accept leanSpec mocked aggregate proofs

### DIFF
--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -57,6 +57,13 @@ use tracing::debug;
 /// of `"1"`, `"true"`, or `"yes"` (case-insensitive) enables the driver.
 pub const TEST_DRIVER_ENV: &str = "HIVE_LEAN_TEST_DRIVER";
 
+/// Sentinel prefixing every placeholder proof leanSpec's mocked prover emits
+/// (`proofSetting: 0` fixtures). Matches `MOCK_PROOF_PREFIX` in leanSpec's
+/// `packages/testing/src/consensus_testing/crypto_mode.py`. Proofs carrying it
+/// are accepted without cryptographic verification, mirroring leanSpec's mocked
+/// verifier; genuine (`proofSetting: 1`) proofs still run the real verifier.
+const MOCK_PROOF_PREFIX: &[u8] = b"\x00MOCKED-AGGREGATION-PROOF\x00";
+
 /// Whether the supplied env-var value should activate the driver.
 fn parse_truthy_env_value(value: &str) -> bool {
     matches!(
@@ -390,6 +397,11 @@ fn apply_step(store: &mut Store, step: ForkChoiceStep) -> Result<(), String> {
                 .ok_or_else(|| "gossipAggregatedAttestation step missing proof".to_string())?;
             let participants: EthAggregationBits = proof.participants.into();
             let proof_bytes: Vec<u8> = proof.proof.into();
+            // leanSpec's mocked prover (proofSetting=0) emits placeholder proofs
+            // prefixed with MOCK_PROOF_PREFIX and expects verifiers to accept them
+            // unchecked. Route those through the non-verifying path; genuine proofs
+            // still run the real verifier.
+            let is_mocked = proof_bytes.starts_with(MOCK_PROOF_PREFIX);
             let proof_data = ByteList512KiB::try_from(proof_bytes)
                 .map_err(|err| format!("aggregated proof data too large: {err:?}"))?;
             let data: ethlambda_types::attestation::AttestationData = att.data.into();
@@ -397,7 +409,13 @@ fn apply_step(store: &mut Store, step: ForkChoiceStep) -> Result<(), String> {
                 proof: SingleMessageAggregate::new(participants, proof_data),
                 data,
             };
-            store::on_gossip_aggregated_attestation(store, aggregated).map_err(|e| e.to_string())
+            if is_mocked {
+                store::on_gossip_aggregated_attestation_without_verification(store, aggregated)
+                    .map_err(|e| e.to_string())
+            } else {
+                store::on_gossip_aggregated_attestation(store, aggregated)
+                    .map_err(|e| e.to_string())
+            }
         }
         // `checks`-only steps are no-ops here: the simulator validates them
         // against the snapshot returned alongside this response.


### PR DESCRIPTION
## Problem

ethlambda's Hive test-driver (`crates/net/rpc/src/test_driver.rs`) fails devnet5 `lean-spec-tests-fork-choice` because it does not honor leanSpec's MOCKED crypto mode.

leanSpec fork_choice fixtures generated with `proofSetting: 0` carry PLACEHOLDER aggregate proofs: every proof blob is the sentinel bytes `\x00MOCKED-AGGREGATION-PROOF\x00` followed by a sha256 fingerprint, NOT a real proof. leanSpec's own verifier (`packages/testing/src/consensus_testing/crypto_mode.py`) accepts any sentinel-prefixed blob unchecked and only falls through to the real verifier for genuine (`proofSetting=1`) proofs. A conformant client must do the same.

The driver routed every `gossipAggregatedAttestation` step through the verifying `store::on_gossip_aggregated_attestation`, which decompresses the proof and fails deserialization on a mock blob (`VerificationError::DeserializationFailed`). The driver then reported `accepted=false` where the fixture expects `valid=true`, producing a Hive "acceptance mismatch". This accounts for ~24 fork-choice failures.

## Fix

Detect the `MOCK_PROOF_PREFIX` sentinel before constructing the aggregate and route mocked proofs through the non-verifying path `store::on_gossip_aggregated_attestation_without_verification`. That path still runs all NON-crypto validation (`validate_attestation_data`, participant/index checks), so validation-rejection fixtures still reject correctly. Genuine (`proofSetting=1`) proofs continue to run the real verifier unchanged.

## Tests

New `crates/net/rpc/tests/test_driver_mocked_proofs.rs` replays real fixtures through the router exactly as Hive does (init + per-step POST, comparing `accepted` to each step's `valid` and `snapshot.headSlot` to `checks.headSlot`), gated on fixtures being present:

- `test_valid_gossip_aggregated_attestation.json` (proofSetting=0): the mocked aggregated-attestation step is now ACCEPTED; replay finds no divergence.
- `test_aggregated_attestation_source_after_target_rejected.json` (proofSetting=0): the validation-rejection step is still REJECTED, proving only CRYPTO verification was skipped, not validation.

`cargo test -p ethlambda-rpc --release --test test_driver_mocked_proofs` and the existing `test_driver_e2e` both pass; `make fmt` and `make lint` are clean.

## Note

This is 1 of 2 independent PRs fixing the devnet5 fork-choice Hive suite; the other folds block-borne attestation votes. Both touch `apply_step` in the same file, so a trivial rebase may be needed when the second merges.