### PR TITLE
fix(test-driver): fold block-borne attestation votes into fork choice

### DIFF
--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -374,7 +374,7 @@ fn apply_step(store: &mut Store, step: ForkChoiceStep) -> Result<(), String> {
             // not the proof bytes). Mirrors the same fold in
             // crates/blockchain/tests/forkchoice_spectests.rs.
             let block = block_data.to_block();
-            let entries: Vec<(HashedAttestationData, SingleMessageAggregate)> = block
+            let entries: Vec<_> = block
                 .body
                 .attestations
                 .iter()

--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -40,7 +40,8 @@ use ethlambda_test_fixtures::{
 };
 use ethlambda_types::{
     attestation::{
-        AggregationBits as EthAggregationBits, SignedAggregatedAttestation, SignedAttestation,
+        AggregationBits as EthAggregationBits, HashedAttestationData, SignedAggregatedAttestation,
+        SignedAttestation,
     },
     block::{Block, ByteList512KiB, SingleMessageAggregate},
     checkpoint::Checkpoint,
@@ -363,7 +364,30 @@ fn apply_step(store: &mut Store, step: ForkChoiceStep) -> Result<(), String> {
                     + signed_block.message.slot * MILLISECONDS_PER_SLOT;
                 store::on_tick(store, block_time_ms, true);
             }
-            store::on_block_without_verification(store, signed_block).map_err(|e| e.to_string())
+            store::on_block_without_verification(store, signed_block).map_err(|e| e.to_string())?;
+
+            // Fold the block's attestations into the fork-choice known pool so
+            // block-borne votes carry weight. The production node SNARK-splits
+            // the block's merged proof and folds the recovered single-message
+            // aggregates; fixture blocks are blank, so reconstruct structurally
+            // from aggregation_bits (fork choice reads only the participant set,
+            // not the proof bytes). Mirrors the same fold in
+            // crates/blockchain/tests/forkchoice_spectests.rs.
+            let block = block_data.to_block();
+            let entries: Vec<(HashedAttestationData, SingleMessageAggregate)> = block
+                .body
+                .attestations
+                .iter()
+                .map(|att| {
+                    (
+                        HashedAttestationData::new(att.data.clone()),
+                        SingleMessageAggregate::empty(att.aggregation_bits.clone()),
+                    )
+                })
+                .collect();
+            store.insert_known_aggregated_payloads_batch(entries);
+            store::update_head(store, false);
+            Ok(())
         }
         "attestation" => {
             let att = step

--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -379,10 +379,9 @@ fn apply_step(store: &mut Store, step: ForkChoiceStep) -> Result<(), String> {
                 .attestations
                 .iter()
                 .map(|att| {
-                    (
-                        HashedAttestationData::new(att.data.clone()),
-                        SingleMessageAggregate::empty(att.aggregation_bits.clone()),
-                    )
+                    let hashed_attestation = HashedAttestationData::new(att.data.clone());
+                    let aggregate = SingleMessageAggregate::empty(att.aggregation_bits.clone());
+                    (hashed_attestation, aggregate)
                 })
                 .collect();
             store.insert_known_aggregated_payloads_batch(entries);


### PR DESCRIPTION
## What

The Hive test-driver's `block` step (`crates/net/rpc/src/test_driver.rs`) imported blocks via `on_block_without_verification` but never folded the attestations embedded in the block body into the fork-choice known pool. Block-borne votes therefore carried **no fork-choice weight**, so the head stayed on the lexicographic tie-winner instead of switching to the fork the block's attestations vote for. Hive reported `headSlot mismatch` (e.g. expected 4, got 2), accounting for ~13 devnet5 `lean-spec-tests-fork-choice` failures.

## Fix

After importing the block, reconstruct one `SingleMessageAggregate` per attestation from its `aggregation_bits`, insert them into the known pool via `insert_known_aggregated_payloads_batch`, and recompute the head with `update_head`. This mirrors the fold already done in `crates/blockchain/tests/forkchoice_spectests.rs`.

The production node SNARK-splits the block's merged multi-message aggregate proof and folds the recovered single-message aggregates. Fixture blocks are blank (no real proof to split), so the fold is reconstructed structurally from the participant bits: fork choice reads only the participant set, not the proof bytes.

## Tests

Added `crates/net/rpc/tests/test_driver_block_votes.rs`, which replays real leanSpec fixtures through the router exactly as Hive does (init + per-step POST) and asserts no divergence between the driver's reported head slot and each step's `checks.headSlot`:

- `test_head_switches_to_heavier_fork` (previously diverged at step 3, head 2 vs expected 4)
- `test_simple_one_block_reorg`

Both gated on fixtures being present so a clean checkout still passes.

## Notes

This is **1 of 2** independent PRs fixing the devnet5 fork-choice Hive suite. The other accepts leanSpec mocked aggregate proofs. Both touch `apply_step`, so a trivial rebase may be needed when the second merges.