### PR TITLE
docs: clarify image tag descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Docker images are published to `ghcr.io/lambdaclass/ethlambda` with the followin
 | Tag | Description |
 |-----|-------------|
 | `devnetX` | Stable image for a specific devnet (e.g. `devnet4`) |
-| `latest` | Alias for the stable image of the currently running devnet |
-| `unstable` | Development builds; promoted to `devnetX`/`latest` once tested |
+| `latest` | Alias for the latest stable image of the currently running devnet |
+| `unstable` | Built from the latest main commit; promoted to `devnetX`/`latest` once tested |
 | `sha-XXXXXXX` | Specific commit |
 
 [`RELEASE.md`](./RELEASE.md) has more details on our release process and how to tag new images.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,9 +21,9 @@ exact commit it was built from.
 On top of that, the workflow accepts a comma-separated list of custom tags as a
 parameter (e.g. `latest,devnet2`). We use the following tagging convention:
 
-- `unstable` - the latest image built from the `main` branch, without any devnet-specific features
-- `latest` - the latest image built for the current devnet (`devnet3` at the time of writing)
-- `devnetX` - the latest image built with `devnetX` support (e.g. `devnet3`, `devnet4`)
+- `unstable` - the latest image built from the `main` branch
+- `latest` - the latest stable image built for the current devnet (`devnet5` at the time of writing)
+- `devnetX` - the latest stable image built with `devnetX` support (e.g. `devnet3`, `devnet4`)
 
 Future devnets will introduce new tags, with previous ones left without updates.
 
@@ -31,7 +31,7 @@ Future devnets will introduce new tags, with previous ones left without updates.
 
 ```bash
 docker pull ghcr.io/lambdaclass/ethlambda:unstable       # latest from main
-docker pull ghcr.io/lambdaclass/ethlambda:devnet3        # devnet3-compatible
+docker pull ghcr.io/lambdaclass/ethlambda:devnet5        # devnet5-compatible
 docker pull ghcr.io/lambdaclass/ethlambda:sha-12f8377    # pinned to a specific commit
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,7 +23,7 @@ parameter (e.g. `latest,devnet2`). We use the following tagging convention:
 
 - `unstable` - the latest image built from the `main` branch
 - `latest` - the latest stable image built for the current devnet (`devnet5` at the time of writing)
-- `devnetX` - the latest stable image built with `devnetX` support (e.g. `devnet3`, `devnet4`)
+- `devnetX` - the latest stable image built with `devnetX` support (e.g. `devnet4`, `devnet5`)
 
 Future devnets will introduce new tags, with previous ones left without updates.
 


### PR DESCRIPTION
## Summary

Clarifies the Docker image-tag wording in `README.md` and `RELEASE.md`:

- `unstable` is built from the latest `main` commit.
- `latest` / `devnetX` are the latest **stable** devnet images.
- Bumped the stale `devnet3` "at the time of writing" and `docker pull` examples to `devnet5` (the current devnet).

## Notes

- Left untouched: `Cargo.toml` `leansig` `devnet4` branch (real dependency), the `devnet3/devnet4` test-ignore comment in `encoding.rs`, and the README "Older devnets" list (`devnet1-4` are correctly the *older* ones; `devnet5` is current).
- The new `docs/spec_deviations.md` page (and its `SUMMARY.md` index entry) was split into #499.