### PR TITLE
ci: harden leanSpec fixtures release-info step

### DIFF
--- a/.github/actions/run-fixture-tests/action.yml
+++ b/.github/actions/run-fixture-tests/action.yml
@@ -70,8 +70,8 @@ runs:
         fixtures_url="${{ steps.fixtures-release.outputs.url }}"
         sha_url="${{ steps.fixtures-release.outputs.sha_url }}"
         echo "Downloading fixtures from $fixtures_url"
-        curl -L -f -o "$tmpdir/fixtures-prod-scheme.tar.gz" "$fixtures_url"
-        curl -L -f -o "$tmpdir/fixtures-prod-scheme.tar.gz.sha256" "$sha_url"
+        curl -L -f --retry 5 --retry-all-errors -o "$tmpdir/fixtures-prod-scheme.tar.gz" "$fixtures_url"
+        curl -L -f --retry 5 --retry-all-errors -o "$tmpdir/fixtures-prod-scheme.tar.gz.sha256" "$sha_url"
         expected=$(cut -d' ' -f1 "$tmpdir/fixtures-prod-scheme.tar.gz.sha256")
         actual=$(sha256sum "$tmpdir/fixtures-prod-scheme.tar.gz" | awk '{print $1}')
         if [ "$expected" != "$actual" ]; then

--- a/.github/actions/run-fixture-tests/action.yml
+++ b/.github/actions/run-fixture-tests/action.yml
@@ -10,12 +10,43 @@ runs:
     - name: Get leanSpec fixtures release info
       id: fixtures-release
       shell: bash
+      env:
+        # Authenticate the API call: unauthenticated requests share the runner
+        # IP's low rate-limit pool, which is the usual cause of transient failures.
+        GH_TOKEN: ${{ github.token }}
       run: |
+        set -euo pipefail
         api_url="https://api.github.com/repos/leanEthereum/leanSpec/releases/latest"
-        json=$(curl -sL "$api_url")
-        fixtures_url=$(echo "$json" | python3 -c "import sys,json; j=json.load(sys.stdin); print(next(a.get('browser_download_url') for a in j.get('assets',[]) if a.get('name')=='fixtures-prod-scheme.tar.gz'))")
-        sha_url=$(echo "$json" | python3 -c "import sys,json; j=json.load(sys.stdin); print(next(a.get('browser_download_url') for a in j.get('assets',[]) if a.get('name')=='fixtures-prod-scheme.tar.gz.sha256'))")
-        sha=$(curl -sL "$sha_url" | cut -d' ' -f1)
+
+        # -f fails on HTTP errors (so an error body is never captured as data) and
+        # --retry rides out transient network/5xx hiccups. Fail loudly, since a
+        # command substitution in an assignment does not trip `set -e` on its own.
+        json=$(curl -sSL -f --retry 5 --retry-all-errors \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $GH_TOKEN" \
+          "$api_url") \
+          || { echo "::error::Failed to fetch leanSpec latest release metadata from $api_url"; exit 1; }
+
+        asset_url() {
+          echo "$json" | python3 -c \
+            "import sys,json; name=sys.argv[1]; j=json.load(sys.stdin); print(next(a['browser_download_url'] for a in j.get('assets',[]) if a.get('name')==name))" \
+            "$1"
+        }
+        fixtures_url=$(asset_url "fixtures-prod-scheme.tar.gz") \
+          || { echo "::error::Release is missing the fixtures-prod-scheme.tar.gz asset"; exit 1; }
+        sha_url=$(asset_url "fixtures-prod-scheme.tar.gz.sha256") \
+          || { echo "::error::Release is missing the fixtures-prod-scheme.tar.gz.sha256 asset"; exit 1; }
+
+        sha=$(curl -sSL -f --retry 5 --retry-all-errors "$sha_url" | cut -d' ' -f1) \
+          || { echo "::error::Failed to download the fixtures checksum from $sha_url"; exit 1; }
+
+        # Validate before writing: a transient HTML error page captured as $sha
+        # previously corrupted $GITHUB_OUTPUT ("Invalid format '<!--'").
+        if [[ ! "$sha" =~ ^[0-9a-fA-F]{64}$ ]]; then
+          echo "::error::Expected a 64-char hex SHA256 for the fixtures archive, got: '$sha'"
+          exit 1
+        fi
+
         {
           echo "url=$fixtures_url"
           echo "sha_url=$sha_url"


### PR DESCRIPTION
## Problem

The daily scheduled CI intermittently fails at the very first step of the `run-fixture-tests` action (before any Rust builds), e.g. [run 28942947291](https://github.com/lambdaclass/ethlambda/actions/runs/28942947291/job/85869413074):

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '<!--'
```

## Root cause

The `Get leanSpec fixtures release info` step fetched the release metadata and the checksum asset with `curl -sL` (no `-f`). When the GitHub API / asset CDN returned a **transient HTML error page** (rate-limit or 5xx), that HTML was captured as data and written verbatim into `$GITHUB_OUTPUT`, corrupting the `key=value` file (`<!--` is the offending line). The failure was silent because a command substitution inside an assignment (`var=$(...)`) does not trip `set -e`, so the bad value flowed straight through. Unauthenticated API calls from shared-runner IPs make the rate-limit trigger routine; re-running the job usually "fixes" it.

## Fix

- **Authenticate** the API call with `github.token` (avoids the shared unauthenticated rate-limit pool).
- Add `-f` + `--retry 5 --retry-all-errors` so HTTP errors fail fast and transient hiccups are retried instead of captured as data.
- **Fail loudly** on each curl/parse (assignments don't propagate errexit on their own).
- **Validate** the checksum is a 64-char hex string before writing to `$GITHUB_OUTPUT`.

## Testing

- `python -c yaml.safe_load` + `bash -n` on the extracted script: pass.
- Synthetic: `asset_url` lookup resolves both assets; hex guard accepts a valid sha and rejects `<!--`.
- Live end-to-end against the current `leanEthereum/leanSpec` `latest` release: resolves both asset URLs and a valid 64-hex checksum.