### PR TITLE
test(spec): harden fixture parsing and assert new fork-choice checks (leanSpec #1189)

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -227,6 +227,22 @@ fn validate_attestation_data(store: &Store, data: &AttestationData) -> Result<()
         return Err(StoreError::TargetNotAncestorOfHead);
     }
 
+    // Finalized-Ancestor Check - Fork choice only ever descends from the latest
+    // finalized block, so a vote whose head sits on a branch orphaned by
+    // finalization carries no weight. Rejecting it here stops a stale vote from
+    // re-entering the pools after finalization pruning has dropped it. This is
+    // sound because the store's finalized checkpoint is re-derived from the head
+    // on each update, so it is always an ancestor of the head. See leanSpec #1179.
+    let finalized = store.latest_finalized();
+    if !checkpoint_is_ancestor(store, &finalized, &data.head, &head_header) {
+        return Err(StoreError::HeadNotDescendantOfFinalized {
+            head_root: data.head.root,
+            head_slot: data.head.slot,
+            finalized_root: finalized.root,
+            finalized_slot: finalized.slot,
+        });
+    }
+
     // Head Consistency Check - A vote cannot have observed its head before that
     // head existed, so the vote's slot must not precede the head block's slot.
     if data.slot < data.head.slot {
@@ -938,6 +954,16 @@ pub enum StoreError {
     #[error("Target checkpoint must be ancestor of head")]
     TargetNotAncestorOfHead,
 
+    #[error(
+        "Head checkpoint {head_root} at slot {head_slot} does not descend from finalized block {finalized_root} at slot {finalized_slot}"
+    )]
+    HeadNotDescendantOfFinalized {
+        head_root: H256,
+        head_slot: u64,
+        finalized_root: H256,
+        finalized_slot: u64,
+    },
+
     #[error("Attestation slot {attestation_slot} precedes head block slot {head_slot}")]
     AttestationSlotBeforeHead {
         attestation_slot: u64,
@@ -1529,6 +1555,81 @@ mod tests {
         assert!(
             validate_attestation_data(&store, &data).is_ok(),
             "fully canonical vote must validate"
+        );
+    }
+
+    /// leanSpec #1179: a vote whose head sits on a branch orphaned by
+    /// finalization must be rejected. The vote is admissible while finalization
+    /// still sits below the fork point, but once a sibling block finalizes a slot
+    /// the orphaned head does not descend from, fork choice can no longer count
+    /// it: re-gossiping the same vote must be rejected, not re-admitted.
+    #[test]
+    fn validate_attestation_rejects_head_off_finalized_branch() {
+        let mut store = new_test_store();
+        let genesis = store.head();
+
+        // Canonical chain: genesis(0) <- block_1(1) <- block_2(2).
+        // Orphan branch off block_1: block_1(1) <- orph_2(2) <- orph_3(3).
+        let block_1 = H256([1u8; 32]);
+        let block_2 = H256([2u8; 32]);
+        let orph_2 = H256([3u8; 32]);
+        let orph_3 = H256([4u8; 32]);
+        insert_test_block(&mut store, block_1, 1, genesis);
+        insert_test_block(&mut store, block_2, 2, block_1);
+        insert_test_block(&mut store, orph_2, 2, block_1);
+        insert_test_block(&mut store, orph_3, 3, orph_2);
+        store
+            .set_time(3 * INTERVALS_PER_SLOT)
+            .expect("set_time should succeed");
+
+        // Vote entirely on the orphan branch: source=block_1, target=orph_2,
+        // head=orph_3. Source/target/head form one parent chain, so every
+        // topology and ancestry check below the finalized check passes.
+        let data = AttestationData {
+            slot: 3,
+            source: Checkpoint {
+                root: block_1,
+                slot: 1,
+            },
+            target: Checkpoint {
+                root: orph_2,
+                slot: 2,
+            },
+            head: Checkpoint {
+                root: orph_3,
+                slot: 3,
+            },
+        };
+
+        // While finalization still sits at genesis (below the block_1 fork point),
+        // the orphan head descends from finalized, so the vote is admissible.
+        assert!(
+            validate_attestation_data(&store, &data).is_ok(),
+            "vote must validate while finalized sits below the fork point"
+        );
+
+        // block_2 finalizes slot 2 on the canonical branch. orph_3 does not
+        // descend from block_2, so the vote must now be rejected.
+        let finalized = Checkpoint {
+            root: block_2,
+            slot: 2,
+        };
+        store
+            .update_checkpoints(ForkCheckpoints::new(block_2, None, Some(finalized)))
+            .expect("update_checkpoints should succeed");
+
+        let result = validate_attestation_data(&store, &data);
+        assert!(
+            matches!(
+                result,
+                Err(StoreError::HeadNotDescendantOfFinalized {
+                    head_root,
+                    head_slot: 3,
+                    finalized_root,
+                    finalized_slot: 2,
+                }) if head_root == orph_3 && finalized_root == block_2
+            ),
+            "Expected HeadNotDescendantOfFinalized, got: {result:?}"
         );
     }
 

--- a/crates/blockchain/state_transition/tests/types.rs
+++ b/crates/blockchain/state_transition/tests/types.rs
@@ -23,6 +23,7 @@ impl StateTransitionTestVector {
 
 /// A single state transition test case
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StateTransitionTest {
     #[allow(dead_code)]
     pub network: String,
@@ -32,6 +33,23 @@ pub struct StateTransitionTest {
     pub pre: TestState,
     pub blocks: Vec<Block>,
     pub post: Option<PostState>,
+    /// Expected post-state `hash_tree_root`, present alongside `post`. Captured
+    /// only so `deny_unknown_fields` accepts it; the per-field `post` checks
+    /// already pin the post-state.
+    #[serde(rename = "postStateRoot")]
+    #[allow(dead_code)]
+    pub post_state_root: Option<H256>,
+    /// Expected rejection reason for negative cases. Captured only so
+    /// `deny_unknown_fields` accepts it; failure is asserted via a missing
+    /// `post`.
+    #[serde(rename = "rejectionReason")]
+    #[allow(dead_code)]
+    pub rejection_reason: Option<String>,
+    /// Aggregation proof regime (unused by the STF runner). Captured only so
+    /// `deny_unknown_fields` accepts it.
+    #[serde(rename = "proofSetting")]
+    #[allow(dead_code)]
+    pub proof_setting: Option<u8>,
     #[serde(rename = "_info")]
     #[allow(dead_code)]
     pub info: TestInfo,

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -455,17 +455,24 @@ fn validate_checks(
     // Mirrors leanSpec's `{data.target.slot for data in pool}` over all
     // distinct pool entries.
     if let Some(ref expected) = checks.latest_known_aggregated_target_slots {
-        let actual: Vec<u64> = sorted_unique(
-            st.known_aggregated_payloads()
-                .values()
-                .map(|(data, _)| data.target.slot),
-        );
-        check_target_slots(
-            "latestKnownAggregatedTargetSlots",
-            &actual,
-            expected,
-            step_idx,
-        )?;
+        // Sorted, de-duplicated set of target slots keyed in the known pool.
+        let actual: Vec<u64> = st
+            .known_aggregated_payloads()
+            .values()
+            .map(|(data, _)| data.target.slot)
+            .collect::<BTreeSet<u64>>()
+            .into_iter()
+            .collect();
+        let mut expected_sorted = expected.to_vec();
+        expected_sorted.sort_unstable();
+        expected_sorted.dedup();
+        if actual != expected_sorted.as_slice() {
+            return Err(format!(
+                "Step {step_idx}: latestKnownAggregatedTargetSlots mismatch: \
+                 expected {expected_sorted:?}, got {actual:?}"
+            )
+            .into());
+        }
     }
 
     // NOTE: `latestNewAggregatedTargetSlots`, `attestationSignatureTargetSlots`
@@ -556,31 +563,6 @@ fn resolve_label(
         )
         .into()
     })
-}
-
-/// Collect an iterator of slots into a sorted, de-duplicated `Vec`.
-fn sorted_unique(slots: impl Iterator<Item = u64>) -> Vec<u64> {
-    let set: BTreeSet<u64> = slots.collect();
-    set.into_iter().collect()
-}
-
-/// Compare an actual sorted-unique target-slot set against the fixture's.
-fn check_target_slots(
-    name: &str,
-    actual: &[u64],
-    expected: &[u64],
-    step_idx: usize,
-) -> datatest_stable::Result<()> {
-    let mut expected_sorted = expected.to_vec();
-    expected_sorted.sort_unstable();
-    expected_sorted.dedup();
-    if actual != expected_sorted.as_slice() {
-        return Err(format!(
-            "Step {step_idx}: {name} mismatch: expected {expected_sorted:?}, got {actual:?}"
-        )
-        .into());
-    }
-    Ok(())
 }
 
 /// Walk parent links from `head`, collecting every reachable block root.

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -95,7 +95,7 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
         // Process steps
         for (step_idx, step) in test.steps.into_iter().enumerate() {
             // Head before this step executes, for the `reorgDepth` check.
-            let old_head = store.head();
+            let old_head = store.head()?;
             // Block built/imported this step, for the block-body checks. Mirrors
             // leanSpec's per-step `filled_block` (only a block step sets it).
             let mut filled_block: Option<Block> = None;
@@ -521,9 +521,9 @@ fn validate_checks(
 
     // Validate reorgDepth: blocks reachable from the old head but not the new.
     if let Some(expected_depth) = checks.reorg_depth {
-        let blocks = st.get_live_chain();
+        let blocks = st.get_live_chain()?;
         let old_ancestors = ancestor_set(&blocks, old_head);
-        let new_ancestors = ancestor_set(&blocks, st.head());
+        let new_ancestors = ancestor_set(&blocks, st.head()?);
         let actual_depth = old_ancestors.difference(&new_ancestors).count() as u64;
         if actual_depth != expected_depth {
             return Err(format!(
@@ -535,7 +535,7 @@ fn validate_checks(
 
     // Validate labelsInStore: each labeled block must still be in the block tree.
     if let Some(ref labels) = checks.labels_in_store {
-        let blocks = st.get_live_chain();
+        let blocks = st.get_live_chain()?;
         for label in labels {
             let root = resolve_label(label, block_registry, step_idx)?;
             if !blocks.contains_key(&root) {
@@ -693,7 +693,7 @@ fn validate_canonical_equivocation_head_among(
         .max_by_key(|(_, _, att_root)| *att_root)
         .expect("fork_data is non-empty");
 
-    let actual_head = st.head();
+    let actual_head = st.head()?;
     if actual_head != *winning_fork_root {
         let actual_label = fork_data
             .iter()

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     path::Path,
     sync::Arc,
 };
@@ -9,13 +9,16 @@ use ethlambda_storage::{Store, backend::InMemoryBackend};
 use ethlambda_types::{
     attestation::{
         AttestationData, HashedAttestationData, SignedAggregatedAttestation, SignedAttestation,
+        validator_indices,
     },
     block::{Block, SingleMessageAggregate},
     primitives::{ByteList, H256, HashTreeRoot as _},
     state::{State, anchor_pair_is_consistent},
 };
 
-use ethlambda_test_fixtures::fork_choice::{AttestationCheck, ForkChoiceTestVector, StoreChecks};
+use ethlambda_test_fixtures::fork_choice::{
+    AttestationCheck, BlockAttestationCheck, ForkChoiceTestVector, StoreChecks,
+};
 
 const SUPPORTED_FIXTURE_FORMAT: &str = "fork_choice_test";
 
@@ -75,15 +78,27 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
             .into());
         }
 
+        // The anchor is always reachable under the label "genesis", matching
+        // leanSpec's harness which seeds `block_registry = {"genesis": anchor}`
+        // (true even for checkpoint-sync fixtures anchored past slot 0). Label
+        // checks such as `sourceRootLabel` and `labelsInStore` rely on it.
+        let anchor_root = anchor_block.hash_tree_root();
+
         let backend = Arc::new(InMemoryBackend::new());
         let mut store = Store::get_forkchoice_store(backend, anchor_state, anchor_block)
             .expect("anchor state and block must match");
 
         // Block registry: maps block labels to their roots
         let mut block_registry: HashMap<String, H256> = HashMap::new();
+        block_registry.insert("genesis".to_string(), anchor_root);
 
         // Process steps
         for (step_idx, step) in test.steps.into_iter().enumerate() {
+            // Head before this step executes, for the `reorgDepth` check.
+            let old_head = store.head();
+            // Block built/imported this step, for the block-body checks. Mirrors
+            // leanSpec's per-step `filled_block` (only a block step sets it).
+            let mut filled_block: Option<Block> = None;
             match step.step_type.as_str() {
                 "block" => {
                     let block_data = step.block.expect("block step missing block data");
@@ -94,6 +109,9 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
                         let root = block.hash_tree_root();
                         block_registry.insert(label.clone(), root);
                     }
+
+                    // The block this step delivers is the leanSpec `filled_block`.
+                    filled_block = Some(block_data.to_block());
 
                     let signed_block = block_data.to_blank_signed_block();
 
@@ -208,7 +226,14 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
 
             // Validate checks
             if let Some(checks) = step.checks {
-                validate_checks(&store, &checks, step_idx, &block_registry)?;
+                validate_checks(
+                    &store,
+                    &checks,
+                    step_idx,
+                    &block_registry,
+                    old_head,
+                    filled_block.as_ref(),
+                )?;
             }
         }
     }
@@ -234,6 +259,8 @@ fn validate_checks(
     checks: &StoreChecks,
     step_idx: usize,
     block_registry: &HashMap<String, H256>,
+    old_head: H256,
+    filled_block: Option<&Block>,
 ) -> datatest_stable::Result<()> {
     // Validate time check: fixtures encode the expected store time in intervals
     // since genesis (matching `Store::time()`).
@@ -402,16 +429,309 @@ fn validate_checks(
         }
     }
 
+    // Validate attestationTargetRootLabel: the attestation target root must
+    // resolve to the labeled block.
+    if let Some(ref label) = checks.attestation_target_root_label {
+        let expected = resolve_label(label, block_registry, step_idx)?;
+        let actual = store::get_attestation_target(st).root;
+        if actual != expected {
+            return Err(format!(
+                "Step {step_idx}: attestationTargetRootLabel mismatch (label '{label}'): \
+                 expected {expected:?}, got {actual:?}"
+            )
+            .into());
+        }
+    }
+
     // Validate attestationChecks
     if let Some(ref att_checks) = checks.attestation_checks {
         for att_check in att_checks {
-            validate_attestation_check(st, att_check, step_idx)?;
+            validate_attestation_check(st, att_check, step_idx, block_registry)?;
         }
+    }
+
+    // Validate the accepted (known) pool's target-slot set: the sorted-unique
+    // set of target slots keyed in the known aggregated pool must match.
+    // Mirrors leanSpec's `{data.target.slot for data in pool}` over all
+    // distinct pool entries.
+    if let Some(ref expected) = checks.latest_known_aggregated_target_slots {
+        let actual: Vec<u64> = sorted_unique(
+            st.known_aggregated_payloads()
+                .values()
+                .map(|(data, _)| data.target.slot),
+        );
+        check_target_slots(
+            "latestKnownAggregatedTargetSlots",
+            &actual,
+            expected,
+            step_idx,
+        )?;
+    }
+
+    // NOTE: `latestNewAggregatedTargetSlots`, `attestationSignatureTargetSlots`
+    // and `newPoolProofParticipants` are parsed but NOT asserted here. They
+    // read the pending (new) aggregated pool and the raw gossip-signature pool,
+    // which this offline runner does not drive the way leanSpec's harness does:
+    // it advances ticks without the aggregator role and folds block-borne votes
+    // straight into the known pool, so the new/signature pools do not track
+    // leanSpec's contents. The accepted (known) pool, which the runner does
+    // populate, is asserted above.
+    // TODO(leanSpec new/signature pools): assert these once the runner drives
+    // interval-2 aggregation with the aggregator role so the pending and raw
+    // signature pools mirror leanSpec's.
+
+    // Validate block-body checks against the block built this step.
+    if let Some(expected_count) = checks.block_attestation_count {
+        let block = filled_block.ok_or_else(|| {
+            format!("Step {step_idx}: blockAttestationCount set but no block was built this step")
+        })?;
+        let actual = block.body.attestations.len() as u64;
+        if actual != expected_count {
+            return Err(format!(
+                "Step {step_idx}: blockAttestationCount mismatch: expected {expected_count}, \
+                 got {actual}"
+            )
+            .into());
+        }
+    }
+    if let Some(ref block_checks) = checks.block_attestations {
+        let block = filled_block.ok_or_else(|| {
+            format!("Step {step_idx}: blockAttestations set but no block was built this step")
+        })?;
+        validate_block_attestations(block, block_checks, step_idx)?;
     }
 
     // Validate lexicographicHeadAmong
     if let Some(ref fork_labels) = checks.lexicographic_head_among {
         validate_lexicographic_head_among(st, fork_labels, step_idx, block_registry)?;
+    }
+
+    // Validate canonicalEquivocationHeadAmong (leanSpec #1189)
+    if let Some(ref fork_labels) = checks.canonical_equivocation_head_among {
+        validate_canonical_equivocation_head_among(st, fork_labels, step_idx, block_registry)?;
+    }
+
+    // Validate reorgDepth: blocks reachable from the old head but not the new.
+    if let Some(expected_depth) = checks.reorg_depth {
+        let blocks = st.get_live_chain();
+        let old_ancestors = ancestor_set(&blocks, old_head);
+        let new_ancestors = ancestor_set(&blocks, st.head());
+        let actual_depth = old_ancestors.difference(&new_ancestors).count() as u64;
+        if actual_depth != expected_depth {
+            return Err(format!(
+                "Step {step_idx}: reorgDepth mismatch: expected {expected_depth}, got {actual_depth}"
+            )
+            .into());
+        }
+    }
+
+    // Validate labelsInStore: each labeled block must still be in the block tree.
+    if let Some(ref labels) = checks.labels_in_store {
+        let blocks = st.get_live_chain();
+        for label in labels {
+            let root = resolve_label(label, block_registry, step_idx)?;
+            if !blocks.contains_key(&root) {
+                return Err(format!(
+                    "Step {step_idx}: labelsInStore: block '{label}' (root={root:?}) \
+                     not found in the store"
+                )
+                .into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve a block label to its root via the step's block registry.
+fn resolve_label(
+    label: &str,
+    block_registry: &HashMap<String, H256>,
+    step_idx: usize,
+) -> datatest_stable::Result<H256> {
+    block_registry.get(label).copied().ok_or_else(|| {
+        format!(
+            "Step {step_idx}: label '{label}' not found in block registry. Available: {:?}",
+            block_registry.keys().collect::<Vec<_>>()
+        )
+        .into()
+    })
+}
+
+/// Collect an iterator of slots into a sorted, de-duplicated `Vec`.
+fn sorted_unique(slots: impl Iterator<Item = u64>) -> Vec<u64> {
+    let set: BTreeSet<u64> = slots.collect();
+    set.into_iter().collect()
+}
+
+/// Compare an actual sorted-unique target-slot set against the fixture's.
+fn check_target_slots(
+    name: &str,
+    actual: &[u64],
+    expected: &[u64],
+    step_idx: usize,
+) -> datatest_stable::Result<()> {
+    let mut expected_sorted = expected.to_vec();
+    expected_sorted.sort_unstable();
+    expected_sorted.dedup();
+    if actual != expected_sorted.as_slice() {
+        return Err(format!(
+            "Step {step_idx}: {name} mismatch: expected {expected_sorted:?}, got {actual:?}"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Walk parent links from `head`, collecting every reachable block root.
+///
+/// Mirrors leanSpec's `_ancestor_set`: only roots present in the block tree are
+/// collected, so the walk stops at the anchor (whose parent is not in the tree).
+fn ancestor_set(blocks: &HashMap<H256, (u64, H256)>, head: H256) -> HashSet<H256> {
+    let mut seen = HashSet::new();
+    let mut root = head;
+    while let Some(&(_, parent_root)) = blocks.get(&root) {
+        seen.insert(root);
+        if parent_root == H256::ZERO {
+            break;
+        }
+        root = parent_root;
+    }
+    seen
+}
+
+/// Validate the detailed per-aggregate checks against a built block body.
+///
+/// Mirrors leanSpec's `_validate_block_attestations`: each expected check must
+/// match an aggregate whose participant set is exactly equal, then the matched
+/// aggregate's slot/target-slot are compared.
+fn validate_block_attestations(
+    block: &Block,
+    expected_checks: &[BlockAttestationCheck],
+    step_idx: usize,
+) -> datatest_stable::Result<()> {
+    let actual: Vec<(BTreeSet<u64>, &AttestationData)> = block
+        .body
+        .attestations
+        .iter()
+        .map(|att| {
+            (
+                validator_indices(&att.aggregation_bits).collect(),
+                &att.data,
+            )
+        })
+        .collect();
+
+    for check in expected_checks {
+        let expected_participants: BTreeSet<u64> = check.participants.iter().copied().collect();
+        let matched = actual
+            .iter()
+            .find(|(participants, _)| *participants == expected_participants);
+        let (_, data) = matched.ok_or_else(|| {
+            let available: Vec<_> = actual
+                .iter()
+                .map(|(p, _)| p.iter().collect::<Vec<_>>())
+                .collect();
+            format!(
+                "Step {step_idx}: blockAttestations: no aggregate with participants \
+                 {expected_participants:?}. Available: {available:?}"
+            )
+        })?;
+
+        if let Some(expected_slot) = check.attestation_slot
+            && data.slot != expected_slot
+        {
+            return Err(format!(
+                "Step {step_idx}: blockAttestations: aggregate {expected_participants:?} \
+                 attestationSlot mismatch: expected {expected_slot}, got {}",
+                data.slot
+            )
+            .into());
+        }
+        if let Some(expected_target) = check.target_slot
+            && data.target.slot != expected_target
+        {
+            return Err(format!(
+                "Step {step_idx}: blockAttestations: aggregate {expected_participants:?} \
+                 targetSlot mismatch: expected {expected_target}, got {}",
+                data.target.slot
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+/// Validate the equal-slot equivocation tiebreak (leanSpec #1189).
+///
+/// Each listed fork must be targeted by an attestation in the accepted (known)
+/// aggregated pool; the head must sit on the fork whose targeting attestation
+/// carries the largest `hash_tree_root` (the pool key). Scheme-independent:
+/// roots are read from the store, never pinned by the fixture.
+fn validate_canonical_equivocation_head_among(
+    st: &Store,
+    fork_labels: &[String],
+    step_idx: usize,
+    block_registry: &HashMap<String, H256>,
+) -> datatest_stable::Result<()> {
+    if fork_labels.len() < 2 {
+        return Err(format!(
+            "Step {step_idx}: canonicalEquivocationHeadAmong requires at least 2 forks, got {}",
+            fork_labels.len()
+        )
+        .into());
+    }
+
+    // The known aggregated pool is keyed by hash_tree_root(AttestationData).
+    let known = st.known_aggregated_payloads();
+
+    // Per fork: block root, and the largest attestation-data root targeting it.
+    let mut fork_data: Vec<(&str, H256, H256)> = Vec::with_capacity(fork_labels.len());
+    for label in fork_labels {
+        let fork_root = resolve_label(label, block_registry, step_idx)?;
+        let max_att_root = known
+            .iter()
+            .filter(|(_, (data, _))| data.target.root == fork_root)
+            .map(|(data_root, _)| *data_root)
+            .max()
+            .ok_or_else(|| {
+                format!(
+                    "Step {step_idx}: canonicalEquivocationHeadAmong fork '{label}' \
+                     (block_root={fork_root:?}) has no attestation targeting it in the \
+                     accepted aggregated pool"
+                )
+            })?;
+        fork_data.push((label.as_str(), fork_root, max_att_root));
+    }
+
+    // Winner: the fork carrying the largest attestation-data root.
+    let (winning_label, winning_fork_root, _) = fork_data
+        .iter()
+        .max_by_key(|(_, _, att_root)| *att_root)
+        .expect("fork_data is non-empty");
+
+    let actual_head = st.head();
+    if actual_head != *winning_fork_root {
+        let actual_label = fork_data
+            .iter()
+            .find(|(_, root, _)| *root == actual_head)
+            .map(|(label, _, _)| *label)
+            .unwrap_or("unknown");
+        let fork_info: Vec<String> = fork_data
+            .iter()
+            .map(|(label, root, att_root)| {
+                format!("  {label}: block_root={root:?} attestation_data_root={att_root:?}")
+            })
+            .collect();
+        return Err(format!(
+            "Step {step_idx}: canonical equivocation tiebreak failed.\n\
+             The head must be the fork with the largest attestation-data root.\n\
+             Expected head: '{winning_label}' ({winning_fork_root:?})\n\
+             Actual head:   '{actual_label}' ({actual_head:?})\n\
+             Competing forks:\n{}",
+            fork_info.join("\n")
+        )
+        .into());
     }
 
     Ok(())
@@ -421,6 +741,7 @@ fn validate_attestation_check(
     st: &Store,
     check: &AttestationCheck,
     step_idx: usize,
+    block_registry: &HashMap<String, H256>,
 ) -> datatest_stable::Result<()> {
     let validator_id = check.validator;
     let location = check.location.as_str();
@@ -442,6 +763,19 @@ fn validate_attestation_check(
             step_idx, validator_id, location
         )
     })?;
+
+    // Validate source root by label if specified.
+    if let Some(ref label) = check.source_root_label {
+        let expected = resolve_label(label, block_registry, step_idx)?;
+        if attestation.source.root != expected {
+            return Err(format!(
+                "Step {step_idx}: attestation source root mismatch for validator {validator_id} \
+                 (label '{label}'): expected {expected:?}, got {:?}",
+                attestation.source.root
+            )
+            .into());
+        }
+    }
 
     // Validate attestation slot if specified
     if let Some(expected_slot) = check.attestation_slot

--- a/crates/blockchain/tests/forkchoice_spectests.rs
+++ b/crates/blockchain/tests/forkchoice_spectests.rs
@@ -92,6 +92,15 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
         let mut block_registry: HashMap<String, H256> = HashMap::new();
         block_registry.insert("genesis".to_string(), anchor_root);
 
+        // Cumulative block tree (root -> (slot, parent_root)), never pruned.
+        // Mirrors leanSpec's `store.blocks`, which only ever grows: the store's
+        // `LiveChain` index drops entries below the finalized slot, but the
+        // reference harness keeps every block it ever imported. `reorgDepth`
+        // and `labelsInStore` must resolve blocks that finalization has already
+        // pruned from `LiveChain`, so we accumulate live-chain snapshots here
+        // instead of re-reading the pruned index at check time.
+        let mut all_blocks: HashMap<H256, (u64, H256)> = store.get_live_chain()?;
+
         // Process steps
         for (step_idx, step) in test.steps.into_iter().enumerate() {
             // Head before this step executes, for the `reorgDepth` check.
@@ -224,6 +233,11 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
                 }
             }
 
+            // Fold this step's blocks into the cumulative tree before checks so
+            // ancestry walks see blocks finalization may have just pruned from
+            // the live-chain index (see `all_blocks` above).
+            all_blocks.extend(store.get_live_chain()?);
+
             // Validate checks
             if let Some(checks) = step.checks {
                 validate_checks(
@@ -233,6 +247,7 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
                     &block_registry,
                     old_head,
                     filled_block.as_ref(),
+                    &all_blocks,
                 )?;
             }
         }
@@ -261,6 +276,7 @@ fn validate_checks(
     block_registry: &HashMap<String, H256>,
     old_head: H256,
     filled_block: Option<&Block>,
+    all_blocks: &HashMap<H256, (u64, H256)>,
 ) -> datatest_stable::Result<()> {
     // Validate time check: fixtures encode the expected store time in intervals
     // since genesis (matching `Store::time()`).
@@ -520,10 +536,13 @@ fn validate_checks(
     }
 
     // Validate reorgDepth: blocks reachable from the old head but not the new.
+    // Walk the cumulative block tree, not the live-chain index: a reorg that
+    // also advanced finalization may have pruned the abandoned branch from
+    // `LiveChain`, which would undercount the depth. leanSpec walks its
+    // never-pruned `store.blocks` here for the same reason.
     if let Some(expected_depth) = checks.reorg_depth {
-        let blocks = st.get_live_chain()?;
-        let old_ancestors = ancestor_set(&blocks, old_head);
-        let new_ancestors = ancestor_set(&blocks, st.head()?);
+        let old_ancestors = ancestor_set(all_blocks, old_head);
+        let new_ancestors = ancestor_set(all_blocks, st.head()?);
         let actual_depth = old_ancestors.difference(&new_ancestors).count() as u64;
         if actual_depth != expected_depth {
             return Err(format!(
@@ -533,12 +552,13 @@ fn validate_checks(
         }
     }
 
-    // Validate labelsInStore: each labeled block must still be in the block tree.
+    // Validate labelsInStore: each labeled block must still be in the block
+    // tree. Mirrors leanSpec's `root in store.blocks` against the never-pruned
+    // tree, so a finalized block pruned from the live-chain index still counts.
     if let Some(ref labels) = checks.labels_in_store {
-        let blocks = st.get_live_chain()?;
         for label in labels {
             let root = resolve_label(label, block_registry, step_idx)?;
-            if !blocks.contains_key(&root) {
+            if !all_blocks.contains_key(&root) {
                 return Err(format!(
                     "Step {step_idx}: labelsInStore: block '{label}' (root={root:?}) \
                      not found in the store"

--- a/crates/common/test-fixtures/src/common.rs
+++ b/crates/common/test-fixtures/src/common.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Container<T> {
     pub data: Vec<T>,
 }
@@ -30,6 +31,7 @@ pub struct Container<T> {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(rename = "genesisTime")]
     pub genesis_time: u64,
@@ -48,6 +50,7 @@ impl From<Config> for ChainConfig {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Checkpoint {
     pub root: H256,
     pub slot: u64,
@@ -67,6 +70,7 @@ impl From<Checkpoint> for DomainCheckpoint {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockHeader {
     pub slot: u64,
     #[serde(rename = "proposerIndex")]
@@ -96,6 +100,7 @@ impl From<BlockHeader> for ethlambda_types::block::BlockHeader {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Validator {
     index: u64,
     #[serde(rename = "attestationPublicKey")]
@@ -121,6 +126,7 @@ impl From<Validator> for DomainValidator {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestState {
     pub config: Config,
     pub slot: u64,
@@ -186,6 +192,7 @@ impl From<TestState> for State {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Block {
     pub slot: u64,
     #[serde(rename = "proposerIndex")]
@@ -210,6 +217,7 @@ impl From<Block> for DomainBlock {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockBody {
     pub attestations: Container<AggregatedAttestation>,
 }
@@ -233,6 +241,7 @@ impl From<BlockBody> for DomainBlockBody {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedAttestation {
     #[serde(rename = "aggregationBits")]
     pub aggregation_bits: AggregationBits,
@@ -249,6 +258,7 @@ impl From<AggregatedAttestation> for DomainAggregatedAttestation {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AggregationBits {
     pub data: Vec<bool>,
 }
@@ -264,6 +274,7 @@ impl From<AggregationBits> for DomainAggregationBits {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttestationData {
     pub slot: u64,
     pub head: Checkpoint,
@@ -287,6 +298,7 @@ impl From<AttestationData> for DomainAttestationData {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestInfo {
     pub hash: String,
     pub comment: String,
@@ -295,6 +307,12 @@ pub struct TestInfo {
     pub description: String,
     #[serde(rename = "fixtureFormat")]
     pub fixture_format: String,
+    /// Digest of the validator key set the fixture was generated against.
+    /// Present on every current fixture; captured only so `deny_unknown_fields`
+    /// does not reject it.
+    #[serde(rename = "keySetDigest")]
+    #[allow(dead_code)]
+    pub key_set_digest: String,
 }
 
 // ============================================================================

--- a/crates/common/test-fixtures/src/fork_choice.rs
+++ b/crates/common/test-fixtures/src/fork_choice.rs
@@ -33,6 +33,7 @@ impl ForkChoiceTestVector {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ForkChoiceTest {
     #[allow(dead_code)]
     pub network: String,
@@ -52,6 +53,11 @@ pub struct ForkChoiceTest {
     #[serde(rename = "maxSlot")]
     #[allow(dead_code)]
     pub max_slot: u64,
+    /// Top-level expected rejection reason for whole-vector negative tests.
+    /// Captured only so `deny_unknown_fields` accepts it.
+    #[serde(rename = "rejectionReason")]
+    #[allow(dead_code)]
+    pub rejection_reason: Option<String>,
     #[serde(rename = "_info")]
     pub info: TestInfo,
 }
@@ -73,6 +79,7 @@ impl ForkChoiceTest {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ForkChoiceStep {
     /// Whether this step is expected to be accepted by the store.
     ///
@@ -98,6 +105,20 @@ pub struct ForkChoiceStep {
     /// `false` to deliver the block ahead of the store clock.
     #[serde(rename = "tickToSlot", default = "default_true")]
     pub tick_to_slot: bool,
+    /// Full canonical store snapshot the simulator emits after every step
+    /// (leanSpec `StoreSnapshot`). Captured but not yet asserted by the offline
+    /// runner.
+    // TODO(leanSpec storeSnapshot): assert the snapshot contents against Store
+    // getters (block roots, block weights, aggregated-payload participant sets,
+    // gossip-signature groups) once the required Store plumbing exists.
+    #[serde(rename = "storeSnapshot")]
+    pub store_snapshot: Option<StoreSnapshot>,
+    /// Expected rejection reason for a step marked `valid: false`. Captured only
+    /// so `deny_unknown_fields` accepts it; step outcomes are asserted via the
+    /// `valid` flag.
+    #[serde(rename = "rejectionReason")]
+    #[allow(dead_code)]
+    pub rejection_reason: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -105,6 +126,7 @@ fn default_true() -> bool {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttestationStepData {
     #[serde(rename = "validatorIndex")]
     pub validator_id: Option<u64>,
@@ -122,6 +144,7 @@ pub struct AttestationStepData {
 /// `{ data: "0x<hex>" }`; the latter is the lean-multisig single-message
 /// aggregate `compress_without_pubkeys()` bytes for that AttestationData.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProofStepData {
     pub participants: AggregationBits,
     pub proof: HexByteList,
@@ -129,6 +152,7 @@ pub struct ProofStepData {
 
 /// Hex-encoded byte list in the fixture format: `{ "data": "0xdeadbeef" }`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HexByteList {
     data: String,
 }
@@ -151,6 +175,7 @@ where
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockStepData {
     pub slot: u64,
     #[serde(rename = "proposerIndex")]
@@ -199,6 +224,7 @@ impl BlockStepData {
 /// Root-typed fields have a `*RootLabel` companion that resolves a block label via the
 /// step's block registry, mirroring the leanSpec fixture schema.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StoreChecks {
     /// Expected store time in intervals since genesis.
     pub time: Option<u64>,
@@ -244,13 +270,72 @@ pub struct StoreChecks {
 
     #[serde(rename = "attestationTargetSlot")]
     pub attestation_target_slot: Option<u64>,
+    /// Expected attestation target block root by label reference.
+    #[serde(rename = "attestationTargetRootLabel")]
+    pub attestation_target_root_label: Option<String>,
     #[serde(rename = "attestationChecks")]
     pub attestation_checks: Option<Vec<AttestationCheck>>,
     #[serde(rename = "lexicographicHeadAmong")]
     pub lexicographic_head_among: Option<Vec<String>>,
+
+    /// Equal-slot equivocation tiebreak: the listed fork labels must each be
+    /// targeted by an attestation in the accepted (known) aggregated pool, and
+    /// the head must sit on the fork whose attestation carries the largest
+    /// `hash_tree_root` (leanSpec #1189). Scheme-independent: roots are read
+    /// from the store, never pinned.
+    #[serde(rename = "canonicalEquivocationHeadAmong")]
+    pub canonical_equivocation_head_among: Option<Vec<String>>,
+
+    /// Expected sorted-unique set of target slots keyed in the raw gossip
+    /// signature pool.
+    #[serde(rename = "attestationSignatureTargetSlots")]
+    pub attestation_signature_target_slots: Option<Vec<u64>>,
+    /// Expected sorted-unique set of target slots keyed in the pending (new)
+    /// aggregated proof pool.
+    #[serde(rename = "latestNewAggregatedTargetSlots")]
+    pub latest_new_aggregated_target_slots: Option<Vec<u64>>,
+    /// Expected sorted-unique set of target slots keyed in the accepted (known)
+    /// aggregated proof pool.
+    #[serde(rename = "latestKnownAggregatedTargetSlots")]
+    pub latest_known_aggregated_target_slots: Option<Vec<u64>>,
+
+    /// Expected union of validator indices across pending-pool proofs, keyed by
+    /// target slot. JSON object keys are stringified slots (e.g. `"1"`); parse
+    /// them to `u64` at assertion time.
+    #[serde(rename = "newPoolProofParticipants")]
+    pub new_pool_proof_participants: Option<HashMap<String, Vec<u64>>>,
+
+    /// Expected number of aggregated attestations in the block built for this
+    /// step. More than one means votes split over incompatible sources.
+    #[serde(rename = "blockAttestationCount")]
+    pub block_attestation_count: Option<u64>,
+    /// Detailed per-aggregate checks on the block built for this step.
+    #[serde(rename = "blockAttestations")]
+    pub block_attestations: Option<Vec<BlockAttestationCheck>>,
+
+    /// Expected count of blocks from the previous head back to its common
+    /// ancestor with the new head.
+    #[serde(rename = "reorgDepth")]
+    pub reorg_depth: Option<u64>,
+
+    /// Block labels that must still be present in the block tree (verifying
+    /// abandoned forks are retained).
+    #[serde(rename = "labelsInStore")]
+    pub labels_in_store: Option<Vec<String>>,
+
+    /// Expected root of the block built for this step, named by label. The
+    /// offline runner does not build blocks (it imports fixture-supplied ones),
+    /// so this is captured but not asserted.
+    // TODO(leanSpec filledBlockRootLabel): assert once a block-building step
+    // exists; the offline runner imports blocks rather than building them.
+    #[serde(rename = "filledBlockRootLabel")]
+    #[allow(dead_code)]
+    pub filled_block_root_label: Option<String>,
 }
 
+/// Per-validator attestation content check within a step's `attestationChecks`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttestationCheck {
     pub validator: u64,
     #[serde(rename = "attestationSlot")]
@@ -259,7 +344,88 @@ pub struct AttestationCheck {
     pub head_slot: Option<u64>,
     #[serde(rename = "sourceSlot")]
     pub source_slot: Option<u64>,
+    /// Expected source checkpoint root, named by label and resolved to a root.
+    #[serde(rename = "sourceRootLabel")]
+    pub source_root_label: Option<String>,
     #[serde(rename = "targetSlot")]
     pub target_slot: Option<u64>,
     pub location: String,
+}
+
+/// Checks for one aggregated attestation in a built block body
+/// (leanSpec `AggregatedAttestationCheck`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BlockAttestationCheck {
+    /// Validator indices this aggregate must cover exactly.
+    pub participants: Vec<u64>,
+    #[serde(rename = "attestationSlot")]
+    pub attestation_slot: Option<u64>,
+    #[serde(rename = "targetSlot")]
+    pub target_slot: Option<u64>,
+}
+
+// ============================================================================
+// Store snapshot (leanSpec `StoreSnapshot`)
+// ============================================================================
+
+/// Canonical store snapshot emitted after every fork-choice step.
+///
+/// Parsed in full so `deny_unknown_fields` accepts it, but not yet asserted by
+/// the offline runner; see the `TODO(leanSpec storeSnapshot)` on
+/// [`ForkChoiceStep::store_snapshot`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)]
+pub struct StoreSnapshot {
+    pub time: u64,
+    #[serde(rename = "headRoot")]
+    pub head_root: H256,
+    #[serde(rename = "safeTargetRoot")]
+    pub safe_target_root: H256,
+    #[serde(rename = "latestJustified")]
+    pub latest_justified: Checkpoint,
+    #[serde(rename = "latestFinalized")]
+    pub latest_finalized: Checkpoint,
+    #[serde(rename = "blockRoots")]
+    pub block_roots: Vec<H256>,
+    #[serde(rename = "blockWeights")]
+    pub block_weights: Vec<BlockWeightEntry>,
+    #[serde(rename = "knownAggregatedPayloads")]
+    pub known_aggregated_payloads: Vec<AggregatedPayloadEntry>,
+    #[serde(rename = "newAggregatedPayloads")]
+    pub new_aggregated_payloads: Vec<AggregatedPayloadEntry>,
+    #[serde(rename = "attestationSignatures")]
+    pub attestation_signatures: Vec<AttestationSignatureEntry>,
+}
+
+/// A `{root, weight}` entry in [`StoreSnapshot::block_weights`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)]
+pub struct BlockWeightEntry {
+    pub root: H256,
+    pub weight: u64,
+}
+
+/// A `{dataRoot, participantSets}` entry in the snapshot's aggregated pools.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)]
+pub struct AggregatedPayloadEntry {
+    #[serde(rename = "dataRoot")]
+    pub data_root: H256,
+    #[serde(rename = "participantSets")]
+    pub participant_sets: Vec<Vec<u64>>,
+}
+
+/// A `{dataRoot, validatorIndices}` entry in the snapshot's signature pool.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)]
+pub struct AttestationSignatureEntry {
+    #[serde(rename = "dataRoot")]
+    pub data_root: H256,
+    #[serde(rename = "validatorIndices")]
+    pub validator_indices: Vec<u64>,
 }

--- a/crates/common/test-fixtures/src/verify_signatures.rs
+++ b/crates/common/test-fixtures/src/verify_signatures.rs
@@ -34,6 +34,7 @@ impl VerifySignaturesTestVector {
 
 /// A single verify-signatures test case.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct VerifySignaturesTest {
     #[allow(dead_code)]
     pub network: String,
@@ -49,6 +50,11 @@ pub struct VerifySignaturesTest {
     /// spellings are accepted.
     #[serde(default, rename = "expectException", alias = "rejectionReason")]
     pub expect_exception: Option<String>,
+    /// Aggregation proof regime (see [`crate::fork_choice::ForkChoiceTest`]).
+    /// Captured only so `deny_unknown_fields` accepts it.
+    #[serde(rename = "proofSetting")]
+    #[allow(dead_code)]
+    pub proof_setting: Option<u8>,
     #[serde(rename = "_info")]
     #[allow(dead_code)]
     pub info: TestInfo,
@@ -57,6 +63,7 @@ pub struct VerifySignaturesTest {
 /// Fixture-side signed block: a block plus its raw merged multi-message
 /// aggregate proof bytes.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestSignedBlock {
     #[serde(alias = "message")]
     pub block: Block,
@@ -69,6 +76,7 @@ pub struct TestSignedBlock {
 /// The multi-signature container nests the raw lean-multisig wire one level
 /// deep: `{ "proof": { "data": "0x..." } }`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MergedProof {
     pub proof: HexBytes,
 }
@@ -81,6 +89,7 @@ impl MergedProof {
 
 /// `{ "data": "0x..." }` wrapper used by leanSpec fixtures for byte fields.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HexBytes {
     pub data: String,
 }


### PR DESCRIPTION
## Why

The spec-test fixture types silently dropped any JSON field they did not model. When leanSpec adds a new fixture check, ethlambda kept passing while verifying nothing new. That masked drift is exactly how PR **#1189**'s `canonicalEquivocationHeadAmong` (and a dozen other already-shipped fields) landed in the 07-11 fixtures without ethlambda asserting any of them.

> **Stacked on #510** (branch `fix/attestation-reject-head-off-finalized`, the `HEAD_NOT_DESCENDANT_OF_FINALIZED` fix that makes all fork-choice fixtures pass). This PR targets that branch and will be **retargeted to `main` once #510 merges**.

## What

### 1. `deny_unknown_fields` hardening (fail loudly on drift)

Added `#[serde(deny_unknown_fields)]` to every fixture-facing struct and modeled every field the current (07-11) fixtures actually carry, so a future upstream schema addition fails at parse time instead of being silently ignored.

Structs that got `deny_unknown_fields`:

- `common.rs`: `Container<T>`, `Config`, `Checkpoint`, `BlockHeader`, `Validator`, `TestState`, `Block`, `BlockBody`, `AggregatedAttestation`, `AggregationBits`, `AttestationData`, `TestInfo`.
- `fork_choice.rs`: `ForkChoiceTest`, `ForkChoiceStep`, `AttestationStepData`, `ProofStepData`, `HexByteList`, `BlockStepData`, `StoreChecks`, `AttestationCheck`, plus new `BlockAttestationCheck`, `StoreSnapshot`, `BlockWeightEntry`, `AggregatedPayloadEntry`, `AttestationSignatureEntry`.
- `verify_signatures.rs`: `VerifySignaturesTest`, `TestSignedBlock`, `MergedProof`, `HexBytes`.
- `state_transition/tests/types.rs`: `StateTransitionTest` (`PostState` already had it).

The flatten wrapper vectors (`ForkChoiceTestVector`, etc.) are intentionally left without the attribute (serde forbids `deny_unknown_fields` + `flatten`). The Hive driver's own request wrappers (`StateTransitionRunRequest`/`InitForkChoiceRequest`/`VerifySignaturesRequest`) are also left without it, so a stray *top-level* field (e.g. `_info`) is still tolerated. Note, however, that these wrappers embed the shared fixture types (`TestState`, `Block`, `TestSignedBlock`, `ForkChoiceStep`, …), which this PR *does* harden: any unknown field nested inside `anchorState`/`anchorBlock`/`pre`/`blocks`/`signedBlock` (or a fork-choice step body) now fails deserialization at the Axum handler rather than being silently dropped. This is intentional: silently dropping a replay-relevant field would make the driver report misleading results, so failing loudly on simulator-side schema drift is the safer boundary for a conformance driver.

Previously-dropped fields now modeled include: `_info.keySetDigest`, top-level `proofSetting` / `rejectionReason` / `postStateRoot`, per-step `storeSnapshot` / `rejectionReason`, `attestationChecks[].sourceRootLabel`, and the full new `StoreChecks` batch.

The fixture crate is a **production dependency of the RPC Hive test-driver**, so this also hardens the binary's parsing of simulator-delivered JSON. The driver returns a store snapshot and applies no `StoreChecks` itself (the leanSpec simulator does the comparisons), so no driver logic changed.

### 2. Newly **asserted** checks in the fork-choice runner

| Check | Notes |
|-------|-------|
| `canonicalEquivocationHeadAmong` | **leanSpec #1189.** Head must sit on the fork whose targeting attestation in the accepted (known) pool carries the largest `hash_tree_root`. Scheme-independent; mirrors `lexicographicHeadAmong`. Covers the 3 equivocation fixtures. |
| `latestKnownAggregatedTargetSlots` | Sorted-unique target slots of the known aggregated pool. |
| `attestationTargetRootLabel` | Attestation target root resolves to the labeled block. |
| `attestationChecks[].sourceRootLabel` | Per-validator source checkpoint root by label. |
| `labelsInStore` | Labeled blocks still present in the block tree. |
| `reorgDepth` | `ancestors(old_head) \ ancestors(new_head)`. |
| `blockAttestations` / `blockAttestationCount` | Per-aggregate participant/slot checks + count on the block imported this step. |

Also seeds the block registry with the anchor under the label `"genesis"`, matching leanSpec's harness, so label-based checks resolve (true even for checkpoint-sync anchors past slot 0).

### 3. Parsed but **not** asserted (each carries a `TODO`)

`latestNewAggregatedTargetSlots`, `attestationSignatureTargetSlots`, `newPoolProofParticipants`, `storeSnapshot`, `filledBlockRootLabel`.

These read the pending (new) aggregated pool, the raw gossip-signature pool, or the identity of a freshly-built block. The offline runner advances ticks **without** the aggregator role and folds block-borne votes straight into the known pool, so those pools/built-block do not track leanSpec's harness. The accepted (known) pool — which the runner does populate — is asserted. `storeSnapshot` is a whole-store snapshot (692 steps) that would need substantial new Store plumbing to compare.

## Verification

- `cargo test --release -p ethlambda-blockchain --test forkchoice_spectests` → **122 passed**
- `cargo test --release -p ethlambda-state-transition --test stf_spectests` → **74 passed**
- `cargo test --release -p ethlambda-blockchain --test signature_spectests` → **3 passed**
- `make test` → fully green
- `make fmt` / `make lint` (clippy `-D warnings`) clean; whole workspace (incl. Hive driver binary) builds.
- Confirmed the `canonicalEquivocationHeadAmong` assertion executes and is meaningful: inverting the winner selection (max→min) fails exactly the 3 equivocation fixtures; poisoning the computed `reorgDepth`/`blockAttestationCount` actuals fails exactly the fixtures carrying those checks.
