### PR TITLE
test(spec): assert full post-state root against fixture postStateRoot

### DIFF
--- a/crates/blockchain/state_transition/tests/stf_spectests.rs
+++ b/crates/blockchain/state_transition/tests/stf_spectests.rs
@@ -53,6 +53,20 @@ fn run(path: &Path) -> datatest_stable::Result<()> {
         match (result, test.post) {
             (Ok(_), Some(expected_post)) => {
                 compare_post_states(&post_state, &expected_post, &block_registry)?;
+                // Hardening: the full post-state hash_tree_root must equal the
+                // fixture's `postStateRoot`. The per-field `post` checks only
+                // pin the fields the fixture chose to enumerate; this catches
+                // any state field they omit.
+                if let Some(expected_root) = test.post_state_root {
+                    let actual_root = post_state.hash_tree_root();
+                    if actual_root != expected_root {
+                        return Err(format!(
+                            "Test '{name}' post-state root mismatch: \
+                             expected {expected_root:?}, got {actual_root:?}"
+                        )
+                        .into());
+                    }
+                }
             }
             (Ok(_), None) => {
                 return Err(

--- a/crates/blockchain/state_transition/tests/types.rs
+++ b/crates/blockchain/state_transition/tests/types.rs
@@ -33,11 +33,10 @@ pub struct StateTransitionTest {
     pub pre: TestState,
     pub blocks: Vec<Block>,
     pub post: Option<PostState>,
-    /// Expected post-state `hash_tree_root`, present alongside `post`. Captured
-    /// only so `deny_unknown_fields` accepts it; the per-field `post` checks
-    /// already pin the post-state.
+    /// Expected post-state `hash_tree_root`, present alongside `post`. Asserted
+    /// against the full post-state root after the per-field `post` checks, so
+    /// any state field those checks don't enumerate is still pinned.
     #[serde(rename = "postStateRoot")]
-    #[allow(dead_code)]
     pub post_state_root: Option<H256>,
     /// Expected rejection reason for negative cases. Captured only so
     /// `deny_unknown_fields` accepts it; failure is asserted via a missing

--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -45,7 +45,7 @@ use ethlambda_types::{
     },
     block::{Block, ByteList512KiB, SingleMessageAggregate},
     checkpoint::Checkpoint,
-    primitives::H256,
+    primitives::{H256, HashTreeRoot as _},
     state::{State, anchor_pair_is_consistent},
 };
 use serde::{Deserialize, Serialize};
@@ -169,6 +169,11 @@ struct StateTransitionPost {
     latest_block_header_slot: u64,
     latest_block_header_state_root: H256,
     historical_block_hashes_count: usize,
+    /// Full post-state `hash_tree_root`, mirroring the fixture's `postStateRoot`.
+    /// `latest_block_header_state_root` above is only the state's recorded
+    /// header field; this is the SSZ root of the entire post-state, so the hive
+    /// simulator can assert the whole state, not just the enumerated summary.
+    post_state_root: H256,
 }
 
 #[derive(Debug, Serialize)]
@@ -455,6 +460,7 @@ fn post_summary(state: &State) -> StateTransitionPost {
         latest_block_header_slot: state.latest_block_header.slot,
         latest_block_header_state_root: state.latest_block_header.state_root,
         historical_block_hashes_count: state.historical_block_hashes.len(),
+        post_state_root: state.hash_tree_root(),
     }
 }
 

--- a/crates/net/rpc/src/test_driver.rs
+++ b/crates/net/rpc/src/test_driver.rs
@@ -45,7 +45,7 @@ use ethlambda_types::{
     },
     block::{Block, ByteList512KiB, SingleMessageAggregate},
     checkpoint::Checkpoint,
-    primitives::{H256, HashTreeRoot as _},
+    primitives::H256,
     state::{State, anchor_pair_is_consistent},
 };
 use serde::{Deserialize, Serialize};
@@ -169,11 +169,6 @@ struct StateTransitionPost {
     latest_block_header_slot: u64,
     latest_block_header_state_root: H256,
     historical_block_hashes_count: usize,
-    /// Full post-state `hash_tree_root`, mirroring the fixture's `postStateRoot`.
-    /// `latest_block_header_state_root` above is only the state's recorded
-    /// header field; this is the SSZ root of the entire post-state, so the hive
-    /// simulator can assert the whole state, not just the enumerated summary.
-    post_state_root: H256,
 }
 
 #[derive(Debug, Serialize)]
@@ -460,7 +455,6 @@ fn post_summary(state: &State) -> StateTransitionPost {
         latest_block_header_slot: state.latest_block_header.slot,
         latest_block_header_state_root: state.latest_block_header.state_root,
         historical_block_hashes_count: state.historical_block_hashes.len(),
-        post_state_root: state.hash_tree_root(),
     }
 }
 


### PR DESCRIPTION
## What

Turns the STF fixtures' `postStateRoot` field into an actual assertion instead of a parse-only placeholder.

## Why

The STF spec-test runner captured `postStateRoot` only to satisfy `deny_unknown_fields`. The per-field `post` checks pin only the fields a fixture chooses to enumerate, leaving any other state field unverified. Comparing the full post-state `hash_tree_root` against the fixture's `postStateRoot` pins the entire state on every successful transition.

## Changes

| File | Change |
|------|--------|
| `state_transition/tests/stf_spectests.rs` | On a successful STF, assert `post_state.hash_tree_root() == postStateRoot`. |
| `state_transition/tests/types.rs` | Drop `#[allow(dead_code)]` on `post_state_root`; document its new role. |

## Testing

- `cargo test -p ethlambda-state-transition --release --test stf_spectests` -> 71 passed (59 fixtures exercise the new check).
- Verified the check is live by inverting the comparison (dozens of fixtures failed with matching expected/got roots), then reverted.
- `cargo fmt --all`, `cargo clippy -p ethlambda-rpc -p ethlambda-state-transition --all-targets` clean.

Based on `test/leanspec-fixture-check-hardening`; targets that branch.