### PR TITLE
fix(blockchain): record tick-interval sample on proposer interval-0 skip

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -834,6 +834,23 @@ impl BlockChainServer {
             tokio::time::sleep(Duration::from_millis(wait_ms)).await;
         }
 
+        // Record the tick-interval sample here, from inside the proposal path.
+        //
+        // Building the block above advanced the store clock to this slot's
+        // interval 0 (one interval past the interval-4 tick we are running in),
+        // so `on_tick` skips the real interval-0 tick via its idempotency guard.
+        // A skipped tick records nothing and does not advance `last_tick_instant`,
+        // so without this the next tick (interval 1) would measure the gap all the
+        // way back to the interval-4 tick — two intervals, a false ~1.6s spike in
+        // `lean_tick_interval_duration_seconds` even though ticks are firing on
+        // cadence. Recording here (after the alignment sleep, i.e. at ~the
+        // interval-0 boundary) stands in for the skipped tick and keeps samples at
+        // ~one interval.
+        if let Some(prev_instant) = self.last_tick_instant {
+            metrics::observe_tick_interval_duration(prev_instant.elapsed());
+        }
+        self.last_tick_instant = Some(Instant::now());
+
         self.process_and_publish_block(slot, validator_id, signed_block);
     }
 


### PR DESCRIPTION
## Problem

`lean_tick_interval_duration_seconds` was reporting a spurious **~1.6s** tail on every proposer slot, which read as the tick loop stalling. It is a metric-accounting artifact, not real tick lag.

On a proposer slot, the block is built during **interval 4 of the previous slot**; building advances the store clock to the next slot's **interval 0**, so the real interval-0 tick is skipped by `on_tick`'s idempotency guard. The metric measures wall-clock time between consecutive *recorded* ticks, and a skipped tick neither records a sample nor advances `last_tick_instant`, so the following **interval-1** tick measured across **two** intervals (~1.6s) even though ticks were firing on their 0.8s cadence.

## Fix

Record the tick-interval sample from the proposal path, after the publish-alignment sleep (i.e. at ~the interval-0 boundary), standing in for the skipped interval-0 tick. Per-slot samples then stay at ~one interval.

- Clean case (build fits within its interval): interval-0 records ~0.8s. ✅
- Overrun case (build > 0.8s, common under load): the interval-0 sample instead reflects the real build-block duration, which is the honest signal (the actor genuinely couldn't tick on time), rather than a phantom two-interval smear.

Scope: only the proposer path is touched, since that is the only source of the interval-0 skip. A genuinely delayed tick (e.g. a slow `on_block` import) is unaffected and still shows as real lag.

## Verification

Confirmed on a single-node local devnet (0 gossip imports isolate the proposer path): before the fix, tick samples >1.2s were 1:1 with block builds and pinned at ~1.6s; all skipped ticks were at interval 0 (BlockPublication). With the fix the skipped interval-0 slot is accounted for.