### PR TITLE
fix(blockchain): sample tick interval in handle_tick so skipped ticks don't inflate it

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -293,13 +293,6 @@ impl BlockChainServer {
             return;
         }
 
-        // Observe tick interval duration. Done after the idempotency guard so a
-        // skipped duplicate tick doesn't shorten the next real tick's sample.
-        if let Some(prev_instant) = self.last_tick_instant {
-            metrics::observe_tick_interval_duration(prev_instant.elapsed());
-        }
-        self.last_tick_instant = Some(Instant::now());
-
         // Update current slot metric
         metrics::update_current_slot(slot);
         self.update_sync_status(slot);
@@ -1186,6 +1179,24 @@ pub(crate) trait BlockChainProtocol: Send + Sync {
 impl BlockChainServer {
     #[send_handler]
     async fn handle_tick(&mut self, _msg: block_chain_protocol::Tick, ctx: &Context<Self>) {
+        // Observe the interval between tick-handler invocations here, at the
+        // scheduler level, so a sample is taken for *every* tick — including the
+        // ones `on_tick` drops via its idempotency guard. The main case is the
+        // interval-0 tick after a proposer builds the next block one interval
+        // early: the build advances the store clock to interval 0, so that tick
+        // is skipped. Recording only inside `on_tick` (after the guard) would
+        // miss it, so the following tick's sample would span two intervals and
+        // show a false ~1.6s spike in `lean_tick_interval_duration_seconds` even
+        // though ticks are firing on their ~800ms cadence.
+        //
+        // Ticks that fire early from wall-clock drift and are then guard-skipped
+        // are also sampled here; that only adds occasional sub-interval samples,
+        // which is acceptable for a metric meant to surface *late* ticks.
+        if let Some(prev_instant) = self.last_tick_instant {
+            metrics::observe_tick_interval_duration(prev_instant.elapsed());
+        }
+        self.last_tick_instant = Some(Instant::now());
+
         let now_ms = unix_now_ms();
         self.on_tick(now_ms, ctx).await;
 


### PR DESCRIPTION
Alternative to #513 (same bug, different approach).

## Problem

`lean_tick_interval_duration_seconds` reported a spurious ~1.6s tail on every proposer slot. It measures wall-clock time between consecutive *recorded* ticks, recorded inside `on_tick` **after** the idempotency guard. A guard-skipped tick records no sample and doesn't advance `last_tick_instant`. On a proposer slot the block is built during interval 4 of the previous slot, which advances the store clock to the next slot's **interval 0**, so the real interval-0 tick is skipped — and the following **interval-1** tick then measured across two intervals (~1.6s) even though ticks were firing on their 800ms cadence.

## Approach

Move the sample to `handle_tick`, the scheduler-level handler that runs for **every** tick (including guard-skipped ones). One sample per tick regardless of whether `on_tick` drops the duty, so a skipped interval no longer inflates the next sample.

Versus #513 (which records from the proposer path after the publish-alignment sleep): this needs **no proposer special-casing** and covers any skip uniformly. It matches how Zeam records the same metric (at the clock layer, decoupled from duty execution).

**Tradeoff:** wall-clock-drift duplicate ticks (which the guard also swallows) are now sampled too, adding occasional sub-interval samples. Harmless for a metric meant to surface *late* ticks; noted in the comment.

## Verification

Confirmed on a single-node local devnet (0 gossip imports isolate the proposer path). Behavior is equivalent to #513: the skipped interval-0 tick is now sampled (sample count rises to ~5/slot), no pinned ~1.6s artifact remains, and the large samples track the real (variable) block-build duration rather than a fixed two-interval value. Total recorded time is unchanged (`_sum` matches #513's run).