### PR TITLE
fix(blockchain): count lean_attestations_valid_total on gossip only

### DIFF
--- a/crates/blockchain/src/metrics.rs
+++ b/crates/blockchain/src/metrics.rs
@@ -706,9 +706,13 @@ pub fn set_node_start_time() {
     LEAN_NODE_START_TIME_SECONDS.set(timestamp as i64);
 }
 
-/// Increment the valid attestations counter.
-pub fn inc_attestations_valid(count: u64) {
-    LEAN_ATTESTATIONS_VALID_TOTAL.inc_by(count);
+/// Increment the valid attestations counter by one.
+///
+/// Counts one per gossip attestation (single or aggregated) that passes all
+/// validation checks, symmetric with [`inc_attestations_invalid`]. Matches
+/// leanSpec's `lean_attestations_valid_total`, a validation-pipeline counter.
+pub fn inc_attestations_valid() {
+    LEAN_ATTESTATIONS_VALID_TOTAL.inc();
 }
 
 /// Increment the invalid attestations counter.

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -427,7 +427,7 @@ pub fn on_gossip_attestation(
         metrics::update_gossip_signatures(store.gossip_signatures_count());
     }
 
-    metrics::inc_attestations_valid(1);
+    metrics::inc_attestations_valid();
 
     let slot = attestation.data.slot;
     let target_slot = attestation.data.target.slot;
@@ -536,7 +536,7 @@ fn on_gossip_aggregated_attestation_core(
         "Aggregated attestation processed"
     );
 
-    metrics::inc_attestations_valid(1);
+    metrics::inc_attestations_valid();
 
     Ok(())
 }
@@ -682,11 +682,11 @@ fn on_block_core(
         .insert_state(block_root, post_state)
         .expect("DB insert should succeed");
 
-    for att in block.body.attestations.iter() {
-        // Count each participating validator as a valid attestation.
-        let count = validator_indices(&att.aggregation_bits).count() as u64;
-        metrics::inc_attestations_valid(count);
-    }
+    // Block-included attestations are intentionally not counted here.
+    // `lean_attestations_valid_total` tracks the gossip validation pipeline
+    // (symmetric with `inc_attestations_invalid`), matching leanSpec. Votes
+    // arriving inside a block are counted by
+    // `lean_state_transition_attestations_processed_total` instead.
 
     // Update forkchoice head based on new block and attestations
     update_head(store, false);


### PR DESCRIPTION
## Problem

`lean_attestations_valid_total` is defined by leanSpec as the running count of attestations that pass **all validation checks** (paired with `lean_attestations_invalid_total`, "rejected during validation"). It is a validation-pipeline counter; leanSpec increments it once per validated gossip attestation (`source="gossip"`).

ethlambda additionally incremented it **once per participating validator for every block-included attestation** (`on_block_core`), which:

- **broke valid/invalid symmetry** — `inc_attestations_invalid` only fires on the gossip validation path (`store.rs:391`, `:479`), so `valid` was inflated with no matching `invalid` counterpart;
- **double-counted** votes already counted when first seen on gossip;
- **mixed units** — a gossip aggregate counts as `1`, while the same voters count as `N` when packed into a block.

## Change

Drop the block-inclusion counting so the counter measures exactly the gossip validation pipeline, matching leanSpec. Votes arriving inside a block remain counted by `lean_state_transition_attestations_processed_total`. Every remaining call site increments by one, so the helper is simplified to a no-argument `inc()`.

## Verification

`make fmt`, `make lint` (clean), `cargo test -p ethlambda-blockchain` (46 unit tests pass), full workspace build. Fork-choice/signature spec tests require downloaded fixtures (absent in this env) and are unaffected by a metrics-only change.
