### PR TITLE
fix(checkpoint-sync): retry on timeout

### DIFF
--- a/bin/ethlambda/src/checkpoint_sync.rs
+++ b/bin/ethlambda/src/checkpoint_sync.rs
@@ -367,13 +367,7 @@ pub async fn fetch_anchor_with_retry(
         match fetch_anchor_block_and_state(checkpoint_urls, genesis_time, validators).await {
             Ok(pair) => return Ok(pair),
             Err(err) if attempt < MAX_CHECKPOINT_ATTEMPTS => {
-                warn!(
-                    attempt,
-                    max_attempts = MAX_CHECKPOINT_ATTEMPTS,
-                    %err,
-                    backoff_secs = CHECKPOINT_RETRY_BACKOFF.as_secs(),
-                    "Checkpoint sync attempt failed; retrying"
-                );
+                warn!(attempt, %err, "Checkpoint sync attempt failed; retrying");
                 tokio::time::sleep(CHECKPOINT_RETRY_BACKOFF).await;
                 attempt += 1;
             }

--- a/bin/ethlambda/src/checkpoint_sync.rs
+++ b/bin/ethlambda/src/checkpoint_sync.rs
@@ -27,6 +27,14 @@ const MAX_ANCHOR_FETCH_ATTEMPTS: u32 = 3;
 /// Delay between anchor fetch attempts.
 const ANCHOR_FETCH_RETRY_DELAY: Duration = Duration::from_secs(1);
 
+/// Fixed backoff between checkpoint-sync attempts.
+const CHECKPOINT_RETRY_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Maximum checkpoint-sync attempts before the process gives up, giving a
+/// slow-to-boot peer time to become reachable. Attempts stay within Hive's
+/// client-startup budget when each one fails fast.
+const MAX_CHECKPOINT_ATTEMPTS: u32 = 5;
+
 #[derive(Debug, thiserror::Error)]
 pub enum CheckpointSyncError {
     #[error("HTTP request failed: {0}")]
@@ -342,6 +350,34 @@ pub async fn fetch_anchor_block_and_state(
                 }
                 last_err = Some(err);
             }
+        }
+    }
+}
+
+/// Fetch the finalized anchor, retrying any failure (e.g. the peer not yet
+/// reachable) for up to MAX_CHECKPOINT_ATTEMPTS attempts with a fixed backoff
+/// between them before giving up.
+pub async fn fetch_anchor_with_retry(
+    checkpoint_urls: &[String],
+    genesis_time: u64,
+    validators: &[Validator],
+) -> Result<(State, SignedBlock), CheckpointSyncError> {
+    let mut attempt: u32 = 1;
+    loop {
+        match fetch_anchor_block_and_state(checkpoint_urls, genesis_time, validators).await {
+            Ok(pair) => return Ok(pair),
+            Err(err) if attempt < MAX_CHECKPOINT_ATTEMPTS => {
+                warn!(
+                    attempt,
+                    max_attempts = MAX_CHECKPOINT_ATTEMPTS,
+                    %err,
+                    backoff_secs = CHECKPOINT_RETRY_BACKOFF.as_secs(),
+                    "Checkpoint sync attempt failed; retrying"
+                );
+                tokio::time::sleep(CHECKPOINT_RETRY_BACKOFF).await;
+                attempt += 1;
+            }
+            Err(err) => return Err(err),
         }
     }
 }

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -707,7 +707,7 @@ async fn fetch_initial_state(
 
     info!(?checkpoint_urls, "Starting checkpoint sync");
 
-    let (state, signed_block) = checkpoint_sync::fetch_anchor_block_and_state(
+    let (state, signed_block) = checkpoint_sync::fetch_anchor_with_retry(
         checkpoint_urls,
         genesis.genesis_time,
         &validators,


### PR DESCRIPTION
## Problem

In Hive interop runs, ethlambda intermittently fails to start with the harness reporting `client did not start: terminated unexpectedly`. On the dashboard this surfaces as flaky reqresp failures against whichever scenario's fresh client-boot happened to coincide with the peer being slow (a different scenario, or none, fails each run).

The container log shows the real cause:

```
Starting checkpoint sync url=http://172.17.0.3:5052/lean/v0/states/finalized
(+15.0s) WARN Checkpoint sync failed for this peer; no more URLs to try  err=error sending request ... operation timed out
ERROR All checkpoint sync attempts failed
ERROR Failed to initialize state
Error: operation timed out  @ bin/ethlambda/src/main.rs:208
```

## Root cause

Checkpoint sync fails fast on any connection/timeout error. Hive supplies a **single** checkpoint URL, and `try_checkpoint_url` only retries the `AnchorPairingMismatch` case; any connection/timeout/HTTP error returns immediately. So one 15s miss to a peer that is still booting propagates up through `fetch_initial_state` (`main.rs` `?`) and exits the whole process, well inside the harness's client-startup budget where a retry would have succeeded.

## Fix

Wrap the anchor fetch in a bounded retry (`fetch_anchor_with_retry`) that reattempts a failed fetch for up to `MAX_CHECKPOINT_ATTEMPTS` attempts with a fixed `CHECKPOINT_RETRY_BACKOFF` delay between them. When each attempt fails fast at the connect timeout, the attempts stay within the harness's client-startup budget.

The per-attempt 15s connect/read timeouts and the internal `AnchorPairingMismatch` retry are intentionally left unchanged.

## Testing

- `cargo build -p ethlambda`, `cargo clippy -p ethlambda -- -D warnings`, `cargo fmt -p ethlambda -- --check` — clean.
- `cargo test -p ethlambda checkpoint_sync` — existing checkpoint-sync unit tests pass (22).
