### PR TITLE
build: bump Rust toolchain to 1.97.1

### DIFF
--- a/.github/actions/run-fixture-tests/action.yml
+++ b/.github/actions/run-fixture-tests/action.yml
@@ -104,7 +104,7 @@ runs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: "1.92.0"
+        toolchain: "1.97.1"
 
     - name: Setup cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.97.1"
           components: rustfmt, clippy
 
       - name: Setup cache

--- a/.github/workflows/daily_loc_report.yml
+++ b/.github/workflows/daily_loc_report.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.97.1"
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Not to be confused with Ethereum consensus clients AKA Beacon Chain clients AKA 
 ## Quick Reference
 
 **Main branch:** `main`
-**Rust version:** 1.92.0 (edition 2024)
+**Rust version:** 1.97.1 (edition 2024)
 **Test fixtures release:** Download latest production fixtures from leanSpec releases
 
 ## Codebase Structure (12 workspace crates)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["ethereum", "blockchain", "consensus", "protocol"]
 license = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/lambdaclass/ethlambda"
-rust-version = "1.92.0"
+rust-version = "1.97.1"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 
-FROM rust:1.92-bookworm AS chef
+FROM rust:1.97-bookworm AS chef
 WORKDIR /app
 
 # Install cargo-chef and system dependencies

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -166,7 +166,7 @@ The fork-choice tree from the finalized root, with LMD-GHOST weights computed ov
 
 ```json
 {
-  "version": "ethlambda/v0.1.0-main-892ad575/x86_64-unknown-linux-gnu/rustc-v1.85.0",
+  "version": "ethlambda/v0.1.0-main-892ad575/x86_64-unknown-linux-gnu/rustc-v1.97.1",
   "peer_id": "16Uiu2HAm7v1x…"
 }
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Motivation

The toolchain pin had drifted five releases behind upstream stable (1.92.0 → 1.97.1, released 2026-07-14). Bumping picks up compiler and clippy fixes and keeps the declared MSRV aligned with the toolchain we actually build with.

## Description

Updates every real version pin:

| File | Change |
|---|---|
| `rust-toolchain.toml` | `channel` 1.92.0 → 1.97.1 |
| `Cargo.toml` | workspace `rust-version` (MSRV) 1.92.0 → 1.97.1 |
| `Dockerfile` | builder base `rust:1.92-bookworm` → `rust:1.97-bookworm` |
| `.github/workflows/ci.yml` | `toolchain` 1.92.0 → 1.97.1 |
| `.github/actions/run-fixture-tests/action.yml` | `toolchain` 1.92.0 → 1.97.1 |
| `.github/workflows/daily_loc_report.yml` | `toolchain` 1.92.0 → 1.97.1 |
| `CLAUDE.md` | Quick Reference version line |
| `docs/rpc.md` | node-identity sample response `rustc-v1.85.0` → `rustc-v1.97.1` |

The `docs/rpc.md` string is illustrative rather than a pin, but it was two bumps stale, so it is refreshed here to keep it tracking reality.

Deliberately **not** changed:

- `flake.nix` and `preview-config.nix` derive the toolchain from `rust-toolchain.toml`, so they follow automatically.
- `.github/workflows/pr-main_mdbook.yml` stays on `toolchain: stable`, since it only needs cargo to install `mdbook-linkcheck2` and was never pinned.
- `crates/net/rpc/src/node.rs` (`rustc-v1.92.0`) is an injected test sentinel (`v9.9.9-test-deadbeef`) asserted to round-trip verbatim. It does not read the real rustc version and the test passes regardless, so it is left alone.

## Verification

Run locally on `rustc 1.97.1 (8bab26f4f 2026-07-14)`:

| Check | Result |
|---|---|
| `cargo fmt --all` | no changes |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean, zero new lints across the five-version jump |
| `cargo test --workspace --release` | 543 passed, 0 failed, 7 ignored, 30 binaries, 0 warnings |
| `Cargo.lock` churn | none |
| `rust:1.97-bookworm` on Docker Hub | present (active amd64 image) |

The 7 ignored tests are the pre-existing `#[ignore]` leanVM crypto tests.