### PR TITLE
fix(state-transition): bound distinct attestation data in the transition

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use ethlambda_types::{
     ShortRoot,
     attestation::AttestationData,
-    block::{AggregatedAttestations, Block, BlockHeader},
+    block::{AggregatedAttestations, Block, BlockHeader, MAX_ATTESTATIONS_DATA},
     checkpoint::Checkpoint,
     primitives::{H256, HashTreeRoot as _},
     state::{HISTORICAL_ROOTS_LIMIT, JustificationValidators, State},
@@ -56,6 +56,8 @@ pub enum Error {
         finalized_slot: u64,
         tracked_length: usize,
     },
+    #[error("block carries {count} distinct AttestationData entries; maximum is {max}")]
+    TooManyAttestationData { count: usize, max: usize },
 }
 
 /// Transition the given pre-state to the block's post-state.
@@ -250,6 +252,24 @@ fn process_attestations(
     attestations: &AggregatedAttestations,
 ) -> Result<(), Error> {
     let _timing = metrics::time_attestations_processing();
+
+    // Cap the distinct attestation data a block may carry (leanSpec #536).
+    //
+    // Each distinct data allocates a tally sized to the validator set below, so the
+    // distinct count, not the attestation count, is what drives the work here. Split
+    // aggregates over one data share their tally and count once.
+    //
+    // `on_block` re-checks this before signature verification so a crafted block is
+    // rejected cheaply, but the bound belongs to the transition: this is the only
+    // entry point block production and fixture replay share with block import.
+    let distinct_attestation_data: HashSet<&AttestationData> =
+        attestations.iter().map(|att| &att.data).collect();
+    if distinct_attestation_data.len() > MAX_ATTESTATIONS_DATA {
+        return Err(Error::TooManyAttestationData {
+            count: distinct_attestation_data.len(),
+            max: MAX_ATTESTATIONS_DATA,
+        });
+    }
 
     // Validate the justification bookkeeping before unpacking the flat vote list
     // (leanSpec #1178). A `State` decoded from untrusted bytes (e.g. checkpoint


### PR DESCRIPTION
## What

Enforce the per-block cap on distinct `AttestationData` inside `process_attestations`, where leanSpec has it, in addition to the existing check at the import boundary in `on_block`.

## Why

leanSpec puts the bound in the transition (`state_transition.process_attestations`) and `fork_choice.on_block` defers to it explicitly:

> The transition itself bounds the distinct-data count. Only the wire-level duplicate prohibition lives here.

We only had it in `on_block` (`store.rs`), so `state_transition()` accepted an over-cap block and then failed on the state root instead. Two callers reach the transition without passing through `on_block`:

| caller | before | after |
|---|---|---|
| `build_block` -> `process_block` | unbounded (the proposer-side clamp is the only guard) | fails loudly instead of publishing an unimportable block |
| spec-fixture replay / Hive `state_transition/run` | over-cap block accepted, then `STATE_ROOT_MISMATCH` | rejected with the cap error |

The check goes first in `process_attestations`, ahead of the justification-bookkeeping guards, matching the spec's order when a block violates two rules at once.

## The duplicate check in `on_block` stays

Deliberately, for now: it runs before `verify_block_signatures`, so an over-cap block is still rejected without paying for proof verification. Whether we collapse the two sites into one is a follow-up decision.

## Testing

- `cargo test --workspace --profile release-fast`: green, no new tests added here.
- The behavior is covered by the existing fixture `test_block_exceeding_distinct_attestation_data_cap_rejects_block`, which asserts failure but not yet the reason. Cross-checked against #547, which adds the reason assertion to the fixture runners: with both branches applied, that fixture passes for the right reason (`TOO_MANY_ATTESTATION_DATA`, previously `STATE_ROOT_MISMATCH`).

Whichever of the two lands first, the other's exhaustive `From<&Error> for RejectionReason` match makes the missing mapping arm a compile error, so the reason cannot be silently dropped.

(leanSpec #536)