### PR TITLE
fix(metrics): count aggregated-signature verification outcomes

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -531,6 +531,8 @@ fn on_gossip_aggregated_attestation_core(
             &data_root,
             slot,
         )
+        .inspect(|_| metrics::inc_pq_sig_aggregated_signatures_valid())
+        .inspect_err(|_| metrics::inc_pq_sig_aggregated_signatures_invalid())
         .map_err(StoreError::AggregateVerificationFailed)?;
     }
 


### PR DESCRIPTION
## Problem

`lean_pq_sig_aggregated_signatures_valid_total` and `lean_pq_sig_aggregated_signatures_invalid_total` are registered in `metrics::init()` and exported on `/metrics`, but **no call site ever incremented them**. Both sat at `0` for a node's entire lifetime, even though aggregate verification runs on every gossip aggregate the node receives.

[leanMetrics](https://github.com/leanEthereum/leanMetrics/blob/main/metrics.md) samples both "On aggregated signature verification":

| Name | Type | Usage | Sample collection event |
|---|---|---|---|
| `lean_pq_sig_aggregated_signatures_valid_total` | Counter | Total number of valid aggregated signatures | On aggregated signature verification |
| `lean_pq_sig_aggregated_signatures_invalid_total` | Counter | Total number of invalid aggregated signatures | On aggregated signature verification |

Found while auditing `docs/metrics.md` against how metrics are actually emitted; the doc marks both ✅ Supported, which was not true.

## Change

Two lines. Bump both counters where `on_gossip_aggregated_attestation_core` runs the lean-multisig verifier, symmetric with the individual-attestation counters a few lines above:

```rust
.inspect(|_| metrics::inc_pq_sig_aggregated_signatures_valid())
.inspect_err(|_| metrics::inc_pq_sig_aggregated_signatures_invalid())
.map_err(StoreError::AggregateVerificationFailed)?;
```

Control flow is unchanged; the same error propagates as before. The counters sit inside the existing `time_pq_sig_aggregated_signatures_verification()` guard, so they add negligible overhead to what the histogram measures.

## Scope

Only the gossip-aggregate path is instrumented, not `verify_block_signatures`. Two reasons:

1. It is the path the verification-time histogram already covers, so all three aggregated-signature metrics describe one identical event set.
2. The block-borne object is a type-2 merged *multi-message* proof that also binds the proposer signature, not an aggregated *attestation* signature.

Happy to widen this if we'd rather count block imports too, but that would also mean extending the timing histogram to cover proofs an order of magnitude larger, shifting an existing metric's distribution.

## Testing

- `make fmt`, clippy `-D warnings` clean
- `cargo test -p ethlambda-blockchain --profile release-fast --lib`: 65/65 pass

Spec tests were not run locally (`leanSpec/fixtures` not present in this checkout); the change adds only counter side effects to unchanged control flow, so CI covers them.