### PR TITLE
docs: note that equal API and metrics ports merge routers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,10 @@ actual_slot = finalized_slot + 1 + relative_index
 
 ## HTTP Servers (API + Metrics)
 
-The RPC crate runs two independent Axum servers (API on `:5052`, metrics/debug on `:5054`). See [`docs/rpc.md`](docs/rpc.md) for the full reference: CLI flags and defaults, the API endpoints (health, finalized state/block, justified checkpoint, blocks by root/slot, fork-choice tree + D3.js UI, runtime aggregator toggle), the metrics/debug endpoints (Prometheus `/metrics`, jemalloc heap profiling), the Hive test-driver endpoints, plus request/response shapes, status codes, and content types.
+The RPC crate serves the API router (`--api-port`, default 5052) and the metrics/debug routers
+(`--metrics-port`, default 5054). When the two ports differ it binds two independent Axum servers;
+when they are equal it merges all three routers onto a single listener, so pointing both flags at
+one port is supported and not a misconfiguration. See [`docs/rpc.md`](docs/rpc.md) for the full reference: CLI flags and defaults, the API endpoints (health, finalized state/block, justified checkpoint, blocks by root/slot, fork-choice tree + D3.js UI, runtime aggregator toggle), the metrics/debug endpoints (Prometheus `/metrics`, jemalloc heap profiling), the Hive test-driver endpoints, plus request/response shapes, status codes, and content types.
 
 ## Configuration Files
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

`CLAUDE.md` described the RPC crate as unconditionally running two independent Axum servers:

> The RPC crate runs two independent Axum servers (API on `:5052`, metrics/debug on `:5054`).

That is only true when the two ports differ. `crates/net/rpc/src/lib.rs` merges the API and metrics/debug routers onto a single listener when `--api-port` and `--metrics-port` are equal, so pointing both flags at one port is a supported configuration rather than a misconfiguration.

## What Changed

**`CLAUDE.md`** — the "HTTP Servers (API + Metrics)" paragraph now states both cases: two servers when the ports differ, one merged listener when they match. The pointer to [`docs/rpc.md`](docs/rpc.md) for the full reference is unchanged.

Docs only; no code, no behavior change.

## Related Issues / PRs

- Split out of #554, which touched this paragraph incidentally while doing unrelated startup work.

## ✅ Verification Checklist

- [x] Docs-only change; no code touched, so `fmt`/`lint`/`test` are unaffected
- [x] Claim verified against `crates/net/rpc/src/lib.rs`
