### PR TITLE
refactor(types): move the interval grid into ethlambda-types

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -68,13 +68,13 @@ pub struct BlockChainConfig {
     pub proposer_config: ProposerConfig,
 }
 
-/// Milliseconds per interval (800ms ticks).
-pub const MILLISECONDS_PER_INTERVAL: u64 = 800;
-/// Number of intervals per slot (5 intervals of 800ms = 4 seconds).
-pub const INTERVALS_PER_SLOT: u64 = 5;
-/// Milliseconds in a slot (derived from interval duration and count).
-pub const MILLISECONDS_PER_SLOT: u64 = MILLISECONDS_PER_INTERVAL * INTERVALS_PER_SLOT;
+// The interval grid lives in `ethlambda-types` because `ethlambda-storage` also
+// derives slots from `store.time()` and must not carry a second copy of a
+// consensus-critical constant.
 pub use ethlambda_types::block::MAX_ATTESTATIONS_DATA;
+pub use ethlambda_types::constants::{
+    INTERVALS_PER_SLOT, MILLISECONDS_PER_INTERVAL, MILLISECONDS_PER_SLOT,
+};
 pub use sync_status::SyncStatusController;
 /// Future-slot tolerance for gossip attestations, expressed in intervals.
 ///

--- a/crates/common/types/src/constants.rs
+++ b/crates/common/types/src/constants.rs
@@ -8,3 +8,10 @@
 /// eventually be derived from the fork version and genesis validators root.
 // TODO: derive dynamically once the spec defines fork identification.
 pub const FORK_DIGEST: &str = "12345678";
+
+/// Milliseconds per interval (800ms ticks).
+pub const MILLISECONDS_PER_INTERVAL: u64 = 800;
+/// Number of intervals per slot (5 intervals of 800ms = 4 seconds).
+pub const INTERVALS_PER_SLOT: u64 = 5;
+/// Milliseconds in a slot (derived from interval duration and count).
+pub const MILLISECONDS_PER_SLOT: u64 = MILLISECONDS_PER_INTERVAL * INTERVALS_PER_SLOT;


### PR DESCRIPTION
## 🗒️ Description / Motivation

Extracted from #561, which needs the interval grid readable from `ethlambda-storage`. The move stands on its own, so it lands here rather than riding along with the heartbeat work.

`ethlambda-storage` derives slot and interval from `store.time()`, but it cannot depend on `ethlambda-blockchain` — the dependency runs the other way. Today it can only *document* the formula in a comment on `Store::time()` instead of using the constants. `ethlambda-types` is already a dependency of both crates, so housing them there removes the asymmetry and keeps a second copy of a consensus-critical constant from appearing in storage.

## What Changed

- `crates/common/types/src/constants.rs` — now defines `MILLISECONDS_PER_INTERVAL`, `INTERVALS_PER_SLOT` and `MILLISECONDS_PER_SLOT`, docs carried over verbatim.
- `crates/blockchain/src/lib.rs` — the three definitions become a re-export of the same names from `ethlambda_types::constants`.

## Correctness / Behavior Guarantees

Pure move. **Values are unchanged**: 800 ms per interval, 5 intervals per slot, 4000 ms per slot.

`ethlambda_blockchain::{MILLISECONDS_PER_INTERVAL, INTERVALS_PER_SLOT, MILLISECONDS_PER_SLOT}` still resolve via the re-export, so no downstream import changes — `crates/net/rpc/src/spec.rs` in particular is untouched.

`tooling/event-monitor` keeps its own `DEFAULT_INTERVALS_PER_SLOT`; it is a separate binary that reads the real value from `/lean/v0/config/spec` over HTTP and only falls back to the local default when no node answers.

## Tests Added / Run

No new tests — there is no behavior to test. Existing suite covers the constants through every consumer.

```
make fmt
make lint
make leanSpec/fixtures     # fixtures were absent in the worktree
cargo test --workspace --profile release-fast --no-fail-fast
```

## Related Issues / PRs

- Extracted from #561

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing
