### PR TITLE
refactor(storage): add Store::current_slot

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -68,13 +68,13 @@ pub struct BlockChainConfig {
     pub proposer_config: ProposerConfig,
 }
 
-/// Milliseconds per interval (800ms ticks).
-pub const MILLISECONDS_PER_INTERVAL: u64 = 800;
-/// Number of intervals per slot (5 intervals of 800ms = 4 seconds).
-pub const INTERVALS_PER_SLOT: u64 = 5;
-/// Milliseconds in a slot (derived from interval duration and count).
-pub const MILLISECONDS_PER_SLOT: u64 = MILLISECONDS_PER_INTERVAL * INTERVALS_PER_SLOT;
+// The interval grid lives in `ethlambda-types` because `ethlambda-storage` also
+// derives slots from `store.time()` and must not carry a second copy of a
+// consensus-critical constant.
 pub use ethlambda_types::block::MAX_ATTESTATIONS_DATA;
+pub use ethlambda_types::constants::{
+    INTERVALS_PER_SLOT, MILLISECONDS_PER_INTERVAL, MILLISECONDS_PER_SLOT,
+};
 pub use sync_status::SyncStatusController;
 /// Future-slot tolerance for gossip attestations, expressed in intervals.
 ///

--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -1413,7 +1413,7 @@ impl Handler<NewAttestation> for BlockChainServer {
         // Early aggregation only advances the current slot's group counts, so a
         // late- or future-slot attestation can never cross the threshold; skip
         // the check unless this attestation is for the store's current slot.
-        let current_slot = self.store.time().expect("store time exists") / INTERVALS_PER_SLOT;
+        let current_slot = self.store.current_slot();
         if msg.attestation.data.slot == current_slot {
             self.maybe_start_early_aggregation(ctx).await;
         }

--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -348,7 +348,7 @@ pub fn on_tick(store: &mut Store, timestamp_ms: u64, has_proposal: bool) {
             .set_time(store.time().unwrap() + 1)
             .expect("set_time should succeed");
 
-        let slot = store.time().unwrap() / INTERVALS_PER_SLOT;
+        let slot = store.current_slot();
         let interval = SlotInterval::from_intervals_since_genesis(store.time().unwrap());
 
         trace!(%slot, ?interval, "processing tick");
@@ -637,7 +637,7 @@ fn on_block_core(
     // Horizon is the current slot plus one whole slot of margin, so an intended
     // early block still imports (mirrors the attestation future-slot guard, but
     // with a whole-slot rather than one-interval margin).
-    let current_slot = store.time().expect("DB read should succeed") / INTERVALS_PER_SLOT;
+    let current_slot = store.current_slot();
     if slot > current_slot + 1 {
         return Err(StoreError::BlockTooFarInFuture {
             block_slot: slot,

--- a/crates/common/types/src/constants.rs
+++ b/crates/common/types/src/constants.rs
@@ -8,3 +8,10 @@
 /// eventually be derived from the fork version and genesis validators root.
 // TODO: derive dynamically once the spec defines fork identification.
 pub const FORK_DIGEST: &str = "12345678";
+
+/// Milliseconds per interval (800ms ticks).
+pub const MILLISECONDS_PER_INTERVAL: u64 = 800;
+/// Number of intervals per slot (5 intervals of 800ms = 4 seconds).
+pub const INTERVALS_PER_SLOT: u64 = 5;
+/// Milliseconds in a slot (derived from interval duration and count).
+pub const MILLISECONDS_PER_SLOT: u64 = MILLISECONDS_PER_INTERVAL * INTERVALS_PER_SLOT;

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -14,6 +14,7 @@ use ethlambda_types::{
         Block, BlockBody, BlockHeader, MultiMessageAggregate, SignedBlock, SingleMessageAggregate,
     },
     checkpoint::Checkpoint,
+    constants::INTERVALS_PER_SLOT,
     genesis::GenesisConfig,
     primitives::{H256, HashTreeRoot as _},
     state::{ChainConfig, State, anchor_pair_is_consistent},
@@ -817,9 +818,8 @@ impl Store {
 
     /// Returns the current store time in interval counts since genesis.
     ///
-    /// Each increment represents one 800ms interval. Derive slot/interval as:
-    ///   slot     = time() / INTERVALS_PER_SLOT
-    ///   interval = time() % INTERVALS_PER_SLOT
+    /// Each increment represents one 800ms interval. Use [`Self::current_slot`]
+    /// for the slot; the interval within it is `time() % INTERVALS_PER_SLOT`.
     pub fn time(&self) -> Result<u64, Error> {
         self.get_metadata(KEY_TIME)
     }
@@ -827,6 +827,11 @@ impl Store {
     /// Sets the current store time.
     pub fn set_time(&mut self, time: u64) -> Result<(), Error> {
         self.set_metadata(KEY_TIME, &time)
+    }
+
+    /// The current slot, derived from the store clock.
+    pub fn current_slot(&self) -> u64 {
+        self.time().expect("store time exists") / INTERVALS_PER_SLOT
     }
 
     // ============ Config ============


### PR DESCRIPTION
## 🗒️ Description / Motivation

Extracted from #561. Stacked on #569, which is what makes it possible: with the interval grid in `ethlambda-types`, `ethlambda-storage` can own the accessor.

Deriving the slot from the store clock was open-coded at three call sites in the blockchain crate, each repeating `store.time() / INTERVALS_PER_SLOT` along with its own `expect` message.

> [!NOTE]
> Targets `refactor/interval-constants-in-types`. Merge #569 first and this rebases onto `main` on its own.

## What Changed

- `crates/storage/src/store.rs` — new `Store::current_slot()`; the `Store::time()` doc comment now points at it for the slot case rather than spelling out the division.
- `crates/blockchain/src/store.rs` — two call sites (`on_tick`, `on_block_core`).
- `crates/blockchain/src/lib.rs` — one call site (the `NewAttestation` handler).

## Correctness / Behavior Guarantees

Identical behavior. All three sites already panicked on a failed `time()` read (`unwrap` / `expect`), so `current_slot()`'s `expect("store time exists")` preserves the failure mode; only the panic message differs at two of them.

Uses of `INTERVALS_PER_SLOT` that are *not* "derive the current slot from the clock" are deliberately untouched: the `% INTERVALS_PER_SLOT` interval derivation, `data.slot.saturating_mul(INTERVALS_PER_SLOT)`, the tick skip-check, and the `set_time(n * INTERVALS_PER_SLOT)` calls in tests.

## Tests Added / Run

No new tests — no behavior change to cover.

```
make fmt
make lint
make leanSpec/fixtures     # fixtures were absent in the worktree
cargo test --workspace --profile release-fast --no-fail-fast
```

## Related Issues / PRs

- Stacked on #569
- Extracted from #561

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing
