### PR TITLE
refactor(blockchain): use Store::head_state in update_safe_target

### DIFF
--- a/crates/blockchain/src/store.rs
+++ b/crates/blockchain/src/store.rs
@@ -148,10 +148,7 @@ pub fn update_head(store: &mut Store) -> HeadUpdate {
 /// evidence even when live participation has collapsed: exactly the failure
 /// mode safe target is supposed to prevent. See leanSpec PR #680.
 fn update_safe_target(store: &mut Store) {
-    let head_state = store
-        .get_state(&store.head().unwrap())
-        .expect("head state exists");
-    let num_validators = head_state.unwrap().validators.len() as u64;
+    let num_validators = store.head_state().validators.len() as u64;
 
     let min_target_score = (num_validators * 2).div_ceil(3);
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

Extracted from #561. Independent of the heartbeat work, so it lands on its own.

`update_safe_target` open-coded the `get_state(&head())` chain that `Store::head_state()` already encapsulates, carrying an extra `unwrap` for no reason.

## What Changed

- `crates/blockchain/src/store.rs` — `update_safe_target` reads the validator count through `store.head_state()`.

## Correctness / Behavior Guarantees

Equivalent, checked rather than assumed: `Store::head_state()` (`crates/storage/src/store.rs:1696`) is exactly `self.get_state(&self.head().expect(..)).expect(..).unwrap()` — the same Result→panic, Result→panic, Option→panic chain the inline version had. Only the `expect` messages differ.

This is the only site in the codebase that open-coded the chain.

## Tests Added / Run

No new tests — no behavior change to cover.

```
make fmt
make lint
make leanSpec/fixtures     # fixtures were absent in the worktree
cargo test --workspace --profile release-fast --no-fail-fast
```

## Related Issues / PRs

- Extracted from #561

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing
