### PR TITLE
refactor(blockchain): reference INTERVALS_PER_SLOT in the tick panic message

### DIFF
--- a/crates/blockchain/src/lib.rs
+++ b/crates/blockchain/src/lib.rs
@@ -106,7 +106,7 @@ impl SlotInterval {
             2 => Self::Aggregation,
             3 => Self::SafeTargetUpdate,
             4 => Self::EndOfSlot,
-            _ => unreachable!("slots only have 5 intervals"),
+            _ => unreachable!("slots only have {INTERVALS_PER_SLOT} intervals"),
         }
     }
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

Extracted from #561, where the interval count changes and this message would otherwise have gone stale.

`SlotInterval::from_intervals_since_genesis` hardcoded the interval count in its `unreachable!` string, so changing the grid would leave a wrong number in a panic message — the one place you least want to be misled.

## What Changed

- `crates/blockchain/src/lib.rs` — the panic message captures `INTERVALS_PER_SLOT` instead of spelling out the number.

## Correctness / Behavior Guarantees

No behavior change; the arm is unreachable by construction (`% INTERVALS_PER_SLOT`). Inline format-arg capture of a `const` inside `unreachable!` was confirmed to compile, not assumed.

Two doc comments in the same file still spell out `800ms` / `5 intervals` in prose. Left alone as out of scope for this PR.

## Tests Added / Run

No new tests — no behavior change to cover.

```
make fmt
make lint
make leanSpec/fixtures     # fixtures were absent in the worktree
cargo test --workspace --profile release-fast --no-fail-fast
```

## Related Issues / PRs

- Extracted from #561

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing
