### PR TITLE
chore(deps): bump libssz crates to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,18 +4523,18 @@ dependencies = [
 
 [[package]]
 name = "libssz"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
+checksum = "b4bdd6d63ed811ae164966de20810be780e07de784a4834ccfe6be90480c369e"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-derive"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
+checksum = "aeee1b9ac9200429f7e9830492765445989ea61c3fb9028ad5a96e1dd5f5e913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4543,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-merkle"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+checksum = "863eca32d1a43e5ec41106a515552efa8307768d37c68d26b7f21ff13cfee1a7"
 dependencies = [
  "libssz",
  "sha2",
@@ -4553,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-types"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
+checksum = "d4231ac301726840a3fe111f11bd4619d3c97ed155cb94c88dbf92b70e04e017"
 dependencies = [
  "libssz",
  "libssz-merkle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,10 @@ clap = { version = "4.3", features = ["derive", "env"] }
 leansig = { git = "https://github.com/leanEthereum/leanSig", branch = "devnet4" }
 
 # SSZ implementation
-libssz = "0.2.2"
-libssz-derive = "0.2.2"
-libssz-merkle = "0.2.2"
-libssz-types = "0.2.2"
+libssz = "0.3.0"
+libssz-derive = "0.3.0"
+libssz-merkle = "0.3.0"
+libssz-types = "0.3.0"
 
 # Build-time version info
 vergen-git2 = { version = "9", features = ["rustc"] }


### PR DESCRIPTION
Bumps `libssz`, `libssz-derive`, `libssz-merkle` and `libssz-types` from 0.2.2 to 0.3.0 ([release notes](https://github.com/lambdaclass/libssz/releases/tag/v0.3.0)).

## Why

0.3.0 tracks [consensus-specs v1.7.0-alpha.13](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.13) and ships a `merkleize` rewrite that elides all-zero subtrees and reuses buffers instead of allocating per layer, which touches every `hash_tree_root` we compute.

## Impact on this codebase: none

0.3.0 is a breaking release, but every breaking change is confined to progressive containers and lists:

| Breaking change | Used here? |
|---|---|
| Progressive merkleization roots changed (EIP-7916): `ProgressiveList`, `ProgressiveBitlist`, `#[ssz(progressive_container)]` | No |
| Progressive containers capped at 256 fields | No |
| Unknown `#[ssz(...)]` keys are now compile errors instead of being silently ignored | No |

No source changes were needed.

## Lockfile scope

The `Cargo.lock` diff is deliberately limited to the four `libssz` entries (version + checksum). A full `cargo update -p libssz ...` re-resolve additionally repointed leanVM's `mt-field`/`mt-poly` at `num-bigint` 0.4 and shifted several other duplicate-version picks (`itertools`, `syn`, `getrandom`). That churn is unrelated to this bump, and silently moving a crypto dependency's bignum library does not belong in a dependency bump, so it was left out. `cargo check --locked` confirms the hand-scoped lockfile resolves cleanly.

## Verification

Run against the minimal lockfile, on the latest `leanSpec` production fixtures:

- `cargo check --workspace --all-targets --locked` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all green, including the SSZ-sensitive suites (`stf_spectests`, `forkchoice_spectests`, `signature_spectests`)

The spec-test suites are the meaningful check here: they compare `hash_tree_root` output and SSZ encode/decode against the leanSpec fixtures, so they would catch any merkleization or serialization change reaching our types.
