### PR TITLE
docs(readme): surface the security policy from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ We have a proof-of-concept formalization of a part of the state transition funct
 - **Weekly community call**: every Friday, streamed live on [@class_lambda](https://x.com/class_lambda); the call link is posted on Telegram beforehand.
 - **Ecosystem coordination**: the [PQ Interop calls](https://github.com/ethereum/pm/issues?q=is%3Aissue+%22PQ+Interop%22+in%3Atitle) on `ethereum/pm` cover cross-client Lean Ethereum work and related updates; the meeting links are posted on each issue.
 
+## Security
+
+We take security seriously. If you discover a vulnerability in this project, please report it responsibly.
+
+- You can report vulnerabilities directly via the **[GitHub "Report a Vulnerability" feature](../../security/advisories/new)**.
+- Alternatively, send an email to **[security@lambdaclass.com](mailto:security@lambdaclass.com)**.
+
+For more details, please refer to our [Security Policy](./.github/SECURITY.md).
+
 ## Contributing
 
 We welcome contributions! Please read our [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to get involved.


### PR DESCRIPTION
## 🗒️ Description / Motivation

Aligns ethlambda with [ethrex's security policy setup](https://github.com/lambdaclass/ethrex/blob/main/.github/SECURITY.md).

`.github/SECURITY.md` **already exists here and is byte-identical to ethrex's** (modulo two trailing-whitespace differences, which ours does not have), so no changes were needed to the policy itself. What was missing is ethrex's README pointer to it: the policy was only reachable through GitHub's Security tab, so anyone reading the repo front page had no idea where to report a vulnerability.

## What Changed

- `README.md`: new `## Security` section, placed just before `## Contributing` to match ethrex's ordering. Text is copied from ethrex's README section verbatim, including the repo-relative `../../security/advisories/new` advisory link (which resolves correctly under this repo) and the `security@lambdaclass.com` fallback.

## Correctness / Behavior Guarantees

Docs only. No code, config, or build changes.

## Tests Added / Run

None; documentation-only change. Verified the two new links resolve:
- `./.github/SECURITY.md` exists in-tree.
- `../../security/advisories/new` is the same relative form ethrex uses, resolving to `https://github.com/lambdaclass/ethlambda/security/advisories/new`.

## Related Issues / PRs

- Related to lambdaclass/ethrex `.github/SECURITY.md`

## ✅ Verification Checklist

- [ ] Ran `make fmt` — clean
- [ ] Ran `make lint` (clippy with `-D warnings`) — clean
- [ ] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing

_(Not run: no Rust sources touched.)_
