### PR TITLE
feat(cli): add the --discovery.* option group

### DIFF
--- a/bin/ethlambda/src/cli.rs
+++ b/bin/ethlambda/src/cli.rs
@@ -113,11 +113,57 @@ pub(crate) struct CliOptions {
     /// `on_block`.
     #[arg(long, default_value = "3")]
     pub(crate) max_attestations_per_block: usize,
+    #[command(flatten)]
+    pub(crate) discovery: DiscoveryConfig,
     /// Shadow-simulator sim-cost + fake-XMSS flags (only under the
     /// `shadow-integration` feature).
     #[cfg(feature = "shadow-integration")]
     #[command(flatten)]
     pub(crate) shadow: ShadowOptions,
+}
+
+/// discv5 peer discovery. Off by default: nothing else on the lean network
+/// speaks discv5 yet, so enabling it only finds other ethlambda nodes.
+#[derive(Debug, clap::Args)]
+pub(crate) struct DiscoveryConfig {
+    /// Enable discv5 peer discovery.
+    ///
+    /// Requires `--discovery.port` to differ from `--gossipsub-port`: both are
+    /// UDP sockets and they cannot share one port.
+    #[arg(long = "discovery.enable", default_value = "false")]
+    pub(crate) enable: bool,
+    /// UDP port for the discv5 socket.
+    ///
+    /// Independent of `--gossipsub-port`, which carries libp2p QUIC. Both
+    /// default to 9000, so enabling discovery means changing one of them.
+    #[arg(long = "discovery.port", default_value = "9000")]
+    pub(crate) port: u16,
+    /// IP address to advertise in the ENR.
+    ///
+    /// Defaults to the bind address, which is the wildcard `0.0.0.0` and is not
+    /// dialable as published. Set this to the address peers should reach this
+    /// node on: `127.0.0.1` for a local devnet, or the host's public address.
+    /// discv5's PONG-based IP voting may still replace it at runtime.
+    #[arg(long = "discovery.advertise-ip")]
+    pub(crate) advertise_ip: Option<std::net::IpAddr>,
+}
+
+impl CliOptions {
+    /// Reject a discovery port that collides with the QUIC port.
+    ///
+    /// Both are UDP. Without this the collision surfaces at bind time as an
+    /// opaque `EADDRINUSE` on whichever socket loses the race.
+    pub(crate) fn validate_discovery(&self) -> eyre::Result<()> {
+        if self.discovery.enable && self.discovery.port == self.gossipsub_port {
+            eyre::bail!(
+                "--discovery.port ({}) must differ from --gossipsub-port ({}): \
+                 both bind UDP and cannot share a port",
+                self.discovery.port,
+                self.gossipsub_port
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Shadow-simulator sim-cost + fake-XMSS flags. Compiled only under the

--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -81,6 +81,7 @@ async fn main() -> eyre::Result<()> {
         .wrap_err("failed to set global tracing subscriber")?;
 
     let options = CliOptions::parse();
+    options.validate_discovery()?;
 
     #[cfg(feature = "shadow-integration")]
     init_shadow_cost(&options.shadow);


### PR DESCRIPTION
## What

Adds the three operator-facing flags the discv5 work needs, on their own, so
the implementation PR (#579) is confined to the p2p crate.

| Flag | Default | Meaning |
| --- | --- | --- |
| `--discovery.enable` | `false` | turn discv5 peer discovery on |
| `--discovery.port` | `9000` | UDP port for the discv5 socket |
| `--discovery.advertise-ip` | unset | IP to advertise in the ENR |

The flags parse and validate here. **Nothing reads them yet**, which is the
point of splitting them out: this is reviewable on its own and cannot change
runtime behaviour of a node that does not pass them.

## Why the port validation

`--discovery.port` and `--gossipsub-port` are both UDP and both default to
9000, so enabling discovery without moving one of them collides. Left
unchecked, that surfaces at bind time as an opaque `EADDRINUSE` on whichever
socket loses the race, pointing at neither flag. `CliOptions::validate_discovery`
rejects it at startup with a message naming both flags and their values.

The check only fires when discovery is enabled, so the shared default is
harmless for every existing deployment.

## Why `--discovery.advertise-ip`

The node binds the wildcard `0.0.0.0`, which is not dialable as published. A
node whose reachable address differs from what it listens on (a devnet on
`127.0.0.1`, or a host behind NAT) needs to say so explicitly. discv5's
PONG-based IP voting may still learn and substitute the real external address
at runtime; this only sets what the ENR carries at startup.

## Testing

- `make lint` clean.
- Colliding ports are rejected by name:
  ```
  $ ethlambda ... --discovery.enable
  Error: --discovery.port (9000) must differ from --gossipsub-port (9000): both bind UDP and cannot share a port
  ```
- Distinct ports pass validation and startup proceeds:
  ```
  $ ethlambda ... --discovery.enable --discovery.port 9010
  Error: failed to load node key from /nonexistent/node.key
  ```
- The group renders under `--help` with its dotted prefixes intact.

## Relationship to #579

#579 carries the discv5 implementation and currently includes these same
flags. If this lands first, #579 rebases onto it and drops the `cli.rs` hunk.
