### PR TITLE
ci: subscribe CI to merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+  # Required for Lint and Test to run against the merge queue's temporary
+  # branch. A merge queue only reports a check as passing if the workflow
+  # subscribes to merge_group; without it the queue waits forever on checks
+  # that never start.
+  merge_group:
   workflow_dispatch:
 
-# Cancel in-progress runs when a new commit is pushed to the same PR or branch
+# Cancel in-progress runs when a new commit is pushed to the same PR or branch.
+# merge_group runs have no head_ref, so they fall back to the unique run_id and
+# are never cancelled by a sibling run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
-  # Required for Lint and Test to run against the merge queue's temporary
-  # branch. A merge queue only reports a check as passing if the workflow
-  # subscribes to merge_group; without it the queue waits forever on checks
-  # that never start.
   merge_group:
   workflow_dispatch:
 
-# Cancel in-progress runs when a new commit is pushed to the same PR or branch.
-# merge_group runs have no head_ref, so they fall back to the unique run_id and
-# are never cancelled by a sibling run.
+# Cancel in-progress runs when a new commit is pushed to the same PR or branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
**Motivation**

GitHub's merge queue runs required checks against a temporary `gh-readonly-queue/*` branch, and it only reports a workflow as passing if that workflow subscribes to the `merge_group` event ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)).

`Lint` and `Test` live in `CI`, which only listened to `push`, `pull_request` and `workflow_dispatch`. If those are set as required checks, the queue would sit waiting on checks that never start.

**Description**

- Add the `merge_group:` trigger to `.github/workflows/ci.yml`.
- Note in the `concurrency` comment that `merge_group` runs carry no `head_ref`, so the group falls back to the unique `run_id` and queue runs are never cancelled by a sibling run.

Only `CI` is changed; the other workflows are not required checks for merging.