### PR TITLE
fix(p2p): disable gossipsub flood publish

### DIFF
--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -242,6 +242,24 @@ pub fn build_swarm(
         .max_messages_per_rpc(Some(500))
         .allow_self_origin(true)
         .idontwant_message_size_threshold(1000)
+        // Flood publish (default: true) fans our own publishes out to every
+        // connected peer instead of just the mesh. The gossipsub v1.1 spec
+        // defines it as score-gated ("all connected peers with a score above a
+        // publish threshold"), but we never configure peer scoring, and
+        // `PeerScoreState::Disabled` makes that gate pass every peer, so we run
+        // the ungated form. Neither leanSpec nor the Ethereum consensus-specs
+        // p2p interface mentions the parameter; lighthouse and ream both set it
+        // false.
+        //
+        // Effect is confined to topics with more than `mesh_n` subscribed
+        // peers, since below that the mesh-bounded path selects everyone
+        // anyway. On devnet-5 that means `block` and `aggregation`, which all
+        // 32 nodes subscribe to: publish fanout drops from 31 peers to 8. The
+        // `attestation_N` topics are UNAFFECTED, because only the 4 nodes
+        // sharing a subnet subscribe to it (3 peers, under `mesh_n`). So this
+        // targets egress bytes, aggregates being 220 KiB apiece, not the
+        // per-peer send-queue entry count, which is dominated by attestations.
+        .flood_publish(false)
         .build()
         .expect("invalid gossipsub config");
 


### PR DESCRIPTION
## Summary

`flood_publish` defaults to **true** in gossipsub and we never override it, so every one of our own publishes fans out to all connected peers rather than the mesh.

The gossipsub v1.1 spec defines flood publishing as **optional** and **score-gated**:

> In gossipsub v1.1 publishing is (optionally) done by publishing the message to all connected peers **with a score above a publish threshold**. [...] This behaviour is prescribed to counter eclipse attacks and ensure that a newly published message from an honest node will reach all connected honest nodes.

We never configure peer scoring, and `PeerScoreState::Disabled` makes `below_threshold` return `(false, 0.0)` for every peer (`peer_score.rs:59-71`). So the score gate silently passes everyone and we run the ungated form of a mechanism the spec defines as gated.

Neither leanSpec's `gossipsub/parameters.py` nor the Ethereum consensus-specs p2p interface mentions this parameter, so there is no normative position either way. On practice: **lighthouse** and **ream** both set it `false`; grandine and lantern leave it on.

## Scope is narrower than it looks, and I want reviewers to see this clearly

`filter_publish_candidates` (`behaviour.rs:777-820`) fills up to `mesh_n` from the candidate set when the mesh is short, so on any topic with `mesh_n` or fewer subscribed peers it selects everyone regardless of this setting. Measured subscriber counts on devnet-5:

| Topic | Subscribers | Peers | vs `mesh_n=8` | Affected |
|---|---|---|---|---|
| `block` | all 32 nodes | 31 | above | **yes**, 31 → 8 |
| `aggregation` | all 32 nodes | 31 | above | **yes**, 31 → 8 |
| `attestation_N` | 4 nodes on the subnet | 3 | below | **no** |

Confirmed via `lean_attestation_committee_subnet`: positions 0, 8, 16, 24 all sit on subnet 0, so an attestation topic has 4 subscribers.

**So this reduces egress bytes, not send-queue pressure.** Aggregates are 220 KiB apiece and blocks are large; both drop from 31 recipients to 8, roughly a 4x cut on the byte-heavy traffic, against measured per-node egress of 200-870 Mbps. It does **not** reduce the per-peer send-queue entry count, which is 91% raw attestations at 1.34 KB each. If you are reviewing this expecting the `Send Queue full` flood to stop, it will not.

## Risk

Flood publishing exists to get an honest node's message to everyone, so turning it off makes IHAVE/IWANT gossip and mesh maintenance the reliability path for non-mesh peers. On a small fully-connected devnet it may have been masking a propagation weakness.

## Verification, and its limits

- [x] `make fmt`
- [x] `make lint` (`cargo clippy --workspace --all-targets -- -D warnings`, clean)
- [x] `cargo test -p ethlambda-p2p --profile release-fast`
- [ ] **Local devnet: not possible.** Distinguishing the two configs needs more than `mesh_n` peers subscribed to a topic, so more than 9 nodes, and leanVM's 4-5 GiB per node makes that infeasible on Docker Desktop. A 2-4 node devnet exercises identical code paths either way, so a green local run would be evidence of nothing.

Verification therefore needs a canary on devnet-5. Falsifiable prediction: the `aggregation` and `block` slices of `Send Queue full`, broken down by topic, should fall; the `attestation_N` slice should be unchanged; NIC egress on the aggregators should drop. If the attestation slice moves, the reasoning above is wrong.