### PR TITLE
feat(p2p): enable gossipsub peer scoring and react to slow peers

### DIFF
--- a/bin/ethlambda/src/main.rs
+++ b/bin/ethlambda/src/main.rs
@@ -266,6 +266,7 @@ async fn main() -> eyre::Result<()> {
         bootnodes,
         listening_socket: p2p_socket,
         validator_ids,
+        network_validator_count: genesis_config.genesis_validators.len() as u64,
         attestation_committee_count,
         subscription_subnets: subscribed_subnets,
     })

--- a/crates/common/metrics/src/lib.rs
+++ b/crates/common/metrics/src/lib.rs
@@ -5,10 +5,10 @@ pub mod timing;
 
 // Re-export prometheus types and macros we use
 pub use prometheus::{
-    Encoder, Error as PrometheusError, Histogram, HistogramVec, IntCounter, IntCounterVec,
-    IntGauge, IntGaugeVec, TextEncoder, core::Collector, gather, register_histogram,
-    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
-    register_int_gauge_vec,
+    Encoder, Error as PrometheusError, GaugeVec, Histogram, HistogramVec, IntCounter,
+    IntCounterVec, IntGauge, IntGaugeVec, TextEncoder, core::Collector, gather, register_gauge_vec,
+    register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    register_int_gauge, register_int_gauge_vec,
 };
 
 // Re-export commonly used items

--- a/crates/net/p2p/src/gossipsub/mod.rs
+++ b/crates/net/p2p/src/gossipsub/mod.rs
@@ -1,6 +1,7 @@
 mod encoding;
 mod handler;
 mod messages;
+pub mod scoring;
 
 pub use encoding::decompress_message;
 pub use handler::{

--- a/crates/net/p2p/src/gossipsub/scoring.rs
+++ b/crates/net/p2p/src/gossipsub/scoring.rs
@@ -1,0 +1,457 @@
+//! Gossipsub peer scoring parameters, ported from lighthouse.
+//!
+//! Without a call to `Behaviour::with_peer_score`, gossipsub keeps
+//! `PeerScoreState::Disabled`, and three of its defences are dead code:
+//! `below_threshold` returns `(false, 0.0)` for every peer so the publish and
+//! gossip gates pass everyone; the heartbeat's "prune peer with negative
+//! score" pass reads a score of 0.0 and never fires; and the
+//! `failed_message_slow_peer` penalty at the `Send Queue full` site takes the
+//! `PeerScoreState::Active` arm never. Enabling scoring is what turns a peer
+//! that cannot drain its send queue into a peer we stop feeding.
+//!
+//! Everything topology-independent is taken from lighthouse's
+//! `gossipsub_scoring_parameters.rs` unchanged, including the deliberately
+//! harsh slow-peer weights. Rates and decay horizons are re-derived for lean,
+//! which has no epochs and where every validator attests every slot.
+//!
+//! DEVIATION: `mesh_message_deliveries` is not configured. It is the only
+//! negative topic-level term, its weight is `-topic_weight`, and it punishes a
+//! peer for delivering fewer mesh messages than expected. Getting the expected
+//! rate wrong would drive healthy peers negative and prune them, which is the
+//! failure mode this scoring is meant to prevent. Lighthouse itself passes
+//! `None` for its low-rate topics. Left out until the rates are measured.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use ethlambda_types::constants::MILLISECONDS_PER_SLOT;
+use libp2p::gossipsub::{PeerScoreParams, PeerScoreThresholds, TopicHash, TopicScoreParams};
+
+use super::{aggregation_topic, attestation_subnet_topic, block_topic};
+
+/// Cap on the score a peer earns from sitting in our mesh, per lighthouse.
+const MAX_IN_MESH_SCORE: f64 = 10.0;
+/// Cap on the score a peer earns from being first to deliver, per lighthouse.
+const MAX_FIRST_MESSAGE_DELIVERIES_SCORE: f64 = 40.0;
+
+/// Topic weights. Lighthouse splits its weight budget across topic kinds and
+/// keeps the total at 1.0 so that `max_positive_score` is stable; the same
+/// split is used here, with the attestation budget spread over the subnets.
+const BLOCK_TOPIC_WEIGHT: f64 = 0.5;
+const AGGREGATION_TOPIC_WEIGHT: f64 = 0.5;
+
+/// Decay horizon, standing in for the beacon epoch that lighthouse's decay
+/// times are expressed in. Lean has no epochs, so a fixed span of slots is
+/// used and lighthouse's multipliers are applied to it unchanged.
+const SLOTS_PER_SCORE_EPOCH: u32 = 32;
+
+/// Number of peers permitted to share one source IP before the quadratic
+/// colocation penalty starts, per lighthouse.
+///
+/// NOTE: a single-host devnet puts every node on 127.0.0.1, so a node with
+/// more than this many peers penalises all of them. Keep local runs at or
+/// below `threshold + 1` nodes, or the penalty, not the slow-peer weight,
+/// dominates the score.
+const IP_COLOCATION_FACTOR_THRESHOLD: f64 = 8.0;
+
+/// Graylist threshold, below which gossipsub ignores a peer's inbound RPCs.
+/// Public because it bounds how far a peer's score can sink, which is what
+/// makes the "scoring alone never disconnects" property checkable.
+pub const GRAYLIST_THRESHOLD: f64 = -16000.0;
+
+fn slot() -> Duration {
+    Duration::from_millis(MILLISECONDS_PER_SLOT)
+}
+
+/// Stand-in for lighthouse's epoch in decay-time expressions.
+fn score_epoch() -> Duration {
+    slot() * SLOTS_PER_SCORE_EPOCH
+}
+
+/// Score thresholds, taken from lighthouse's `lighthouse_gossip_thresholds`.
+pub fn thresholds() -> PeerScoreThresholds {
+    PeerScoreThresholds {
+        gossip_threshold: -4000.0,
+        publish_threshold: -8000.0,
+        graylist_threshold: GRAYLIST_THRESHOLD,
+        accept_px_threshold: 100.0,
+        opportunistic_graft_threshold: 5.0,
+    }
+}
+
+/// Per-tick decay factor that takes `decay_time` to reach `decay_to_zero`.
+fn score_parameter_decay(
+    decay_time: Duration,
+    decay_interval: Duration,
+    decay_to_zero: f64,
+) -> f64 {
+    let ticks = decay_time.as_secs_f64() / decay_interval.as_secs_f64();
+    decay_to_zero.powf(1.0 / ticks)
+}
+
+/// Value a counter converges to when incremented at `rate` per tick and
+/// multiplied by `decay` each tick.
+fn decay_convergence(decay: f64, rate: f64) -> f64 {
+    rate / (1.0 - decay)
+}
+
+/// Inputs that decide the expected message rate on each topic.
+///
+/// `network_validator_count` is the whole network's validator set, not this
+/// node's, because the rate a topic carries is a property of the network.
+pub struct ScoringTopology {
+    pub network_validator_count: u64,
+    pub attestation_committee_count: u64,
+    /// `mesh_n`, needed because a peer is only expected to be first-deliverer
+    /// for its share of the mesh.
+    pub mesh_n: usize,
+}
+
+/// Build the score params. Mirrors lighthouse's `get_peer_score_params`.
+pub fn params(topology: &ScoringTopology) -> PeerScoreParams {
+    let attestation_subnet_weight = 1.0 / topology.attestation_committee_count as f64;
+    // Weights sum to 1.0: block + aggregation + every subnet's share.
+    let total_topic_weight = BLOCK_TOPIC_WEIGHT
+        + AGGREGATION_TOPIC_WEIGHT
+        + attestation_subnet_weight * topology.attestation_committee_count as f64;
+    let max_positive_score =
+        (MAX_IN_MESH_SCORE + MAX_FIRST_MESSAGE_DELIVERIES_SCORE) * total_topic_weight;
+
+    let decay_interval = std::cmp::max(Duration::from_secs(1), slot());
+    let decay_to_zero = 0.01;
+    let decay =
+        |decay_time: Duration| score_parameter_decay(decay_time, decay_interval, decay_to_zero);
+
+    let mut params = PeerScoreParams {
+        decay_interval,
+        decay_to_zero,
+        retain_score: score_epoch() * 100,
+        app_specific_weight: 1.0,
+        ip_colocation_factor_threshold: IP_COLOCATION_FACTOR_THRESHOLD,
+        behaviour_penalty_threshold: 6.0,
+        behaviour_penalty_decay: decay(score_epoch() * 10),
+        // Lighthouse's overrides, 50x the libp2p defaults of -0.2 / 0.2. This
+        // is the term that reacts to `Send Queue full`: every failed send adds
+        // 1.0 to `slow_peer_penalty`, and the score contribution is
+        // `(penalty - threshold) * weight`.
+        slow_peer_decay: 0.1,
+        slow_peer_weight: -10.0,
+        slow_peer_threshold: 0.0,
+        ..Default::default()
+    };
+
+    // Behaviour penalty is scaled so that the configured threshold sits at the
+    // gossip threshold, exactly as lighthouse derives it.
+    let target_value = decay_convergence(
+        params.behaviour_penalty_decay,
+        10.0 / SLOTS_PER_SCORE_EPOCH as f64,
+    ) - params.behaviour_penalty_threshold;
+    params.behaviour_penalty_weight = thresholds().gossip_threshold / target_value.powi(2);
+
+    params.topic_score_cap = max_positive_score * 0.5;
+    params.ip_colocation_factor_weight = -params.topic_score_cap;
+
+    let mut topics: HashMap<TopicHash, TopicScoreParams> = HashMap::new();
+
+    // One block per slot.
+    topics.insert(
+        block_topic().hash(),
+        topic_params(
+            BLOCK_TOPIC_WEIGHT,
+            1.0,
+            score_epoch() * 20,
+            decay_interval,
+            decay_to_zero,
+            topology.mesh_n,
+        ),
+    );
+
+    // One aggregate per subnet per slot, when every subnet has an aggregator.
+    topics.insert(
+        aggregation_topic().hash(),
+        topic_params(
+            AGGREGATION_TOPIC_WEIGHT,
+            topology.attestation_committee_count as f64,
+            score_epoch(),
+            decay_interval,
+            decay_to_zero,
+            topology.mesh_n,
+        ),
+    );
+
+    // Every validator attests every slot, so a subnet carries its share of the
+    // validator set each slot. This is the main departure from the beacon
+    // chain, where a validator attests once per epoch.
+    let attestations_per_subnet_per_slot =
+        topology.network_validator_count as f64 / topology.attestation_committee_count as f64;
+    for subnet in 0..topology.attestation_committee_count {
+        topics.insert(
+            attestation_subnet_topic(subnet).hash(),
+            topic_params(
+                attestation_subnet_weight,
+                attestations_per_subnet_per_slot,
+                score_epoch() * 4,
+                decay_interval,
+                decay_to_zero,
+                topology.mesh_n,
+            ),
+        );
+    }
+
+    params.topics = topics;
+    params
+}
+
+/// Mirrors lighthouse's `get_topic_params` with `mesh_message_info: None`.
+fn topic_params(
+    topic_weight: f64,
+    expected_message_rate: f64,
+    first_message_decay_time: Duration,
+    decay_interval: Duration,
+    decay_to_zero: f64,
+    mesh_n: usize,
+) -> TopicScoreParams {
+    let mut t = TopicScoreParams::default();
+    t.topic_weight = topic_weight;
+
+    t.time_in_mesh_quantum = slot();
+    t.time_in_mesh_cap = 3600.0 / t.time_in_mesh_quantum.as_secs_f64();
+    t.time_in_mesh_weight = MAX_IN_MESH_SCORE / t.time_in_mesh_cap;
+
+    t.first_message_deliveries_decay =
+        score_parameter_decay(first_message_decay_time, decay_interval, decay_to_zero);
+    t.first_message_deliveries_cap = decay_convergence(
+        t.first_message_deliveries_decay,
+        2.0 * expected_message_rate / mesh_n as f64,
+    );
+    t.first_message_deliveries_weight =
+        MAX_FIRST_MESSAGE_DELIVERIES_SCORE / t.first_message_deliveries_cap;
+
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::{
+        Swarm, futures::StreamExt, gossipsub, swarm::SwarmEvent, swarm::dial_opts::DialOpts,
+    };
+    use std::time::Duration;
+
+    use super::*;
+    use crate::{GOSSIP_MESH_N, gossipsub_config};
+
+    fn topology() -> ScoringTopology {
+        ScoringTopology {
+            network_validator_count: 12,
+            attestation_committee_count: 4,
+            mesh_n: GOSSIP_MESH_N,
+        }
+    }
+
+    #[test]
+    fn params_are_accepted_by_gossipsub() {
+        // `with_peer_score` runs `PeerScoreParams::validate`, which rejects a
+        // positive weight where a penalty is expected, a zero decay, a decay
+        // outside (0, 1], and several cross-field constraints. Building the
+        // behaviour is the only way to exercise that, and a panic here at
+        // startup would take the node down, so it is worth a test of its own.
+        let mut behaviour: gossipsub::Behaviour = gossipsub::Behaviour::new(
+            gossipsub::MessageAuthenticity::Anonymous,
+            gossipsub_config(),
+        )
+        .expect("behaviour");
+        behaviour
+            .with_peer_score(params(&topology()), thresholds())
+            .expect("params should validate");
+    }
+
+    #[test]
+    fn every_topic_the_node_gossips_on_is_scored() {
+        // A topic absent from `params.topics` earns no positive score at all,
+        // so a peer on it sits at 0.0 and the first dropped message is enough
+        // to make it negative and get it pruned. Every topic we publish to
+        // must therefore be present.
+        let topology = topology();
+        let params = params(&topology);
+        assert!(params.topics.contains_key(&block_topic().hash()));
+        assert!(params.topics.contains_key(&aggregation_topic().hash()));
+        for subnet in 0..topology.attestation_committee_count {
+            assert!(
+                params
+                    .topics
+                    .contains_key(&attestation_subnet_topic(subnet).hash()),
+                "subnet {subnet} is unscored"
+            );
+        }
+        assert_eq!(
+            params.topics.len(),
+            2 + topology.attestation_committee_count as usize
+        );
+    }
+
+    #[test]
+    fn a_graylisted_peer_cannot_reach_the_disconnect_threshold_alone() {
+        // Lighthouse's property, restated for our setup: gossipsub owns no
+        // disconnect path, so the floor a peer's score can reach is bounded by
+        // the graylist threshold and nothing in gossipsub acts on it beyond
+        // ignoring the peer's inbound RPCs. This is what "handle SlowPeer but
+        // do not disconnect" rests on, so it is asserted rather than assumed.
+        let t = thresholds();
+        assert!(t.graylist_threshold < t.publish_threshold);
+        assert!(t.publish_threshold < t.gossip_threshold);
+        assert!(t.gossip_threshold < 0.0);
+    }
+
+    fn node() -> Swarm<gossipsub::Behaviour> {
+        libp2p::SwarmBuilder::with_new_identity()
+            .with_tokio()
+            .with_other_transport(|keypair| {
+                use libp2p::Transport;
+                libp2p::core::transport::MemoryTransport::default()
+                    .upgrade(libp2p::core::upgrade::Version::V1)
+                    .authenticate(libp2p::noise::Config::new(keypair).expect("noise"))
+                    .multiplex(libp2p::yamux::Config::default())
+            })
+            .expect("transport")
+            .with_behaviour(|_keypair| {
+                let mut behaviour = gossipsub::Behaviour::new(
+                    gossipsub::MessageAuthenticity::Anonymous,
+                    gossipsub_config(),
+                )
+                .expect("behaviour");
+                behaviour
+                    .with_peer_score(params(&topology()), thresholds())
+                    .expect("score params");
+                behaviour
+            })
+            .expect("behaviour")
+            .build()
+    }
+
+    /// The behaviour this whole change exists for.
+    ///
+    /// A peer that stops draining its send queue is pruned from the mesh, so
+    /// we stop feeding it, and is NOT disconnected, so it keeps its connection
+    /// and can still be served over request/response. On `main` the same
+    /// scenario leaves the peer in the mesh indefinitely, which on devnet-5
+    /// meant one node losing ~33 messages/second to one peer for 12+ hours.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_stalled_peer_is_pruned_from_the_mesh_but_not_disconnected() {
+        // Scored topic, so the stalled peer starts from a real positive score
+        // rather than a bare 0.0 that any penalty would tip negative.
+        let topic = gossipsub::IdentTopic::new(block_topic().to_string());
+        let (mut a, mut b) = (node(), node());
+        a.behaviour_mut().subscribe(&topic).expect("subscribe a");
+        b.behaviour_mut().subscribe(&topic).expect("subscribe b");
+
+        let addr: libp2p::Multiaddr = "/memory/515151".parse().expect("addr");
+        b.listen_on(addr.clone()).expect("listen");
+        let b_id = *b.local_peer_id();
+        a.dial(DialOpts::unknown_peer_id().address(addr).build())
+            .expect("dial");
+
+        let meshed = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                tokio::select! {
+                    _ = a.select_next_some() => {}
+                    _ = b.select_next_some() => {}
+                }
+                if a.behaviour().mesh_peers(&topic.hash()).any(|p| *p == b_id) {
+                    return;
+                }
+            }
+        })
+        .await;
+        assert!(meshed.is_ok(), "the two nodes should mesh");
+        assert!(
+            a.behaviour().peer_score(&b_id).is_some(),
+            "scoring must be active, or this test proves nothing"
+        );
+
+        // B stays alive but is never polled again, so its connection handler
+        // stops draining and A's per-peer send queue fills. Dropping B would
+        // close the connection instead, which is not the condition under test:
+        // on devnet-5 the peer stayed connected and kept serving Status.
+        let _b_parked = b;
+
+        let mut payload = vec![0u8; 4096];
+        let mut queues_full = 0usize;
+        let mut not_targeted = 0usize;
+        let mut first_not_targeted_at = None;
+        for nonce in 0u64..8_000 {
+            // Unique bytes per publish: the message id is a hash of topic and
+            // data, and `duplicate_cache_time` would otherwise dedupe these.
+            payload[..8].copy_from_slice(&nonce.to_le_bytes());
+            match a.behaviour_mut().publish(topic.clone(), payload.clone()) {
+                Ok(_) => {}
+                Err(gossipsub::PublishError::AllQueuesFull(_)) => queues_full += 1,
+                // Once the score falls under `publish_threshold`, `publish_peers`
+                // drops the peer from the candidate set, so there is no longer
+                // anyone to publish to and we stop even trying to enqueue.
+                Err(gossipsub::PublishError::NoPeersSubscribedToTopic) => {
+                    first_not_targeted_at.get_or_insert(queues_full);
+                    not_targeted += 1;
+                }
+                Err(err) => panic!("unexpected publish error: {err:?}"),
+            }
+        }
+        assert!(queues_full > 0, "the parked peer's queue should fill");
+
+        // `Event::SlowPeer` and the negative-score prune both run on the
+        // gossipsub heartbeat, and `heartbeat_initial_delay` defaults to 5s and
+        // is not overridden by `gossipsub_config`, so the window has to clear
+        // that before the first heartbeat runs at all.
+        let mut slow_peer_reports = 0usize;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let mut pruned = false;
+        while tokio::time::Instant::now() < deadline {
+            let step = tokio::time::timeout(Duration::from_millis(200), a.select_next_some()).await;
+            if let Ok(SwarmEvent::Behaviour(gossipsub::Event::SlowPeer { peer_id, .. })) = step {
+                assert_eq!(peer_id, b_id);
+                slow_peer_reports += 1;
+            }
+            if !a.behaviour().mesh_peers(&topic.hash()).any(|p| *p == b_id) {
+                pruned = true;
+                break;
+            }
+        }
+
+        let score = a.behaviour().peer_score(&b_id).expect("scored");
+        let still_connected = a.behaviour().all_peers().any(|(p, _)| *p == b_id);
+        println!(
+            "\n  AllQueuesFull rejections:   {queues_full}\
+             \n  publishes not even tried:   {not_targeted}\
+             \n  gave up targeting after:    {first_not_targeted_at:?} dropped messages\
+             \n  SlowPeer reports:           {slow_peer_reports}\
+             \n  peer score:                 {score}\
+             \n  pruned from mesh:           {pruned}\
+             \n  still connected:            {still_connected}\n"
+        );
+
+        assert!(
+            slow_peer_reports > 0,
+            "gossipsub should report the peer as slow"
+        );
+        assert!(
+            score < 0.0,
+            "the slow-peer penalty should drive the score negative, got {score}"
+        );
+        assert!(
+            pruned,
+            "the stalled peer should be pruned from the mesh so we stop feeding it"
+        );
+        assert!(
+            still_connected,
+            "scoring must not disconnect: the peer is still useful for request/response"
+        );
+        // The stronger property: we stop *attempting* to publish to it, which
+        // is what actually ends the `Send Queue full` flood. The crossing point
+        // is `publish_threshold / slow_peer_weight` = 8000 / 10 dropped
+        // messages, so at the ~33/s seen on devnet-5 a wedged peer stops being
+        // targeted about 24s in, rather than never.
+        assert!(
+            not_targeted > 0,
+            "past publish_threshold the peer should be dropped from the publish set"
+        );
+    }
+}

--- a/crates/net/p2p/src/gossipsub/scoring.rs
+++ b/crates/net/p2p/src/gossipsub/scoring.rs
@@ -496,11 +496,27 @@ mod tests {
             still_connected,
             "scoring must not disconnect: the peer is still useful for request/response"
         );
-        // The stronger property: we stop *attempting* to publish to it, which
-        // is what actually ends the `Send Queue full` flood. The crossing point
-        // is `publish_threshold / slow_peer_weight` = 8000 / 10 dropped
-        // messages, so at the ~33/s seen on devnet-5 a wedged peer stops being
-        // targeted about 24s in, rather than never.
+        // Past `publish_threshold` the peer also leaves the publish candidate
+        // set. Reaching it here is an artifact of this test publishing 8000
+        // times in a tight synchronous loop, with no `decay_interval` tick in
+        // between, so `slow_peer_penalty` accumulates unchecked to 800.
+        //
+        // It does NOT work that way against a live network. The penalty decays
+        // by `slow_peer_decay` every `decay_interval`, so it settles at
+        //
+        //     penalty_steady = rate * decay_interval / (1 - slow_peer_decay)
+        //     score_steady   = slow_peer_weight * penalty_steady
+        //
+        // which for our parameters is `-44.4 * rate`. Crossing
+        // `publish_threshold` therefore needs a sustained ~180 failed
+        // sends/second; the ~33/s measured on devnet-5 settles near -1500 and
+        // never gets there. So the publish gate is not the mechanism that ends
+        // the flood in production, and this assertion only pins the tight-loop
+        // behaviour. What ends it is the mesh prune below, which needs nothing
+        // more than a negative score: an A/B on a 6-node devnet cut dropped
+        // `Forward` RPCs by 99.2% (2441 -> 20) while dropped `Publish` stayed
+        // flat, because a network with fewer peers than `mesh_n` re-selects the
+        // pruned peer as a publish top-up in `filter_publish_candidates`.
         assert!(
             not_targeted > 0,
             "past publish_threshold the peer should be dropped from the publish set"

--- a/crates/net/p2p/src/gossipsub/scoring.rs
+++ b/crates/net/p2p/src/gossipsub/scoring.rs
@@ -14,12 +14,20 @@
 //! harsh slow-peer weights. Rates and decay horizons are re-derived for lean,
 //! which has no epochs and where every validator attests every slot.
 //!
-//! DEVIATION: `mesh_message_deliveries` is not configured. It is the only
-//! negative topic-level term, its weight is `-topic_weight`, and it punishes a
+//! DEVIATION: the `mesh_message_deliveries` terms are explicitly zeroed. They
+//! are the negative topic-level terms, weighted `-topic_weight`, that punish a
 //! peer for delivering fewer mesh messages than expected. Getting the expected
-//! rate wrong would drive healthy peers negative and prune them, which is the
-//! failure mode this scoring is meant to prevent. Lighthouse itself passes
-//! `None` for its low-rate topics. Left out until the rates are measured.
+//! rate wrong drives healthy peers negative and prunes them, which is the
+//! failure mode this scoring exists to prevent, so they stay off until lean's
+//! real rates are measured. Lighthouse does the same for its low-rate topics.
+//!
+//! Zeroing them has to be explicit. `TopicScoreParams::default()` ships
+//! `mesh_message_deliveries_weight: -1.0` with a threshold of 20 messages per
+//! 10ms window, activating 5s after a peer joins the mesh. No node can meet
+//! that, so leaving the fields at their defaults penalises every peer on a
+//! healthy network: a 6-node devnet run scored every peer between -20 and -67
+//! and pruned every mesh to empty. Lighthouse's `get_topic_params` has an
+//! `else` branch zeroing all eight fields for exactly this reason.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -163,6 +171,7 @@ pub fn params(topology: &ScoringTopology) -> PeerScoreParams {
             decay_interval,
             decay_to_zero,
             topology.mesh_n,
+            max_positive_score,
         ),
     );
 
@@ -176,6 +185,7 @@ pub fn params(topology: &ScoringTopology) -> PeerScoreParams {
             decay_interval,
             decay_to_zero,
             topology.mesh_n,
+            max_positive_score,
         ),
     );
 
@@ -194,6 +204,7 @@ pub fn params(topology: &ScoringTopology) -> PeerScoreParams {
                 decay_interval,
                 decay_to_zero,
                 topology.mesh_n,
+                max_positive_score,
             ),
         );
     }
@@ -202,7 +213,8 @@ pub fn params(topology: &ScoringTopology) -> PeerScoreParams {
     params
 }
 
-/// Mirrors lighthouse's `get_topic_params` with `mesh_message_info: None`.
+/// Mirrors lighthouse's `get_topic_params` with `mesh_message_info: None`,
+/// including its `else` branch.
 fn topic_params(
     topic_weight: f64,
     expected_message_rate: f64,
@@ -210,6 +222,7 @@ fn topic_params(
     decay_interval: Duration,
     decay_to_zero: f64,
     mesh_n: usize,
+    max_positive_score: f64,
 ) -> TopicScoreParams {
     let mut t = TopicScoreParams::default();
     t.topic_weight = topic_weight;
@@ -226,6 +239,24 @@ fn topic_params(
     );
     t.first_message_deliveries_weight =
         MAX_FIRST_MESSAGE_DELIVERIES_SCORE / t.first_message_deliveries_cap;
+
+    // P3 and P3b off. Every field must be zeroed, not merely left alone: see
+    // the module note on what `TopicScoreParams::default()` puts here.
+    t.mesh_message_deliveries_weight = 0.0;
+    t.mesh_message_deliveries_threshold = 0.0;
+    t.mesh_message_deliveries_decay = 0.0;
+    t.mesh_message_deliveries_cap = 0.0;
+    t.mesh_message_deliveries_window = Duration::ZERO;
+    t.mesh_message_deliveries_activation = Duration::ZERO;
+    t.mesh_failure_penalty_weight = 0.0;
+    t.mesh_failure_penalty_decay = 0.0;
+
+    // P4. Kept, and set to lighthouse's weight rather than the default -1.0:
+    // an invalid message is a protocol violation, and one is enough to cancel
+    // out everything a peer can earn.
+    t.invalid_message_deliveries_weight = -max_positive_score / topic_weight;
+    t.invalid_message_deliveries_decay =
+        score_parameter_decay(score_epoch() * 50, decay_interval, decay_to_zero);
 
     t
 }
@@ -287,6 +318,27 @@ mod tests {
             params.topics.len(),
             2 + topology.attestation_committee_count as usize
         );
+    }
+
+    #[test]
+    fn no_topic_carries_a_mesh_delivery_penalty() {
+        // Regression test for a real 6-node devnet failure. Leaving the P3/P3b
+        // fields at `TopicScoreParams::default()` enables them with a
+        // threshold of 20 messages per 10ms window, which no node can meet, so
+        // every peer on a healthy network went negative and every mesh emptied.
+        // Not configuring these is not the same as disabling them.
+        for (topic, t) in params(&topology()).topics {
+            assert_eq!(t.mesh_message_deliveries_weight, 0.0, "{topic}");
+            assert_eq!(t.mesh_message_deliveries_threshold, 0.0, "{topic}");
+            assert_eq!(t.mesh_failure_penalty_weight, 0.0, "{topic}");
+            assert_eq!(t.mesh_message_deliveries_window, Duration::ZERO, "{topic}");
+            // The positive terms must still be live, or peers never build the
+            // buffer that keeps a transient penalty from pruning them.
+            assert!(t.time_in_mesh_weight > 0.0, "{topic}");
+            assert!(t.first_message_deliveries_weight > 0.0, "{topic}");
+            // An invalid message must still cost more than a peer can earn.
+            assert!(t.invalid_message_deliveries_weight < 0.0, "{topic}");
+        }
     }
 
     #[test]

--- a/crates/net/p2p/src/lib.rs
+++ b/crates/net/p2p/src/lib.rs
@@ -38,7 +38,7 @@ use tracing::{debug, info, trace, warn};
 use crate::{
     gossipsub::{
         aggregation_topic, attestation_subnet_topic, block_topic, publish_aggregated_attestation,
-        publish_attestation, publish_block,
+        publish_attestation, publish_block, scoring,
     },
     req_resp::{
         BLOCKS_BY_RANGE_PROTOCOL_V1, BLOCKS_BY_ROOT_PROTOCOL_V1, Codec,
@@ -152,6 +152,55 @@ pub(crate) struct Behaviour {
     req_resp: request_response::Behaviour<Codec>,
 }
 
+/// The gossipsub configuration every node runs. Extracted from
+/// [`build_swarm`] so tests can exercise the real parameters rather than a
+/// hand-rolled approximation of them.
+pub(crate) fn gossipsub_config() -> libp2p::gossipsub::Config {
+    libp2p::gossipsub::ConfigBuilder::default()
+        // d
+        .mesh_n(GOSSIP_MESH_N)
+        // d_low
+        .mesh_n_low(6)
+        // d_high
+        .mesh_n_high(12)
+        // d_lazy
+        .gossip_lazy(6)
+        .heartbeat_interval(Duration::from_millis(700))
+        .fanout_ttl(Duration::from_secs(60))
+        .history_length(6)
+        .history_gossip(3)
+        // seen_ttl_secs = seconds_per_slot * justification_lookback_slots * 2
+        .duplicate_cache_time(Duration::from_secs(4 * 3 * 2))
+        .validation_mode(ValidationMode::Anonymous)
+        .message_id_fn(compute_message_id)
+        // Taken from ream
+        .max_transmit_size(MAX_COMPRESSED_PAYLOAD_SIZE)
+        .max_messages_per_rpc(Some(500))
+        .allow_self_origin(true)
+        .idontwant_message_size_threshold(1000)
+        // Flood publish (default: true) fans our own publishes out to every
+        // connected peer instead of just the mesh. The gossipsub v1.1 spec
+        // defines it as score-gated, and with scoring enabled below that gate
+        // is real, but the parameter stays off: neither leanSpec nor the
+        // Ethereum consensus-specs p2p interface asks for flooding, and both
+        // lighthouse and ream disable it.
+        //
+        // Only topics with more than `mesh_n` subscribed peers are affected,
+        // since below that the mesh-bounded path selects everyone anyway. That
+        // means `block` and `aggregation`, which every node subscribes to. An
+        // `attestation_N` topic is unaffected wherever its subnet has fewer
+        // than `mesh_n` subscribers. So this cuts egress bytes and does
+        // nothing for the per-peer send-queue entry count.
+        .flood_publish(false)
+        .build()
+        .expect("invalid gossipsub config")
+}
+
+/// Gossipsub `d`: the target mesh degree. Shared between the gossipsub config
+/// and the scoring parameters, which divide expected message rates by it to
+/// work out a peer's fair share of first deliveries.
+pub(crate) const GOSSIP_MESH_N: usize = 8;
+
 /// Configuration for building the libp2p swarm.
 ///
 /// INVARIANT: `subscription_subnets` is the fixed set of attestation subnets
@@ -169,6 +218,11 @@ pub struct SwarmConfig {
     pub bootnodes: Vec<Bootnode>,
     pub listening_socket: SocketAddr,
     pub validator_ids: Vec<u64>,
+    /// Validators in the whole network, from genesis. Distinct from
+    /// `validator_ids`, which are only this node's. Peer scoring needs the
+    /// network figure because the message rate a topic carries is a property
+    /// of the network, not of us.
+    pub network_validator_count: u64,
     pub attestation_committee_count: u64,
     /// Attestation subnets to subscribe to, precomputed via
     /// [`attestation_subscription_subnets`].
@@ -220,34 +274,24 @@ pub struct BuiltSwarm {
 pub fn build_swarm(
     config: SwarmConfig,
 ) -> Result<BuiltSwarm, libp2p::gossipsub::SubscriptionError> {
-    let gossipsub_config = libp2p::gossipsub::ConfigBuilder::default()
-        // d
-        .mesh_n(8)
-        // d_low
-        .mesh_n_low(6)
-        // d_high
-        .mesh_n_high(12)
-        // d_lazy
-        .gossip_lazy(6)
-        .heartbeat_interval(Duration::from_millis(700))
-        .fanout_ttl(Duration::from_secs(60))
-        .history_length(6)
-        .history_gossip(3)
-        // seen_ttl_secs = seconds_per_slot * justification_lookback_slots * 2
-        .duplicate_cache_time(Duration::from_secs(4 * 3 * 2))
-        .validation_mode(ValidationMode::Anonymous)
-        .message_id_fn(compute_message_id)
-        // Taken from ream
-        .max_transmit_size(MAX_COMPRESSED_PAYLOAD_SIZE)
-        .max_messages_per_rpc(Some(500))
-        .allow_self_origin(true)
-        .idontwant_message_size_threshold(1000)
-        .build()
-        .expect("invalid gossipsub config");
+    let gossipsub_config = gossipsub_config();
 
-    let gossipsub =
+    let mut gossipsub =
         libp2p::gossipsub::Behaviour::new(MessageAuthenticity::Anonymous, gossipsub_config)
             .expect("failed to initiate behaviour");
+
+    // Turn on peer scoring. Until this call gossipsub sits in
+    // `PeerScoreState::Disabled`, which makes its slow-peer penalty, its
+    // negative-score mesh prune and its publish/gossip gates all no-ops. See
+    // `gossipsub::scoring` for the parameters and how they were derived.
+    let scoring_topology = scoring::ScoringTopology {
+        network_validator_count: config.network_validator_count,
+        attestation_committee_count: config.attestation_committee_count,
+        mesh_n: GOSSIP_MESH_N,
+    };
+    gossipsub
+        .with_peer_score(scoring::params(&scoring_topology), scoring::thresholds())
+        .expect("invalid gossipsub peer score parameters");
 
     let req_resp = request_response::Behaviour::new(
         vec![
@@ -555,6 +599,33 @@ async fn handle_swarm_event(
             message @ libp2p::gossipsub::Event::Message { .. },
         )) => {
             gossipsub::handle_gossipsub_message(server, message).await;
+        }
+        SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(libp2p::gossipsub::Event::SlowPeer {
+            peer_id,
+            failed_messages,
+        })) => {
+            // Raised from the gossipsub heartbeat for every peer whose send
+            // queue rejected at least one message since the previous
+            // heartbeat, the same condition behind the `Send Queue full` WARN
+            // from `libp2p_gossipsub::behaviour`. Before this arm existed the
+            // event fell into the catch-all, so that WARN was the only trace
+            // of a peer we could not reach.
+            //
+            // Deliberately no disconnect. Lighthouse scales gossipsub's
+            // negative score contribution so it can never disconnect a peer on
+            // its own and leaves that to a separate application-level score we
+            // do not have. The reaction here is gossipsub's own: the scoring
+            // enabled in `build_swarm` charges `slow_peer_weight` per failed
+            // message, which drives the peer negative and lets the heartbeat
+            // prune it from the mesh. We only record it.
+            let priority = failed_messages.priority;
+            let non_priority = failed_messages.non_priority;
+            let node_name = server.resolve_node_name(Some(&peer_id));
+            metrics::observe_slow_peer(node_name, priority, non_priority);
+            // The resulting score is published by the periodic
+            // `lean_gossip_peer_score` refresh on the swarm task, which reads
+            // the behaviour directly instead of round-tripping a command.
+            debug!(%peer_id, priority, non_priority, "Slow gossipsub peer");
         }
         SwarmEvent::ConnectionEstablished {
             peer_id,

--- a/crates/net/p2p/src/metrics.rs
+++ b/crates/net/p2p/src/metrics.rs
@@ -251,3 +251,85 @@ pub fn update_gossip_mesh_peers<'a>(
             .set(count);
     }
 }
+
+/// Refresh the per-peer gossipsub score gauge.
+///
+/// Scores only exist once `with_peer_score` has been called; `peer_score`
+/// returns `None` for an unscored peer, and those are skipped rather than
+/// published as 0.0, so a missing series means scoring is off rather than a
+/// peer sitting at neutral.
+pub fn update_gossip_peer_scores<'a>(
+    scores: impl Iterator<Item = (&'a PeerId, f64)>,
+    node_names: &HashMap<PeerId, String>,
+) {
+    static LEAN_GOSSIP_PEER_SCORE: LazyLock<GaugeVec> = LazyLock::new(|| {
+        register_gauge_vec!(
+            "lean_gossip_peer_score",
+            "Current gossipsub score for each connected peer",
+            &["node_name"]
+        )
+        .unwrap()
+    });
+    for (peer_id, score) in scores {
+        let name = node_names
+            .get(peer_id)
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        LEAN_GOSSIP_PEER_SCORE.with_label_values(&[name]).set(score);
+    }
+}
+
+/// Record a gossipsub `Event::SlowPeer` report.
+///
+/// The event fires from the gossipsub heartbeat and carries the messages that
+/// failed to enqueue for that peer since the previous heartbeat, split by
+/// queue. `non_priority` covers Publish, Forward, IHave and IWant, which share
+/// one bounded queue sized by `connection_handler_queue_len`; `priority`
+/// covers the separate control queue, whose cap is hardcoded in the fork.
+pub fn observe_slow_peer(node_name: &str, priority: usize, non_priority: usize) {
+    static LEAN_GOSSIP_SLOW_PEER_REPORTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec!(
+            "lean_gossip_slow_peer_reports_total",
+            "Gossipsub SlowPeer events, one per heartbeat in which a peer failed to consume",
+            &["node_name"]
+        )
+        .unwrap()
+    });
+    static LEAN_GOSSIP_FAILED_MESSAGES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec!(
+            "lean_gossip_failed_messages_total",
+            "Messages that could not be enqueued for a peer, by queue",
+            &["node_name", "queue"]
+        )
+        .unwrap()
+    });
+    LEAN_GOSSIP_SLOW_PEER_REPORTS
+        .with_label_values(&[node_name])
+        .inc();
+    LEAN_GOSSIP_FAILED_MESSAGES
+        .with_label_values(&[node_name, "priority"])
+        .inc_by(priority as u64);
+    LEAN_GOSSIP_FAILED_MESSAGES
+        .with_label_values(&[node_name, "non_priority"])
+        .inc_by(non_priority as u64);
+}
+
+/// Record a gossipsub publish that never reached the wire.
+///
+/// Previously these were logged and discarded, so a node losing every publish
+/// looked identical to a healthy one in metrics. `reason` is the
+/// `PublishError` variant, which distinguishes total loss (`AllQueuesFull`,
+/// every recipient's queue was full) from the benign cases.
+pub fn inc_gossip_publish_failed(reason: &str) {
+    static LEAN_GOSSIP_PUBLISH_FAILED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec!(
+            "lean_gossip_publish_failed_total",
+            "Gossipsub publishes rejected before reaching the wire, by PublishError variant",
+            &["reason"]
+        )
+        .unwrap()
+    });
+    LEAN_GOSSIP_PUBLISH_FAILED
+        .with_label_values(&[reason])
+        .inc();
+}

--- a/crates/net/p2p/src/swarm_adapter.rs
+++ b/crates/net/p2p/src/swarm_adapter.rs
@@ -127,10 +127,12 @@ async fn swarm_loop(
                 execute_command(&mut swarm, cmd);
             }
             _ = mesh_metric_tick.tick() => {
-                metrics::update_gossip_mesh_peers(
-                    swarm.behaviour().gossipsub.all_mesh_peers(),
-                    &node_names,
-                );
+                let gossipsub = &swarm.behaviour().gossipsub;
+                metrics::update_gossip_mesh_peers(gossipsub.all_mesh_peers(), &node_names);
+                let scores = gossipsub.all_peers().filter_map(|(peer_id, _)| {
+                    gossipsub.peer_score(peer_id).map(|score| (peer_id, score))
+                });
+                metrics::update_gossip_peer_scores(scores, &node_names);
             }
         }
     }
@@ -144,7 +146,10 @@ fn execute_command(swarm: &mut libp2p::Swarm<Behaviour>, cmd: SwarmCommand) {
                 .behaviour_mut()
                 .gossipsub
                 .publish(topic, data)
-                .inspect_err(|err| debug!(%err, "Swarm adapter: publish failed"))
+                .inspect_err(|err| {
+                    metrics::inc_gossip_publish_failed(publish_error_kind(err));
+                    debug!(%err, "Swarm adapter: publish failed");
+                })
                 .ok();
         }
         SwarmCommand::Dial(addr) => {
@@ -173,5 +178,24 @@ fn execute_command(swarm: &mut libp2p::Swarm<Behaviour>, cmd: SwarmCommand) {
                 .send_response(channel, response)
                 .inspect_err(|response| debug!(%response, "Swarm adapter: send_response failed"));
         }
+    }
+}
+
+/// Stable label for a `PublishError`, keeping the publish-failure counter
+/// low-cardinality. `AllQueuesFull` is the variant that means real loss: every
+/// recipient's send queue was full, so the message never reached the wire.
+///
+/// Matched exhaustively on purpose, with no catch-all: the fork gates one more
+/// variant behind its `partial_messages` feature, and if that is ever enabled
+/// the compiler should point here rather than silently bucketing it.
+fn publish_error_kind(err: &libp2p::gossipsub::PublishError) -> &'static str {
+    use libp2p::gossipsub::PublishError;
+    match err {
+        PublishError::Duplicate => "duplicate",
+        PublishError::SigningError(_) => "signing_error",
+        PublishError::NoPeersSubscribedToTopic => "no_peers_subscribed",
+        PublishError::MessageTooLarge => "message_too_large",
+        PublishError::TransformFailed(_) => "transform_failed",
+        PublishError::AllQueuesFull(_) => "all_queues_full",
     }
 }


### PR DESCRIPTION
Supersedes #588, which is closed: the `flood_publish(false)` change is included here.

## Problem

A peer whose gossipsub send queue fills is never removed from our mesh, so every later publish and forward is attempted and dropped forever. On devnet-5 one node lost roughly **33 messages/second to one peer, at a flat rate, for over 12 hours**, while request/response to that same peer kept working throughout. 642k `Send Queue full` lines in one hour network-wide, and 64% of the dropped RPCs were real data:

| dropped RPC | 30 min | share |
|---|---:|---:|
| Forward | 80,949 | 37.5% |
| IDontWant | 73,477 | 34.0% |
| Publish | 58,218 | 27.0% |
| IHave | 2,857 | 1.3% |

## Why nothing reacted

Both reaction paths existed and both were dead, and both trace to never calling `with_peer_score`:

- gossipsub's own `failed_message_slow_peer` penalty sits behind a `PeerScoreState::Active` match arm that `Disabled` never takes.
- The heartbeat's negative-score mesh prune reads scores from an empty map, so `unwrap_or_default()` hands it `0.0` and `0.0 < 0.0` is never true.
- Separately, gossipsub *does* raise `Event::SlowPeer`, but `handle_swarm_event` only matched `Event::Message`, so it fell into the catch-all.

## What this does

| | |
|---|---|
| Peer scoring | `with_peer_score` with lighthouse's parameters. Everything topology-independent is copied unchanged, including the slow-peer weights it deliberately sets 50x harsher than the libp2p defaults (`-10.0` against `-0.2`). Rates and decay horizons are re-derived for lean, which has no epochs and where every validator attests every slot. |
| `Event::SlowPeer` | Handled, logged, metered per queue. |
| No disconnect | Nothing closes a connection. gossipsub owns no connection-close path, and lighthouse scales its contribution so a fully graylisted peer lands one point short of its own disconnect threshold. |
| Flood publish | Off (was #588). |
| Metrics | `lean_gossip_peer_score` per peer, `lean_gossip_slow_peer_reports_total`, `lean_gossip_failed_messages_total{queue}`, `lean_gossip_publish_failed_total{reason}`. |

## A/B on a 6-node devnet

One binary in both arms, scoring toggled by env var, so the comparison isolates scoring alone. One node `SIGSTOP`ped and **held for 360s** so it never resumed, with `max_idle_timeout` raised to 900s so QUIC never tore the connection down. `PEERS` stayed at 5 in both arms, confirming no disconnect confounded either result.

| | scoring off | scoring on | |
|---|---:|---:|---|
| dropped `Forward` | 2441 | **20** | **-99.2%** |
| dropped `Publish` | 610 | 648 | flat |
| dropped `IHave` | 0 | 3613 | new |
| mesh peers | 5 | **4** | pruned |
| connected peers | 5 | 5 | never disconnected |
| WARN slope | linear ~9/s, 270s, no plateau | linear, no plateau | |

**The mesh prune is the mechanism and it works.** `Forward` targets only mesh members, so pruning removed 99.2% of the dropped payload — and `Forward` is the single largest category on devnet-5.

**Total WARN count goes up, not down.** A pruned peer becomes a lazy-gossip target and collects `IHave` every heartbeat. So raw `Send Queue full` count is the wrong success metric; the RPC-kind split is the right one. Reviewers watching only the log volume will think this made things worse.

**Dropped `Publish` stayed flat** because `filter_publish_candidates` tops the mesh up to `mesh_n` with random extras that are not re-checked against mesh membership. With 5 peers and `mesh_n` of 8 the mesh can never be full, so the pruned peer is re-selected on every publish. Networks with more peers than `mesh_n` should not see this — but that is an inference from the code, not something this devnet can show.

## Two claims I had wrong

**The publish gate does not end this flood.** `slow_peer_penalty` decays every `decay_interval`, so it settles rather than accumulating:

```
penalty_steady = rate * decay_interval / (1 - slow_peer_decay)
score_steady   = slow_peer_weight * penalty_steady   =  -44.4 * rate
```

Crossing `publish_threshold` needs a sustained **~180 failed sends/second**. devnet-5's ~33/s settles near -1500 and never approaches it. The unit test reaches 800 only because it publishes in a tight synchronous loop with no decay tick in between; that is an artifact of the test and is now documented as one.

**An earlier single-arm run was confounded.** With `max_idle_timeout` at 120s, the connection died at exactly t+120s, which is also when the flood stopped and when mesh went 5->4. I had read that as the score prune. The rerun above raises the timeout and samples `PEERS` every interval so a disconnect can never be misread as a prune again.

## Deviation worth reviewing

The `mesh_message_deliveries` terms (P3/P3b) are **explicitly zeroed**, and the second commit exists because they weren't. `TopicScoreParams::default()` ships `mesh_message_deliveries_weight: -1.0` with a threshold of 20 messages per **10ms** window. Not configuring those fields does not disable them, it enables them with parameters no node can satisfy. Lighthouse's `get_topic_params` has an `else` branch zeroing all eight for exactly this reason.

The healthy 6-node run caught it, and no unit test would have:

| | before fix | after fix |
|---|---|---|
| mesh peers | **0/5 on every node** | 5/5 |
| peer scores | **-20 to -67** | +29 to +37 |
| finality | advancing | advancing |

Finality kept advancing either way, because an empty mesh still gets topped up with random peers. The failure was invisible in head, justified and finalized, which is why there is now a test pinning those eight fields.

## What is still unverified

Reproducing the trigger needed three temporary overrides, none on this branch: `max_stream_data` 10MB -> 64KiB, `connection_handler_queue_len` 5000 -> 100, `max_idle_timeout` 10s -> 900s. Plain stalls produce nothing, because **QUIC's default 10MB per-stream window absorbs ~10,000 undelivered messages before back-pressure reaches the gossipsub queue at all.**

A 6-node/6-validator devnet offers well under 1 message/sec per peer, roughly three orders of magnitude below devnet-5. So the `Publish` behaviour at real scale, and whether a full 8-member mesh avoids the top-up, are both inferences.

Falsifiable prediction for a devnet-5 canary: dropped `Forward` should collapse on the affected node, `lean_gossip_mesh_peers` should drop by one, `lean_gossip_slow_peer_reports_total` should become non-zero, `IHave` drops should rise, and peer counts and finality should not move.

`make fmt`, `make lint` and the full workspace test suite pass.
