### PR TITLE
fix(blockchain): make proof selection tie-breaking deterministic

### DIFF
--- a/crates/blockchain/src/block_builder.rs
+++ b/crates/blockchain/src/block_builder.rs
@@ -806,10 +806,14 @@ fn extend_proofs_greedily(
     }
 
     let mut covered: HashSet<u64> = HashSet::new();
-    let mut remaining_indices: HashSet<usize> = (0..proofs.len()).collect();
+    let mut remaining_indices: Vec<usize> = (0..proofs.len()).collect();
 
     while !remaining_indices.is_empty() {
-        // Pick proof covering the most uncovered validators (count only, no allocation)
+        // Pick proof covering the most uncovered validators (count only, no
+        // allocation). Coverage ties break to the lowest index (pool insertion
+        // order): a HashSet here would let hash-iteration order pick an
+        // arbitrary equal-coverage winner, making the built block's
+        // aggregation bits differ from run to run.
         let best = remaining_indices
             .iter()
             .map(|&idx| {
@@ -819,7 +823,7 @@ fn extend_proofs_greedily(
                     .count();
                 (idx, count)
             })
-            .max_by_key(|&(_, count)| count);
+            .max_by_key(|&(idx, count)| (count, Reverse(idx)));
 
         let Some((best_idx, best_count)) = best else {
             break;
@@ -846,7 +850,7 @@ fn extend_proofs_greedily(
 
         covered.extend(new_covered);
         selected.push((att, proof.clone()));
-        remaining_indices.remove(&best_idx);
+        remaining_indices.retain(|&idx| idx != best_idx);
     }
 }
 
@@ -1957,5 +1961,32 @@ mod tests {
         assert_eq!(selected.len(), 1);
         let covered: HashSet<u64> = selected[0].1.participant_indices().collect();
         assert_eq!(covered, HashSet::from([0, 1, 2, 3]));
+    }
+
+    /// Equal-coverage proofs must be selected in pool order, so that the same
+    /// pool always yields the same block. Iterating a `HashSet` of candidate
+    /// indices made the winner depend on hash order, which varies per process.
+    #[test]
+    fn extend_proofs_greedily_breaks_coverage_ties_by_pool_order() {
+        let data = make_att_data(1);
+
+        // Six proofs of identical coverage size, disjoint so that every round
+        // is again a six-way tie: selection order is decided purely by the
+        // tie-break, and must follow the order they sit in the pool. Six of
+        // them rather than two so an arbitrary order cannot match pool order
+        // by luck (1 in 720 rather than 1 in 2).
+        let proofs: Vec<SingleMessageAggregate> = (0..6)
+            .map(|group| SingleMessageAggregate::empty(make_bits(&[group * 2, group * 2 + 1])))
+            .collect();
+
+        let mut selected = Vec::new();
+        extend_proofs_greedily(&proofs, &mut selected, &data);
+
+        let order: Vec<Vec<u64>> = selected
+            .iter()
+            .map(|(_, proof)| proof.participant_indices().collect())
+            .collect();
+        let pool_order: Vec<Vec<u64>> = (0..6).map(|g| vec![g * 2, g * 2 + 1]).collect();
+        assert_eq!(order, pool_order);
     }
 }


### PR DESCRIPTION
## 🗒️ Description / Motivation

`extend_proofs_greedily` kept its remaining candidate proofs in a `HashSet<usize>` and
picked the best-coverage proof with `max_by_key` over the set's randomized iteration
order, so equal-coverage ties were broken arbitrarily per process: the same store state
could produce blocks with different aggregation bits from one run to the next.

Found while building the offline block-building benchmark (#497), whose same-seed
determinism check reported differing block roots across runs of an identical workload.
Split out of that PR because it is a standalone node-behavior fix, unrelated to the
harness.

## What Changed

| File | Change |
|------|--------|
| `crates/blockchain/src/block_builder.rs` | `remaining_indices` is a `Vec<usize>` iterated in index order; coverage ties break toward the lowest index (pool insertion order) via `max_by_key((count, Reverse(idx)))` |

## Correctness / Behavior Guarantees

- Selection quality is unchanged: the greedy still picks maximum marginal coverage
  every round. Only the choice *among equal-coverage candidates* changes, and that
  choice was previously random.
- Block building is now reproducible for a given pool, which is what makes a
  baseline-vs-optimized benchmark comparison meaningful.

## Tests Added / Run

- `extend_proofs_greedily_breaks_coverage_ties_by_pool_order`: six disjoint proofs of
  identical coverage, so every round is again a six-way tie and selection order is
  decided purely by the tie-break. An arbitrary order cannot match pool order by luck
  (1 in 720); against the previous code the test fails on most runs.
- `make fmt`, `make lint`, `make test` — all clean.

## Related Issues / PRs

- Split out of #497
- Related to #465

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing
