### PR TITLE
docs: document the block-building benchmark

### DIFF
--- a/bin/ethlambda/src/benchmark/mod.rs
+++ b/bin/ethlambda/src/benchmark/mod.rs
@@ -6,8 +6,8 @@
 //! and the slot-alignment sleep are outside the measured span, matching the
 //! node's own `lean_block_building_time_seconds` boundary.
 //!
-//! See docs/plans/block-building-benchmark.md for the design and roadmap
-//! (real-crypto pools and replay-from-datadir land in later milestones).
+//! See docs/benchmarking.md for what is and is not measured, how to read a
+//! report, and the current limitations.
 
 mod corpus;
 mod report;

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,4 +23,5 @@
 
 # Development
 
+- [Benchmarking](./benchmarking.md)
 - [Spec Deviations](./spec_deviations.md)

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -6,8 +6,7 @@ it proposes, against a reproducible synthetic workload, with no devnet running.
 Block building is otherwise only observable through the Prometheus histograms a
 live node exports. Those are noisy, depend on whatever the network happened to
 be doing, and cannot be diffed against a baseline — which makes them a poor
-instrument for the work tracked in
-[#465](https://github.com/lambdaclass/ethlambda/issues/465). The benchmark
+instrument for tracking performance. The benchmark
 trades network realism for repeatability: the same parameters produce the same
 blocks every run, so two reports differ only where the code differs.
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,138 @@
+# Benchmarking block building
+
+`ethlambda benchmark` measures block building the way the node performs it when
+it proposes, against a reproducible synthetic workload, with no devnet running.
+
+Block building is otherwise only observable through the Prometheus histograms a
+live node exports. Those are noisy, depend on whatever the network happened to
+be doing, and cannot be diffed against a baseline — which makes them a poor
+instrument for the work tracked in
+[#465](https://github.com/lambdaclass/ethlambda/issues/465). The benchmark
+trades network realism for repeatability: the same parameters produce the same
+blocks every run, so two reports differ only where the code differs.
+
+## Running it
+
+```bash
+make bench                                  # defaults, mock crypto
+BENCH_ARGS="synthetic --iterations 50" make bench
+```
+
+`make bench` is a thin wrapper. The binary takes the same arguments directly:
+
+```bash
+ethlambda benchmark synthetic --mock-crypto --num-validators 8 --iterations 10
+```
+
+A default mock run finishes in well under a second, which is why CI can afford
+to run one on every pull request.
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--num-validators` | `8` | Validators in the synthetic genesis |
+| `--warmup-slots` | `8` | Unmeasured slots built first, so measured builds run on a state with realistic historical roots and justifications |
+| `--iterations` | `10` | Measured builds, one block each |
+| `--proofs-per-data` | `1` | Aggregates seeded per `AttestationData`, mimicking committee aggregators over disjoint validator subsets |
+| `--seed` | `42` | Seed for the validator set; fixes the whole run |
+| `--mock-crypto` | off | Placeholder proofs instead of real XMSS/leanVM signatures. **Currently required** — see [Limitations](#limitations) |
+| `--enable-proposer-aggregation` | off | Mirrors the node flag: collapse same-data proofs via recursive leanVM aggregation |
+| `--max-attestations-per-block` | `3` | Mirrors the node flag: distinct `AttestationData` per block |
+| `--format` | `human` | `human` or `json` |
+| `--output <path>` | — | Also write the JSON report to a file |
+
+Logs go to stderr and the report to stdout, so `--format json` pipes straight
+into `jq`.
+
+## What it measures
+
+Each iteration enters `produce_block_with_signatures` — the same function
+`BlockChainServer::propose_block` calls — and the harness reports the phases
+inside it:
+
+| Phase | Work |
+| --- | --- |
+| `select_payloads` | Choosing which attestations go in the block |
+| `compact` | Collapsing or picking among proofs for the same data |
+| `stf_simulate` | The state transition that seals `state_root` |
+| `overhead` | The rest of the measured span: tick processing, attestation promotion, fork-choice head, pool clone |
+| `wall` | The whole span |
+
+`overhead` is `wall` minus the sum of the phases, so the columns add up by
+construction.
+
+Deliberately **outside** the measured span, matching the boundary of the node's
+own `lean_block_building_time_seconds` metric: gossip publish, the
+slot-alignment sleep, and importing the block that was just built. The import
+still happens between iterations — otherwise every iteration would build on the
+same head and `process_slots` would get more expensive as the run went on.
+
+Phase times come from the sample sums of the existing
+`lean_block_proposal_attestation_build_phase_seconds` histogram, read before and
+after each build. Histogram sums accumulate raw f64 seconds, so the difference
+between two readings is the elapsed phase time and bucket boundaries play no
+part. Nothing is added to the hot path for the benchmark's benefit. The harness
+asserts each phase was observed exactly once per build and fails the run
+otherwise, because a mis-attributed report is worse than no report.
+
+## Reading a report
+
+```
+Block-building benchmark — synthetic workload (mock crypto)
+  validators=8 warmup_slots=8 iterations=10 proofs_per_data=1 seed=42
+  enable_proposer_aggregation=false max_attestations_per_block=3
+  ethlambda/v0.1.0/aarch64-apple-darwin/rustc-v1.97.1 leansig=15cbdd43 leanvm=e2592df4 os=macos arch=aarch64 threads=14
+
+  iter           compact  select_payloads     stf_simulate   overhead       wall         root
+  1              0.000ms          0.002ms          0.015ms    0.068ms    0.085ms   0x7282cc99
+  ...
+
+  phase              count        min       mean        p50        p90        max
+  select_payloads       10    0.002ms    0.002ms    0.002ms    0.003ms    0.003ms
+  ...
+```
+
+Every measured iteration gets its own row, and the summary follows below it.
+Outliers are never discarded: XMSS signing and OTS window advancement produce
+legitimate heavy tails, and hiding them would misrepresent the thing being
+measured. A coefficient of variation above 10% is flagged so a noisy run is not
+mistaken for a result.
+
+Percentiles are nearest-rank, without interpolation. Sample counts here are
+small, so an actual observed value is more informative than a blend of two
+neighbours.
+
+The `root` column is the block root of each built block. It is what makes a
+before/after comparison trustworthy: if an optimization leaves the root
+sequence unchanged, it changed only speed and not which attestations were
+selected. If the roots move, the change altered block contents and the timing
+comparison means something different than intended.
+
+## Comparing two runs
+
+Same seed and same parameters produce identical root sequences, so a baseline
+and a candidate can be diffed directly. The header line exists to tell you when
+they *cannot* be compared:
+
+- `leansig` and `leanvm` are the resolved revisions the binary was built
+  against, read from `Cargo.lock` at build time. leanSig tracks a moving branch
+  and leanVM performs the signature aggregation, so either one moving changes
+  the measured crypto.
+- `os`, `arch` and `threads` change results across machines.
+
+Two reports that disagree on any of those are not measuring the same thing.
+
+## Limitations
+
+- **`--mock-crypto` is required.** Real XMSS/leanVM pools are not wired up yet,
+  so the run measures selection, compaction and the state transition — not
+  signing or aggregation.
+- **The seal phase is not measured.** Signing, type-1 wrapping and type-2
+  merging happen after the measured span and are not reported.
+- **Synthetic workloads only.** Replaying a real datadir is not implemented, so
+  results reflect a synthetic chain rather than a deep production state.
+
+## In CI
+
+The Test job runs a short mock benchmark and asserts the JSON report's shape
+(`schema_version`, one sample per iteration). It costs seconds, and it means a
+change to the report contract cannot land unnoticed.

--- a/docs/plans/block-building-benchmark.md
+++ b/docs/plans/block-building-benchmark.md
@@ -1,0 +1,159 @@
+# Plan: `ethlambda benchmark` — offline block-building benchmark sub-command
+
+## Context
+
+The README roadmap lists **"Optimize block building" (issue #465)** as the top near-term
+priority, but block building is only observable today through Prometheus histograms on a
+live devnet — there is no reproducible, offline way to measure it or to compare an
+optimization against a baseline. This adds an `ethlambda benchmark` sub-command that
+drives the exact production proposer code path against controlled workloads.
+
+Fixed scope decisions: offline harness; synthetic **and** replay-from-datadir workloads;
+real XMSS/leanVM crypto by default with a mock fast mode.
+
+## What gets measured
+
+The proposer pipeline as executed at interval 4, entered through the same functions the
+actor calls:
+
+```
+produce_block_with_signatures (crates/blockchain/src/store.rs:788)   ← already public
+  ├─ preamble: on_tick → interval 0, promote attestations,
+  │            fork-choice head, pool deep-clone      → reported as derived "build_overhead"
+  └─ build_block: select_payloads → compact → stf_simulate
+seal_block (extracted from crates/blockchain/src/lib.rs:504-631, see refactor)
+  └─ sign → wrap_proposer_type1 (leanVM) → merge_type_2 (leanVM)
+```
+
+**Excluded** (same boundary as the node's own `time_block_building` metric): gossip
+publish, slot-alignment sleep, block import.
+
+**Phase capture with zero hot-path changes**: the existing
+`lean_block_proposal_attestation_build_phase_seconds` HistogramVec accumulates exact f64
+sums, observed exactly once per phase per build — the harness deltas per-label sums
+between iterations (prometheus 0.14 exposes `get_sample_sum()`, readable in-process).
+Guards: assert per-phase count advanced by exactly 1, and warn if `wall − Σphases`
+exceeds 2%.
+
+**Statistics**: warmup 3 + 10 iterations (defaults, configurable); min/mean/p50/p90/max +
+CV>10% warning per phase; raw samples always exported; outliers never auto-discarded
+(XMSS rejection-sampling and OTS window advancement produce legitimate tails). Each
+iteration records `block.hash_tree_root()` — diffing root sequences between baseline and
+optimized runs proves an optimization changed only speed, not attestation selection.
+
+## CLI (verified on clap 4.6.1)
+
+Every existing flat invocation (devnet skills, Dockerfile, lean-quickstart) parses
+byte-for-byte unchanged.
+
+- `command.rs` (new) owns dispatch, and `cli.rs` keeps the exact shape it had: a leading
+  `node` or `benchmark` token is removed before parsing, and the untouched `CliOptions`
+  parser then sees the very same arguments as before for every other form. Its seven
+  required arguments stay plain `PathBuf`/`String`, so clap's own missing-argument errors
+  are preserved without an `Option<T>` to unwrap anywhere.
+
+  The rejected alternative was clap's `subcommand_negates_reqs` +
+  `args_conflicts_with_subcommands` with `command: Option<Command>` on `CliOptions`. It
+  works, but forces all seven required arguments to `Option<T>` — `negates_reqs` lifts
+  only the *requirement check*, while the derive still fails extracting a non-`Option`
+  field that the command line never supplied — which means an unwrap helper on the node
+  path for an invariant clap already enforces. Reviewers pushed back on that churn in
+  #497, and it buys nothing the token dispatch does not.
+- `benchmark` parses through its own `clap::Parser` (`BenchmarkCommand`), so harness
+  arguments never enter `CliOptions` at all. Its argv[0] is rewritten to
+  `ethlambda benchmark` so usage lines name the sub-command that owns them.
+- Because the tokens never reach clap, they would be absent from `--help`; `cli.rs`
+  carries one `after_help` line listing both, sourced from a const `command.rs` owns.
+- `main.rs`: `main` is synchronous and matches on the invocation. The node path keeps the
+  `#[tokio::main]` attributes on `run_node`; the benchmark runs on the main thread and
+  never starts the runtime.
+
+```
+ethlambda benchmark synthetic  --num-validators 8 --warmup-slots 8
+                               --proofs-per-data 1 --seed 42 [--key-cache-dir <dir>]  # cache: M2
+ethlambda benchmark replay     --data-dir <path> --genesis config.yaml [--no-copy]
+                               [--validators … --hash-sig-keys-dir … --node-id …]  # enables seal
+common:  --iterations 10 --mock-crypto --enable-proposer-aggregation
+         --max-attestations-per-block 3 --format human|json --output <path>
+```
+
+Implementation refinements (M1): there is no `--pool-datas` knob — the pool
+accumulates one distinct `AttestationData` per elapsed slot naturally, exactly
+as on a live node, and per-sample `pool_entries` makes the growth visible.
+`--proofs-per-data` defaults to 1 (a single full-coverage aggregate per data,
+what a committee aggregator emits) so justification/finalization advance every
+slot; higher values exercise multi-proof selection but stall justification
+without proposer aggregation — the real coverage cost of that node flag.
+Warmup slots double as chain advancement, so there is no separate warmup-
+iterations knob.
+
+Known pre-existing issue (unrelated): `lean-quickstart/client-cmds/ethlambda-cmd.sh`
+still uses `--custom-network-config-dir`, removed in #321 — needs an upstream fix.
+
+## Harness design (`bin/ethlambda/src/benchmark/{mod,keys,corpus,report}.rs`)
+
+- **Iteration model**: slots advance monotonically, proposer rotates `slot % N` (matches
+  round-robin `is_proposer`); each built block is imported via
+  `on_block_without_verification` so the empty-slot gap stays constant; the pool is
+  re-seeded per iteration in fixed seeded order (insertion order pins proof choice).
+- **Keys**: seeded in-process keygen, cached on disk keyed by (leansig rev, seed, index,
+  role). Minimal-window keygen costs ~1s/key in release (verified empirically; the window
+  floors at 131,072 epochs — ample for thousands of bench slots; the 2^32 lifetime is
+  fixed in the type and unaffected). Arbitrary N, no Docker, no fixture download.
+- **Synthetic corpus**: `State::from_genesis` + `InMemoryBackend`; K warmup blocks; pool
+  = attestations from the last `--pool-datas` slots × `--proofs-per-data` real type-1
+  proofs via `aggregate_signatures` (built outside the timed span, progress on stderr).
+- **`--mock-crypto`**: empty proofs, forces the `keep_best` path (clap `conflicts_with
+  --enable-proposer-aggregation`, since `compact` invokes the real prover), seal skipped
+  and reported as null-not-zero. Runs in seconds → CI smoke test.
+- **Replay (v1 scope)**: copies the datadir before opening (mandatory — `on_tick`/head
+  updates write Metadata per interval and RocksDB has no read-only mode; `--no-copy`
+  opt-out with a warning). Loads via `Store::from_db_state`, builds at head+1. Pools are
+  in-memory-only and unrecoverable from disk, so v1 replay measures selection + STF +
+  state-root realism on real deep states; supplying the node's key trio additionally
+  enables the seal phases. Type-2 splitting / pool recording = deferred future work.
+- **Report**: human table + `--format json` (stdout pipe-clean, logs to stderr) with
+  `schema_version`, environment (CPU model, cores, OS, ethlambda rev via vergen, leansig
+  lock rev via a small `build.rs` Cargo.lock parse — leansig tracks the moving `devnet4`
+  branch), full params + seed, per-iteration raw samples. One configuration per process
+  invocation (global cumulative histograms, rayon/prover state).
+
+## The one library refactor
+
+Extract `crates/blockchain/src/lib.rs:504-631` (proposer sign → type-1 wrap → pubkey
+resolution → type-2 merge) into `pub fn seal_block(...) -> Result<SignedBlock,
+SealBlockError>` in the blockchain crate; `propose_block` calls it. Justified: the
+benchmark cannot reach these phases otherwise (a bin-side copy would drift), it collapses
+six repeated error-return-with-metric blocks into one `match` (net-negative LOC), and
+adding `sign`/`wrap_proposer_type1`/`merge_type_2` labels to the existing phase histogram
+gives production dashboards the currently-untimed expensive steps issue #465 targets.
+Verbatim move, own commit, devnet smoke before merge. `build_block` stays `pub(crate)`.
+
+## Milestones
+
+| | Deliverable | Files |
+|---|---|---|
+| **M1** — CLI + mock end-to-end | `ethlambda benchmark synthetic --mock-crypto` runs in seconds; table + JSON; flat-invocation compat tests; `make bench`; CI smoke step in the existing Test job. Includes one small library fix found by the determinism gate: `extend_proofs_greedily` kept its candidate set in a `HashSet`, so equal-coverage proof ties were broken by randomized hash order and block contents differed run to run — ties now break to the lowest pool index | `cli.rs`, `main.rs`, `benchmark/{mod,corpus,report}.rs`, `build.rs` (leansig rev), `Makefile`, `ci.yml`, `block_builder.rs` (tie-break) |
+| **M2** — real crypto | `seal_block` extraction (first commit) + 3 new phase labels; seeded keygen + cache; real type-1 pools; all 7 phases measured; first baseline JSON recorded | `crates/blockchain/src/{seal.rs,lib.rs,metrics.rs}`, `benchmark/keys.rs`, `types/src/signature.rs` (keygen wrapper) |
+| **M3** — replay + docs | replay mode against a devnet-runner datadir; `docs/benchmarking.md` + `SUMMARY.md` + README roadmap line | `benchmark/corpus.rs`, docs |
+
+One PR per milestone; `make fmt/lint/test` before each; M2 additionally gated by a devnet
+smoke via `test-branch.sh`.
+
+## Verification
+
+- clap `try_parse_from` tests: flat invocation parses, missing-arg errors preserved,
+  `benchmark` parses without node args, mixed invocation rejected.
+- Determinism: two same-seed runs produce identical per-iteration block-root sequences.
+- Accounting: Σphases ≥ 98% of wall per iteration, per-phase count deltas == 1.
+- CI mock smoke: `benchmark synthetic --mock-crypto --num-validators 4 --iterations 3
+  --format json | jq -e '.schema_version == 1'`.
+
+## Main risks
+
+- Real-mode setup cost: iterations × pool proofs of leanVM proving → default real run
+  takes minutes (mitigated: mock mode, small defaults, ETA logging, key cache).
+- `seal_block` extraction touches consensus-critical `propose_block` — verbatim
+  extraction, careful review of the six error branches, devnet smoke.
+- Cross-run comparability: rayon-parallel proving is machine/load-sensitive and leansig
+  is a moving branch — the env block in every report is the guard, not a fix.


### PR DESCRIPTION
## 🗒️ Description / Motivation

Documents the block-building benchmark: what it measures, how to run it, how to read a
report, and what it cannot do yet.

This replaces the design plan this PR originally carried. Per review, a `docs/plans/`
file written as "this is how the benchmark was originally designed" goes stale the moment
the benchmark changes and then actively misleads, so the page now describes the tool
rather than a schedule for building it. The plan served its purpose — it was the shared
reference while #595 and #596 were reviewed — and is not something the tree should keep.

> **Restacked.** Now based on #596, so the page documents behaviour that actually exists
> rather than behaviour that is still in review. Base moves to `main` once the two land.

## What Changed

| File | Change |
|------|--------|
| `docs/benchmarking.md` | New. Running it (flag table with defaults), what the measured span includes and deliberately excludes, how phase times come from the existing histogram, reading the per-iteration and summary tables, comparing two runs, current limitations, the CI smoke step |
| `docs/SUMMARY.md` | Listed under Development |
| `docs/plans/block-building-benchmark.md` | Removed |
| `bin/ethlambda/src/benchmark/mod.rs` | Module doc points at the new page |

## Correctness / Behavior Guarantees

Documentation only — the one code change is a doc-comment path.

Two things the plan file never stated, both of which a reader needs:

- **When two reports may not be compared at all.** The header carries the resolved
  leanSig and leanVM revisions plus the machine fields; leanSig tracks a moving branch
  and leanVM performs the aggregation, so either one moving changes the measured crypto.
- **What is not supported yet** — real crypto, the seal phase, replay from a datadir —
  written as current limitations rather than as milestones, so the page does not promise
  a schedule it cannot keep.

## Tests Added / Run

- `make docs` builds the site with the new page in place; no dangling references to the
  removed plan file anywhere in the tree.
- `make fmt`, `make lint`, `make test` (622 tests) — all clean.

## Related Issues / PRs

- Stacked on #596, which stacks on #595
- Related to #465

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [x] Ran `make test` (`cargo test --workspace --profile release-fast`) — all passing
