### PR TITLE
fix: align Lean justifiability overflow semantics

### DIFF
--- a/crates/blockchain/state_transition/src/lib.rs
+++ b/crates/blockchain/state_transition/src/lib.rs
@@ -503,8 +503,8 @@ pub fn slot_is_justifiable_after(slot: u64, finalized_slot: u64) -> bool {
 /// funnel votes towards only some slots, increasing finalization chances.
 ///
 /// When the `lean-ffi` feature is enabled, this calls the formally verified
-/// Lean4 implementation via FFI. The Lean implementation has been proven correct
-/// for all natural numbers (see `formal/EthLambda/Justifiability/`).
+/// Lean4 implementation via FFI. Its equivalence theorem covers deltas below
+/// `2^62`, the range where the pronic discriminant fits in `u64`.
 ///
 /// Without the feature, uses the native Rust implementation.
 #[cfg(not(feature = "lean-ffi"))]

--- a/formal/EthLambda/Justifiability.lean
+++ b/formal/EthLambda/Justifiability.lean
@@ -33,12 +33,16 @@ def isqrt (n : UInt64) : UInt64 :=
     -- r+1 ≤ n/(r+1)  ↔  (r+1)*(r+1) ≤ n  (when r+1 > 0)
     if r + 1 <= n / (r + 1) then r + 1 else r
 
-/-- Computable justifiability check mirroring the Rust implementation. -/
+/-- Computable justifiability check mirroring Rust's checked arithmetic.
+    The pronic discriminant is evaluated only when `4 * delta + 1` fits in
+    `UInt64`; otherwise that branch returns `false`. -/
 def justifiable (delta : UInt64) : Bool :=
   delta <= 5
     || isqrt delta ^ 2 == delta
-    || (let val := 4 * delta + 1
-        isqrt val ^ 2 == val && val % 2 == 1)
+    || if delta <= 4611686018427387903 then
+         let val := 4 * delta + 1
+         isqrt val ^ 2 == val && val % 2 == 1
+       else false
 
 /-- Full slot-level function matching the Rust `slot_is_justifiable_after` API. -/
 def slotIsJustifiableAfter (slot finalizedSlot : UInt64) : Bool :=

--- a/formal/EthLambdaProofs/Justifiability.lean
+++ b/formal/EthLambdaProofs/Justifiability.lean
@@ -5,3 +5,4 @@ import EthLambdaProofs.Justifiability.Classification
 import EthLambdaProofs.Justifiability.Infinite
 import EthLambdaProofs.Justifiability.Density
 import EthLambdaProofs.Justifiability.ImplEquivalence
+import EthLambdaProofs.Justifiability.Regression

--- a/formal/EthLambdaProofs/Justifiability/ImplEquivalence.lean
+++ b/formal/EthLambdaProofs/Justifiability/ImplEquivalence.lean
@@ -401,6 +401,12 @@ private lemma uint64_sq_toNat (a : UInt64) (ha : a.toNat < 2 ^ 32) :
 theorem justifiable_equiv (d : UInt64) (h : d.toNat < 2 ^ 62) :
     justifiable d = true ↔ Justifiable d.toNat := by
   rw [justifiable_iff]
+  have hguard : d ≤ 4611686018427387903 := by
+    apply UInt64.le_iff_toNat_le_toNat.mpr
+    have hlimit : (4611686018427387903 : UInt64).toNat = 2 ^ 62 - 1 := by
+      decide
+    rw [hlimit]
+    omega
   -- Bounds for 4 * d + 1 not overflowing
   have hval_nat : (4 * d + 1).toNat = 4 * d.toNat + 1 := by
     have h4_eq : (4 : UInt64).toNat = 4 := by decide
@@ -427,7 +433,8 @@ theorem justifiable_equiv (d : UInt64) (h : d.toNat < 2 ^ 62) :
     simp [UInt64.toNat_one]
   -- Unfold justifiable and convert Bool to Prop
   unfold justifiable
-  simp only [Bool.or_eq_true, Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
+  simp only [hguard, ↓reduceIte, Bool.or_eq_true, Bool.and_eq_true,
+    decide_eq_true_eq, beq_iff_eq]
   -- The let binding in justifiable introduces `val := 4 * d + 1`; after simp, it becomes
   -- direct UInt64 expressions that we can rewrite with our bridge lemmas
   constructor

--- a/formal/EthLambdaProofs/Justifiability/Regression.lean
+++ b/formal/EthLambdaProofs/Justifiability/Regression.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 ethlambda contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import EthLambda.Justifiability
+
+/-!
+# Fixed-Width Arithmetic Regression
+
+The pronic discriminant for this value overflows UInt64. Rust uses checked
+arithmetic, so the Lean FFI implementation must reject it as well.
+-/
+
+/-- `4 * delta + 1` would wrap to `9` under unchecked UInt64 arithmetic. -/
+example : justifiable 4611686018427387906 = false := by
+  decide
+
+/-- The largest delta whose pronic discriminant fits remains evaluable. -/
+example : justifiable 4611686018427387903 = false := by
+  decide
+
+/-- Perfect-square detection remains valid at the first overflowing-pronic delta. -/
+example : justifiable 4611686018427387904 = true := by
+  decide
+
+/-- Values above the checked-pronic range do not wrap into false positives. -/
+example : justifiable 18446744073709551615 = false := by
+  decide


### PR DESCRIPTION
## Context

While extending the existing justifiability formalization, I found a
fixed-width arithmetic boundary outside the current proof domain.

For `delta = 2^62 + 2`, the previous Lean implementation returned `true`
because `UInt64` wrapping reduced `4 * delta + 1` to `9`, satisfying the
odd-square check. The corresponding mathematical delta is neither square nor
pronic.

## Change

The Lean implementation now evaluates the pronic branch only when
`4 * delta + 1` fits in `UInt64`, matching the checked-arithmetic structure in
the native Rust source.

Regression proofs cover values around the overflow boundary.

## Proof contract

`justifiable_equiv` remains explicitly bounded by `d.toNat < 2^62`.
This PR does not strengthen that theorem to a total equivalence result.

The Rust-side documentation has also been updated to state the actual proof
domain rather than claiming correctness for all natural numbers.

## Testing

- `cd formal && lake build EthLambdaProofs`
- regression cases for `2^62 - 1`, `2^62`, `2^62 + 2`, and `UInt64::MAX`
