### PR TITLE
build: add a 14-day publish-age cooldown to dependency resolution

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,16 @@ rustflags = [
     "-Ctarget-cpu=x86-64-v3",
     "-Ctarget-feature=+avx2,+sse2,+ssse3,+sse4.1,+sse4.2,+bmi1,+lzcnt,+pclmulqdq",
 ]
+
+# Supply-chain cooldown for dependency resolution (unstable min-publish-age,
+# tracking issue rust-lang/cargo#17009): crate versions published less than
+# 14 days ago are excluded when the resolver runs on a nightly cargo.
+# Stable cargo ignores these tables silently, so builds from the committed
+# Cargo.lock are unaffected; run `make update` to resolve under the policy.
+# When the feature stabilizes, drop the [unstable] table and the nightly
+# resolver pin in the Makefile: the policy then binds all resolution.
+[unstable]
+min-publish-age = true
+
+[registry]
+global-min-publish-age = "14 days"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,10 @@ jobs:
             | jq -e '.schema_version == 1 and (.samples | length == 3)'
 
   # Stable cargo ignores the publish-age cooldown in .cargo/config.toml, so the
-  # lockfile can pin too-young crates (or deliberately via the
-  # CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow escape hatch). Fail the build
-  # when either lockfile does. Infrastructure failures (toolchain download, a
-  # resolution that fails for reasons unrelated to age, e.g. a yanked upstream
-  # crate) only warn: they are outside the PR's control and would block every PR.
+  # lockfile can pin too-young crates. Fail the build when either lockfile does.
+  # Infrastructure failures (toolchain download, a resolution that fails for
+  # reasons unrelated to age, e.g. a yanked upstream crate) only warn: they are
+  # outside the PR's control and would block every PR.
   cooldown:
     name: Dependency cooldown
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # `--locked` so the committed Cargo.lock is actually enforced (see the
+      # tooling steps below), and so a dependency bump cannot sneak past the
+      # publish-age cooldown in .cargo/config.toml by resolving on stable here.
       - name: Cargo check
-        run: cargo check --workspace --all-targets
+        run: cargo check --locked --workspace --all-targets
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
       # tooling/event-monitor declares its own [workspace] table, so every step
       # above stops at the root workspace members and never reaches it. Its
@@ -83,3 +86,31 @@ jobs:
           cargo run --profile release-fast --bin ethlambda -- benchmark synthetic --mock-crypto \
             --num-validators 4 --warmup-slots 4 --iterations 3 --format json \
             | jq -e '.schema_version == 1 and (.samples | length == 3)'
+
+  # Stable cargo ignores the publish-age cooldown in .cargo/config.toml, so the
+  # lockfile can pin too-young crates (or deliberately via `make update-allow`).
+  # Surface them as annotations; this job never fails the build.
+  cooldown:
+    name: Dependency cooldown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check lockfile against the publish-age cooldown
+        run: |
+          if ! rustup toolchain install nightly-2026-06-21 --profile minimal; then
+            echo "::warning title=Publish-age cooldown check skipped::toolchain install failed"
+            exit 0
+          fi
+          if ! cargo +nightly-2026-06-21 update --dry-run -Z min-publish-age > cooldown.txt 2>&1; then
+            # Drop the index/git refresh chatter so the excerpt is the actual error; %0A = newline in annotations
+            msg=$(grep -v '^ *Updating ' cooldown.txt | head -20 | sed ':a;N;$!ba;s/\n/%0A/g')
+            echo "::warning title=Publish-age cooldown probe failed::$msg"
+            exit 0
+          fi
+          hits=$(grep -E "Downgrading|is too new" cooldown.txt || true)
+          if [ -n "$hits" ]; then
+            count=$(echo "$hits" | wc -l)
+            msg=$(echo "$hits" | head -20 | sed ':a;N;$!ba;s/\n/%0A/g')
+            echo "::warning title=Lockfile pins $count crate(s) younger than the publish-age cooldown::$msg"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      # `--locked` so the committed Cargo.lock is actually enforced (see the
-      # tooling steps below), and so a dependency bump cannot sneak past the
-      # publish-age cooldown in .cargo/config.toml by resolving on stable here.
       - name: Cargo check
         run: cargo check --locked --workspace --all-targets
 
@@ -83,34 +80,45 @@ jobs:
       # harness end-to-end and its JSON output contract in a few seconds.
       - name: Benchmark smoke (mock crypto)
         run: |
-          cargo run --profile release-fast --bin ethlambda -- benchmark synthetic --mock-crypto \
+          cargo run --locked --profile release-fast --bin ethlambda -- benchmark synthetic --mock-crypto \
             --num-validators 4 --warmup-slots 4 --iterations 3 --format json \
             | jq -e '.schema_version == 1 and (.samples | length == 3)'
 
   # Stable cargo ignores the publish-age cooldown in .cargo/config.toml, so the
-  # lockfile can pin too-young crates (or deliberately via `make update-allow`).
-  # Surface them as annotations; this job never fails the build.
+  # lockfile can pin too-young crates (or deliberately via the
+  # CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow escape hatch). Fail the build
+  # when either lockfile does. Infrastructure failures (toolchain download, a
+  # resolution that fails for reasons unrelated to age, e.g. a yanked upstream
+  # crate) only warn: they are outside the PR's control and would block every PR.
   cooldown:
     name: Dependency cooldown
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check lockfile against the publish-age cooldown
+      - name: Check lockfiles against the publish-age cooldown
         run: |
           if ! rustup toolchain install nightly-2026-06-21 --profile minimal; then
             echo "::warning title=Publish-age cooldown check skipped::toolchain install failed"
             exit 0
           fi
-          if ! cargo +nightly-2026-06-21 update --dry-run -Z min-publish-age > cooldown.txt 2>&1; then
-            # Drop the index/git refresh chatter so the excerpt is the actual error; %0A = newline in annotations
-            msg=$(grep -v '^ *Updating ' cooldown.txt | head -20 | sed ':a;N;$!ba;s/\n/%0A/g')
-            echo "::warning title=Publish-age cooldown probe failed::$msg"
-            exit 0
-          fi
-          hits=$(grep -E "Downgrading|is too new" cooldown.txt || true)
-          if [ -n "$hits" ]; then
-            count=$(echo "$hits" | wc -l)
-            msg=$(echo "$hits" | head -20 | sed ':a;N;$!ba;s/\n/%0A/g')
-            echo "::warning title=Lockfile pins $count crate(s) younger than the publish-age cooldown::$msg"
-          fi
+          status=0
+          for manifest in Cargo.toml tooling/event-monitor/Cargo.toml; do
+            if ! cargo +nightly-2026-06-21 update --dry-run -Z min-publish-age --manifest-path "$manifest" > cooldown.txt 2>&1; then
+              # Drop the index/git refresh chatter so the excerpt is the actual error; %0A = newline in annotations
+              msg=$(grep -v '^ *Updating ' cooldown.txt | head -20 | sed ':a;N;$!ba;s/\n/%0A/g')
+              echo "::warning title=Publish-age cooldown probe failed for $manifest::$msg"
+              continue
+            fi
+            # A cooldown-driven downgrade is annotated with the too-young version's
+            # publish date; downgrades for other reasons (MSRV, a tightened
+            # requirement) carry no such note and are not this check's business.
+            hits=$(grep -E '^ *Downgrading .*published' cooldown.txt || true)
+            if [ -n "$hits" ]; then
+              count=$(echo "$hits" | wc -l | tr -d ' ')
+              msg=$(echo "$hits" | head -20 | sed ':a;N;$!ba;s/\n/%0A/g')
+              echo "::error title=$manifest pins $count crate(s) younger than the publish-age cooldown::$msg"
+              status=1
+            fi
+          done
+          exit $status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,6 @@ make test                                    # All tests + forkchoice spec tests
 ```bash
 rm -rf leanSpec && make leanSpec/fixtures                # Download latest released test fixtures
 make update UPDATE_ARGS="-p <crate>"                     # Bump deps under the 14-day publish-age cooldown (nightly resolver)
-CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow make update UPDATE_ARGS="-p <crate> --precise <ver>"  # Escape hatch; CI stays red until it ages
 make cooldown-check                                      # Fail if a lockfile pins crates younger than the cooldown (same as CI)
 make docker-build                                        # Build Docker image (DOCKER_TAG=local)
 make run-devnet                                          # Run local devnet with lean-quickstart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,9 @@ make test                                    # All tests + forkchoice spec tests
 ### Common Operations
 ```bash
 rm -rf leanSpec && make leanSpec/fixtures                # Download latest released test fixtures
+make update UPDATE_ARGS="-p <crate>"                     # Bump deps under the 14-day publish-age cooldown (nightly resolver)
+make update-allow PACKAGE=<crate> VERSION=<ver>          # Escape hatch for a version younger than the cooldown
+make cooldown-check                                      # Warn about lockfile entries younger than the cooldown
 make docker-build                                        # Build Docker image (DOCKER_TAG=local)
 make run-devnet                                          # Run local devnet with lean-quickstart
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ make test                                    # All tests + forkchoice spec tests
 ```bash
 rm -rf leanSpec && make leanSpec/fixtures                # Download latest released test fixtures
 make update UPDATE_ARGS="-p <crate>"                     # Bump deps under the 14-day publish-age cooldown (nightly resolver)
-make update-allow PACKAGE=<crate> VERSION=<ver>          # Escape hatch for a version younger than the cooldown
-make cooldown-check                                      # Warn about lockfile entries younger than the cooldown
+CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow make update UPDATE_ARGS="-p <crate> --precise <ver>"  # Escape hatch; CI stays red until it ages
+make cooldown-check                                      # Fail if a lockfile pins crates younger than the cooldown (same as CI)
 make docker-build                                        # Build Docker image (DOCKER_TAG=local)
 make run-devnet                                          # Run local devnet with lean-quickstart
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,9 +101,6 @@ All commits must have a verified signature.
   freshly published crate versions as a supply-chain precaution. A plain `cargo update` or
   `cargo add` on stable bypasses the cooldown; `make lint`/`make test` and CI build
   `--locked` so an unresolved manifest change fails loudly instead of silently re-resolving.
-  For an urgent fix younger than the cooldown, prefix the same command with
-  `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` and review the whole lockfile diff; CI's
-  `Dependency cooldown` job will stay red until that version ages past the window.
   Git dependencies have no publish age and are not covered.
 
 ### Review Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,13 @@ All commits must have a verified signature.
 - **Comments:** Explain *why*, not *what*. Code should be self-explanatory.
 - **Error handling:** Use `Result` and `thiserror`. Avoid `.unwrap()` outside tests.
 - **Dependencies:** Adding a new crate requires justification in the PR description.
+  Resolve version bumps with `make update` (optionally `UPDATE_ARGS="-p <crate>"`): it runs
+  the resolver under a 14-day publish-age cooldown (`.cargo/config.toml`) that excludes
+  freshly published crate versions as a supply-chain precaution. A plain `cargo update` or
+  `cargo add` on stable bypasses the cooldown; `make lint`/`make test` and CI build
+  `--locked` so an unresolved manifest change fails loudly instead of silently re-resolving.
+  For an urgent fix younger than the cooldown use `make update-allow PACKAGE=<crate> VERSION=<version>`
+  and review the whole lockfile diff. Git dependencies have no publish age and are not covered.
 
 ### Review Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,10 @@ All commits must have a verified signature.
   freshly published crate versions as a supply-chain precaution. A plain `cargo update` or
   `cargo add` on stable bypasses the cooldown; `make lint`/`make test` and CI build
   `--locked` so an unresolved manifest change fails loudly instead of silently re-resolving.
-  For an urgent fix younger than the cooldown use `make update-allow PACKAGE=<crate> VERSION=<version>`
-  and review the whole lockfile diff. Git dependencies have no publish age and are not covered.
+  For an urgent fix younger than the cooldown, prefix the same command with
+  `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` and review the whole lockfile diff; CI's
+  `Dependency cooldown` job will stay red until that version ages past the window.
+  Git dependencies have no publish age and are not covered.
 
 ### Review Process
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV NO_DEFAULT_FEATURES=$NO_DEFAULT_FEATURES
 ARG LOCKED="--locked"
 ENV LOCKED=$LOCKED
 
-RUN cargo chef cook --profile $BUILD_PROFILE $NO_DEFAULT_FEATURES --features "$FEATURES" --recipe-path recipe.json
+RUN cargo chef cook --profile $BUILD_PROFILE $NO_DEFAULT_FEATURES --features "$FEATURES" $LOCKED --recipe-path recipe.json
 
 # Build application
 # Include .git so vergen-git2 can extract version info (branch, commit SHA)

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,7 @@ RESOLVER_TOOLCHAIN := nightly-2026-06-21
 # Resolution done on stable (`cargo add`, plain `cargo update`) is NOT covered;
 # this target is the intended path for routine updates. Git dependencies have
 # no publish age and are refreshed WITHOUT any cooldown: review their lockfile
-# rev changes manually. Escape hatch for an urgent bump to a version younger
-# than the cooldown, applied to the WHOLE resolution of that invocation:
-#   CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow make update UPDATE_ARGS="-p h2 --precise 0.4.16"
+# rev changes manually.
 update: ## 📦 Update dependencies under the publish-age cooldown (UPDATE_ARGS="-p foo")
 	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null && \
 	cargo +$(RESOLVER_TOOLCHAIN) update -Z min-publish-age $(UPDATE_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint bench docker-build shadow-build shadow-docker-build run-devnet test docs docs-deps docs-serve
+.PHONY: help fmt lint bench update update-allow cooldown-check docker-build shadow-build shadow-docker-build run-devnet test docs docs-deps docs-serve
 
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -6,13 +6,50 @@ help: ## 📚 Show help for each of the Makefile recipes
 fmt: ## 🎨 Format all code using rustfmt
 	cargo fmt --all
 
+# `--locked` so the committed Cargo.lock is actually enforced: without it cargo
+# silently resolves and rewrites the lockfile, bypassing the publish-age cooldown
+# (see `update` below).
 lint: ## 🔍 Run clippy on all workspace crates
-	cargo clippy --workspace --all-targets -- -D warnings
+	cargo clippy --locked --workspace --all-targets -- -D warnings
 
 test: leanSpec/fixtures ## 🧪 Run all tests
 	# release-fast: release-grade opt-level to avoid stack overflows during
 	# signature verification/aggregation, without paying for LTO on every rebuild
-	cargo test --workspace --profile release-fast
+	cargo test --locked --workspace --profile release-fast
+
+# Used ONLY to resolve dependency updates: min-publish-age (.cargo/config.toml)
+# is nightly-only, everything else runs on the stable toolchain pinned in
+# rust-toolchain.toml.
+RESOLVER_TOOLCHAIN := nightly-2026-06-21
+
+# Versions published less than 14 days ago are excluded from resolution.
+# Resolution done on stable (`cargo add`, plain `cargo update`) is NOT covered;
+# this target is the intended path for routine updates. Git dependencies have
+# no publish age and are refreshed WITHOUT any cooldown: review their lockfile
+# rev changes manually.
+update: ## 📦 Update dependencies under the publish-age cooldown (UPDATE_ARGS="-p foo")
+	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1 && \
+	cargo +$(RESOLVER_TOOLCHAIN) update -Z min-publish-age $(UPDATE_ARGS)
+
+# Escape hatch for an urgent update to a version younger than the cooldown,
+# e.g. `make update-allow PACKAGE=h2 VERSION=0.4.16`. The bypass applies to the
+# WHOLE resolution of this invocation (transitive picks included), so review the
+# resulting lockfile diff.
+update-allow: ## 🚨 Update one crate to a version younger than the cooldown (PACKAGE=... VERSION=...)
+	@test -n "$(PACKAGE)" -a -n "$(VERSION)" || { echo "usage: make update-allow PACKAGE=<crate> VERSION=<version>" >&2; exit 1; }
+	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1 && \
+	CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow \
+	cargo +$(RESOLVER_TOOLCHAIN) update -Z min-publish-age -p $(PACKAGE) --precise $(VERSION)
+
+# Stable cargo ignores the cooldown, so the lockfile can pin too-young crates
+# (or deliberately via `update-allow`); surface them without touching the file.
+cooldown-check: ## 🔎 Warn about lockfile entries younger than the publish-age cooldown
+	@rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1 && \
+	if ! out=$$(cargo +$(RESOLVER_TOOLCHAIN) update --dry-run -Z min-publish-age 2>&1); then \
+		echo "WARNING: publish-age cooldown probe failed:"; echo "$$out" | grep -v "^ *Updating " | head -20; exit 0; \
+	fi; \
+	hits=$$(echo "$$out" | grep -E "Downgrading|is too new" || true); \
+	if [ -n "$$hits" ]; then echo "WARNING: lockfile pins crates younger than the publish-age cooldown:"; echo "$$hits"; fi
 
 BENCH_ARGS ?= synthetic --mock-crypto
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt lint bench update update-allow cooldown-check docker-build shadow-build shadow-docker-build run-devnet test docs docs-deps docs-serve
+.PHONY: help fmt lint bench update cooldown-check docker-build shadow-build shadow-docker-build run-devnet test docs docs-deps docs-serve
 
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -6,9 +6,6 @@ help: ## 📚 Show help for each of the Makefile recipes
 fmt: ## 🎨 Format all code using rustfmt
 	cargo fmt --all
 
-# `--locked` so the committed Cargo.lock is actually enforced: without it cargo
-# silently resolves and rewrites the lockfile, bypassing the publish-age cooldown
-# (see `update` below).
 lint: ## 🔍 Run clippy on all workspace crates
 	cargo clippy --locked --workspace --all-targets -- -D warnings
 
@@ -26,30 +23,28 @@ RESOLVER_TOOLCHAIN := nightly-2026-06-21
 # Resolution done on stable (`cargo add`, plain `cargo update`) is NOT covered;
 # this target is the intended path for routine updates. Git dependencies have
 # no publish age and are refreshed WITHOUT any cooldown: review their lockfile
-# rev changes manually.
+# rev changes manually. Escape hatch for an urgent bump to a version younger
+# than the cooldown, applied to the WHOLE resolution of that invocation:
+#   CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow make update UPDATE_ARGS="-p h2 --precise 0.4.16"
 update: ## 📦 Update dependencies under the publish-age cooldown (UPDATE_ARGS="-p foo")
-	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1 && \
+	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null && \
 	cargo +$(RESOLVER_TOOLCHAIN) update -Z min-publish-age $(UPDATE_ARGS)
 
-# Escape hatch for an urgent update to a version younger than the cooldown,
-# e.g. `make update-allow PACKAGE=h2 VERSION=0.4.16`. The bypass applies to the
-# WHOLE resolution of this invocation (transitive picks included), so review the
-# resulting lockfile diff.
-update-allow: ## 🚨 Update one crate to a version younger than the cooldown (PACKAGE=... VERSION=...)
-	@test -n "$(PACKAGE)" -a -n "$(VERSION)" || { echo "usage: make update-allow PACKAGE=<crate> VERSION=<version>" >&2; exit 1; }
-	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1 && \
-	CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow \
-	cargo +$(RESOLVER_TOOLCHAIN) update -Z min-publish-age -p $(PACKAGE) --precise $(VERSION)
-
-# Stable cargo ignores the cooldown, so the lockfile can pin too-young crates
-# (or deliberately via `update-allow`); surface them without touching the file.
-cooldown-check: ## 🔎 Warn about lockfile entries younger than the publish-age cooldown
-	@rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1 && \
-	if ! out=$$(cargo +$(RESOLVER_TOOLCHAIN) update --dry-run -Z min-publish-age 2>&1); then \
-		echo "WARNING: publish-age cooldown probe failed:"; echo "$$out" | grep -v "^ *Updating " | head -20; exit 0; \
-	fi; \
-	hits=$$(echo "$$out" | grep -E "Downgrading|is too new" || true); \
-	if [ -n "$$hits" ]; then echo "WARNING: lockfile pins crates younger than the publish-age cooldown:"; echo "$$hits"; fi
+# Stable cargo ignores the cooldown, so a lockfile can pin too-young crates;
+# same check as the CI `cooldown` job, without touching the files. A cooldown
+# downgrade is annotated with the too-young version's publish date; downgrades
+# for other reasons carry no such note and are not flagged.
+cooldown-check: ## 🔎 Fail if a lockfile pins crates younger than the publish-age cooldown
+	@rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null && \
+	status=0; \
+	for manifest in Cargo.toml tooling/event-monitor/Cargo.toml; do \
+		if ! out=$$(cargo +$(RESOLVER_TOOLCHAIN) update --dry-run -Z min-publish-age --manifest-path $$manifest 2>&1); then \
+			echo "WARNING: publish-age cooldown probe failed for $$manifest:"; echo "$$out" | grep -v "^ *Updating " | head -20; continue; \
+		fi; \
+		hits=$$(echo "$$out" | grep -E "^ *Downgrading .*published" || true); \
+		if [ -n "$$hits" ]; then echo "ERROR: $$manifest pins crates younger than the publish-age cooldown:"; echo "$$hits"; status=1; fi; \
+	done; \
+	exit $$status
 
 BENCH_ARGS ?= synthetic --mock-crypto
 


### PR DESCRIPTION
## 🗒️ Description / Motivation

Ports Commit-Boost/commit-boost-client#492. Cargo's unstable `min-publish-age` (rust-lang/cargo#17009) lets the resolver skip crate versions published less than N days ago, a cooldown against freshly compromised releases. This enables it at 14 days, adds the Makefile path for resolving under it, and makes every build `--locked` so stable cargo cannot silently re-resolve around the policy.

The feature is nightly-only; stable 1.97.1 ignores the tables silently. Only the pinned `nightly-2026-06-21` resolver enforces the cooldown, so `--locked` everywhere is what makes an unresolved manifest change fail loudly instead of resolving on stable.

## What Changed

| File | Change |
|------|--------|
| `.cargo/config.toml` | `[unstable] min-publish-age = true`, `[registry] global-min-publish-age = "14 days"` |
| `Makefile` | `make update` (resolve under the cooldown), `make update-allow PACKAGE= VERSION=` (escape hatch, bypasses the whole resolution), `make cooldown-check` (advisory). `make lint`/`make test` now `--locked` |
| `.github/workflows/ci.yml` | `cargo check`/`clippy` run `--locked`; new `cooldown` job annotates the run with a warning, never fails |
| `Dockerfile` | `cargo chef cook` honors `$LOCKED` like the final build; the shadow variant still sets it empty |
| `CONTRIBUTING.md`, `CLAUDE.md` | Document the workflow |

## Correctness / Behavior Guarantees

- No manifest or lockfile change. Locked builds are byte-for-byte what they were.
- A `cargo update --workspace --dry-run` does **not** flag too-new locked crates, so the check has to be the full `cargo update --dry-run -Z min-publish-age`, grepping `Downgrading|is too new`. That run also refreshes git dependencies (leanSig, leanVM, ethrex, rust-libp2p) to their branch heads with no cooldown; git revs have no publish age and must be reviewed by hand.
- **Known state today:** a full re-resolution under any window of 8+ days fails with a misleading `rand ^0.10` conflict. Real cause: rand 0.10 needs chacha20 0.10, whose 0.10.0/0.10.1 are yanked and whose only live release (0.10.2) was published 2026-08-27. `make update` errors and the CI job emits a "probe failed" warning until 2026-09-10; `make update-allow` covers an urgent bump before then. The committed lockfile already pins the yanked chacha20 0.10.0, which any future re-resolution will move.

## Tests Added / Run

- `make lint` passes with `--locked`.
- Stable `cargo check --locked` and `cargo update --workspace --dry-run --locked` with the new tables: no warnings, no changes.
- Temporarily pinned `smallvec 1.16.0` (3 days old) and ran the 7-day dry-run: ` Downgrading smallvec v1.16.0 -> v1.15.2 (...)`, confirming the grep pattern. Lockfile restored identical.
- Ran the CI step script locally and `make cooldown-check`: both report the chacha20-driven probe failure as a warning with exit 0.

## Related Issues / PRs

- Related to Commit-Boost/commit-boost-client#492

## ✅ Verification Checklist

- [x] Ran `make fmt` — clean (no Rust changes)
- [x] Ran `make lint` (clippy with `-D warnings`) — clean
- [ ] Ran `make test` — not run; no Rust or fixture changes, only the `--locked` flag was added
